### PR TITLE
feat(streams): add WebSocket v1 client protocol contract

### DIFF
--- a/.changeset/stream-ws-protocol-v1-client.md
+++ b/.changeset/stream-ws-protocol-v1-client.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Add the client-side `workflow-stream-ws/v1` stream-write frame contract.

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 packages/swc-plugin-workflow/transform/tests/**/*.js text eol=lf
 packages/swc-plugin-workflow/transform/tests/**/*.stderr text eol=lf
 
+
+# Canonical cross-repository protocol fixtures are hashed byte-for-byte
+packages/world-vercel/src/__fixtures__/*.json text eol=lf

--- a/packages/world-vercel/src/__fixtures__/workflow-stream-ws-v1.json
+++ b/packages/world-vercel/src/__fixtures__/workflow-stream-ws-v1.json
@@ -1,0 +1,30 @@
+{
+  "protocol": "workflow-stream-ws/v1",
+  "version": 1,
+  "envelope": "u32_be(cbor_meta_length) || cbor_meta || u32_be(body_length) || body_bytes",
+  "frames": [
+    {
+      "direction": "client_to_server",
+      "meta": { "type": "stream_write", "reqId": 7 },
+      "bodyHex": "820102",
+      "frameHex": "0000001cb9000264747970656c73747265616d5f77726974656572657149640700000003820102"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "stream_write_ack",
+        "reqId": 7,
+        "status": 200,
+        "nextIndex": 42
+      },
+      "bodyHex": "",
+      "frameHex": "00000035b9000464747970657073747265616d5f77726974655f61636b657265714964076673746174757318c8696e657874496e646578182a00000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": { "type": "error", "reqId": 8, "status": 400 },
+      "bodyHex": "",
+      "frameHex": "0000001fb900036474797065656572726f72657265714964086673746174757319019000000000"
+    }
+  ]
+}

--- a/packages/world-vercel/src/__fixtures__/workflow-stream-ws-v1.json
+++ b/packages/world-vercel/src/__fixtures__/workflow-stream-ws-v1.json
@@ -1,30 +1,69 @@
 {
   "protocol": "workflow-stream-ws/v1",
   "version": 1,
+  "endpoint": "/api/websockets/v1/runs/:runId/streams/:streamId?writerId=:writerId",
+  "writerId": "wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV",
   "envelope": "u32_be(cbor_meta_length) || cbor_meta || u32_be(body_length) || body_bytes",
+  "chunkEncoding": "numChunks repetitions of u32_be(chunk_length) || chunk_bytes",
   "frames": [
     {
       "direction": "client_to_server",
-      "meta": { "type": "stream_write", "reqId": 7 },
-      "bodyHex": "820102",
-      "frameHex": "0000001cb9000264747970656c73747265616d5f77726974656572657149640700000003820102"
+      "meta": {
+        "type": "write",
+        "reqId": 7,
+        "chunkSeq": 0,
+        "numChunks": 1
+      },
+      "bodyHex": "000000026869",
+      "frameHex": "0000002ab90004647479706565777269746565726571496407686368756e6b53657100696e756d4368756e6b730100000006000000026869"
     },
     {
       "direction": "server_to_client",
       "meta": {
-        "type": "stream_write_ack",
-        "reqId": 7,
-        "status": 200,
-        "nextIndex": 42
+        "type": "write_ack",
+        "reqId": 7
       },
       "bodyHex": "",
-      "frameHex": "00000035b9000464747970657073747265616d5f77726974655f61636b657265714964076673746174757318c8696e657874496e646578182a00000000"
+      "frameHex": "00000019b9000264747970656977726974655f61636b6572657149640700000000"
+    },
+    {
+      "direction": "client_to_server",
+      "meta": {
+        "type": "close",
+        "reqId": 8
+      },
+      "bodyHex": "",
+      "frameHex": "00000015b90002647479706565636c6f73656572657149640800000000"
     },
     {
       "direction": "server_to_client",
-      "meta": { "type": "error", "reqId": 8, "status": 400 },
+      "meta": {
+        "type": "close_ack",
+        "reqId": 8
+      },
       "bodyHex": "",
-      "frameHex": "0000001fb900036474797065656572726f72657265714964086673746174757319019000000000"
+      "frameHex": "00000019b90002647479706569636c6f73655f61636b6572657149640800000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "error",
+        "reqId": 9,
+        "status": 429,
+        "message": "try later"
+      },
+      "bodyHex": "",
+      "frameHex": "00000031b900046474797065656572726f7265726571496409667374617475731901ad676d65737361676569747279206c6174657200000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "error",
+        "status": 400,
+        "message": "bad frame"
+      },
+      "bodyHex": "",
+      "frameHex": "0000002ab900036474797065656572726f7266737461747573190190676d65737361676569626164206672616d6500000000"
     }
   ]
 }

--- a/packages/world-vercel/src/stream-chunks.ts
+++ b/packages/world-vercel/src/stream-chunks.ts
@@ -1,0 +1,31 @@
+/**
+ * Encode stream chunks into the existing length-prefixed binary format:
+ * `chunk* := u32_be(chunk_length) || chunk_bytes`.
+ *
+ * Shared by HTTP multi-chunk writes and `workflow-stream-ws/v1` so the
+ * transport changes only the outer envelope, not the persisted chunk format.
+ */
+export function encodeMultiChunks(chunks: (string | Uint8Array)[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const binaryChunks: Uint8Array[] = [];
+  let totalSize = 0;
+
+  for (const chunk of chunks) {
+    const binary = typeof chunk === 'string' ? encoder.encode(chunk) : chunk;
+    binaryChunks.push(binary);
+    totalSize += 4 + binary.length;
+  }
+
+  const result = new Uint8Array(totalSize);
+  const view = new DataView(result.buffer);
+  let offset = 0;
+
+  for (const binary of binaryChunks) {
+    view.setUint32(offset, binary.length, false);
+    offset += 4;
+    result.set(binary, offset);
+    offset += binary.length;
+  }
+
+  return result;
+}

--- a/packages/world-vercel/src/stream-chunks.ts
+++ b/packages/world-vercel/src/stream-chunks.ts
@@ -1,3 +1,15 @@
+/** Shared HTTP/WS request-work bound matching the server batch cap. */
+export const MAX_CHUNKS_PER_STREAM_WRITE = 1000;
+
+export function normalizeStreamChunks(
+  chunks: (string | Uint8Array)[]
+): Uint8Array[] {
+  const encoder = new TextEncoder();
+  return chunks.map((chunk) =>
+    typeof chunk === 'string' ? encoder.encode(chunk) : chunk
+  );
+}
+
 /**
  * Encode stream chunks into the existing length-prefixed binary format:
  * `chunk* := u32_be(chunk_length) || chunk_bytes`.
@@ -6,16 +18,21 @@
  * transport changes only the outer envelope, not the persisted chunk format.
  */
 export function encodeMultiChunks(chunks: (string | Uint8Array)[]): Uint8Array {
-  const encoder = new TextEncoder();
-  const binaryChunks: Uint8Array[] = [];
+  return encodeNormalizedMultiChunks(normalizeStreamChunks(chunks));
+}
+
+export function encodeNormalizedMultiChunks(
+  binaryChunks: Uint8Array[]
+): Uint8Array {
   let totalSize = 0;
-
-  for (const chunk of chunks) {
-    const binary = typeof chunk === 'string' ? encoder.encode(chunk) : chunk;
-    binaryChunks.push(binary);
+  for (const binary of binaryChunks) {
     totalSize += 4 + binary.length;
+    if (totalSize > 0xffff_ffff) {
+      throw new RangeError(
+        `encoded stream chunks exceed the u32 body-length limit: ${totalSize} bytes`
+      );
+    }
   }
-
   const result = new Uint8Array(totalSize);
   const view = new DataView(result.buffer);
   let offset = 0;

--- a/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
@@ -2,11 +2,16 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import fixture from './__fixtures__/workflow-stream-ws-v1.json';
-import { decodeFrames } from './frames.js';
+import { type DecodedFrame, decodeFrames } from './frames.js';
 import {
+  encodeStreamWsCloseRequest,
   encodeStreamWsWriteRequest,
+  getStreamWsProtocolV1Url,
+  parseStreamWsReply,
   STREAM_WS_PROTOCOL_V1,
-  StreamWsReplyMetaSchema,
+  StreamWriterIdSchema,
+  StreamWsCloseRequestMetaSchema,
+  StreamWsRequestMetaSchema,
   StreamWsWriteRequestMetaSchema,
 } from './stream-ws-protocol-v1.js';
 
@@ -21,7 +26,7 @@ function fromHex(hex: string): Uint8Array {
   return new Uint8Array(Buffer.from(hex, 'hex'));
 }
 
-async function decodeOne(raw: Uint8Array) {
+async function decodeOne(raw: Uint8Array): Promise<DecodedFrame> {
   for await (const frame of decodeFrames(
     (async function* () {
       yield raw;
@@ -42,7 +47,7 @@ describe('workflow-stream-ws/v1 contract', () => {
       new URL('./__fixtures__/workflow-stream-ws-v1.json', import.meta.url)
     );
     expect(createHash('sha256').update(fixtureBytes).digest('hex')).toBe(
-      'd2bbd72c24d18ff11263610dcae968c54273eff2133fa4fb9303ef181834e508'
+      'deaa70651a43039322eb0eb5700c8daaa1cb8efbd8c9f5cbf25f671a78b0e38d'
     );
 
     expect(fixture.protocol).toBe(STREAM_WS_PROTOCOL_V1);
@@ -54,80 +59,162 @@ describe('workflow-stream-ws/v1 contract', () => {
         meta: frame.meta,
         body: fromHex(frame.bodyHex),
       });
-      if (frame.direction === 'client_to_server') {
-        const requestMeta = StreamWsWriteRequestMetaSchema.parse(decoded.meta);
-        expect(encodeStreamWsWriteRequest(requestMeta, decoded.body)).toEqual(
-          raw
-        );
+
+      const type = decoded.meta.type;
+      if (type === 'write') {
+        const meta = StreamWsWriteRequestMetaSchema.parse(decoded.meta);
+        const chunks = decodeMultiChunks(decoded.body);
+        expect(encodeStreamWsWriteRequest(meta, chunks)).toEqual(raw);
+      } else if (type === 'close') {
+        expect(
+          encodeStreamWsCloseRequest(
+            StreamWsCloseRequestMetaSchema.parse(decoded.meta)
+          )
+        ).toEqual(raw);
       } else {
-        expect(StreamWsReplyMetaSchema.parse(decoded.meta)).toEqual(frame.meta);
+        expect(parseStreamWsReply(decoded.meta, decoded.body)).toEqual(
+          frame.meta
+        );
       }
     }
   });
 
-  it('encodes a stream write in the shared binary envelope', async () => {
-    const body = new Uint8Array([0x01, 0x02]);
+  it('encodes writes with the existing multi-chunk body format', async () => {
     const raw = encodeStreamWsWriteRequest(
-      { type: 'stream_write', reqId: 1 },
-      body
+      { type: 'write', reqId: 1, chunkSeq: 4, numChunks: 2 },
+      ['hi', new Uint8Array([0x01, 0x02])]
     );
 
-    await expect(decodeOne(raw)).resolves.toEqual({
-      meta: { type: 'stream_write', reqId: 1 },
-      body,
-    });
-  });
-
-  it('accepts only nonnegative integral request ids', () => {
-    expect(
-      StreamWsWriteRequestMetaSchema.safeParse({
-        type: 'stream_write',
-        reqId: -1,
-      }).success
-    ).toBe(false);
-    expect(
-      StreamWsWriteRequestMetaSchema.safeParse({
-        type: 'stream_write',
-        reqId: 1.5,
-      }).success
-    ).toBe(false);
-  });
-
-  it('accepts successful and error replies with their required status fields', () => {
-    expect(
-      StreamWsReplyMetaSchema.parse({
-        type: 'stream_write_ack',
-        reqId: 1,
-        status: 200,
-        nextIndex: 8,
-      })
-    ).toEqual({
-      type: 'stream_write_ack',
+    const decoded = await decodeOne(raw);
+    expect(decoded.meta).toEqual({
+      type: 'write',
       reqId: 1,
-      status: 200,
-      nextIndex: 8,
+      chunkSeq: 4,
+      numChunks: 2,
     });
+    expect(decodeMultiChunks(decoded.body)).toEqual([
+      new TextEncoder().encode('hi'),
+      new Uint8Array([0x01, 0x02]),
+    ]);
+  });
+
+  it('requires metadata numChunks to match the encoded chunks', () => {
+    expect(() =>
+      encodeStreamWsWriteRequest(
+        { type: 'write', reqId: 1, chunkSeq: 0, numChunks: 2 },
+        ['only one']
+      )
+    ).toThrow('declares 2 chunks but received 1');
+  });
+
+  it('encodes close with an empty body', async () => {
+    await expect(
+      decodeOne(encodeStreamWsCloseRequest({ type: 'close', reqId: 2 }))
+    ).resolves.toEqual({
+      meta: { type: 'close', reqId: 2 },
+      body: new Uint8Array(),
+    });
+  });
+
+  it('ignores unknown fields on known frame types', () => {
     expect(
-      StreamWsReplyMetaSchema.parse({
-        type: 'error',
+      StreamWsRequestMetaSchema.parse({
+        type: 'write',
         reqId: 1,
-        status: 400,
+        chunkSeq: 0,
+        numChunks: 1,
+        futureField: true,
       })
-    ).toEqual({ type: 'error', reqId: 1, status: 400 });
+    ).toEqual({ type: 'write', reqId: 1, chunkSeq: 0, numChunks: 1 });
     expect(
-      StreamWsReplyMetaSchema.safeParse({
-        type: 'stream_write_ack',
-        reqId: 1,
-        status: 200,
+      parseStreamWsReply(
+        { type: 'write_ack', reqId: 1, futureField: true },
+        new Uint8Array()
+      )
+    ).toEqual({ type: 'write_ack', reqId: 1 });
+  });
+
+  it('accepts correlated and connection-fatal errors', () => {
+    expect(
+      parseStreamWsReply(
+        { type: 'error', reqId: 1, status: -7, message: 'bad write' },
+        new Uint8Array()
+      )
+    ).toEqual({ type: 'error', reqId: 1, status: -7, message: 'bad write' });
+    expect(
+      parseStreamWsReply({ type: 'error', status: 9000 }, new Uint8Array())
+    ).toEqual({ type: 'error', status: 9000 });
+  });
+
+  it('rejects response bodies and unknown frame types', () => {
+    expect(() =>
+      parseStreamWsReply({ type: 'write_ack', reqId: 1 }, new Uint8Array([1]))
+    ).toThrow('reply body must be empty');
+    expect(
+      StreamWsRequestMetaSchema.safeParse({ type: 'future', reqId: 1 }).success
+    ).toBe(false);
+  });
+
+  it('validates request counters as nonnegative integers', () => {
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'write',
+        reqId: -1,
+        chunkSeq: 0,
+        numChunks: 1,
       }).success
     ).toBe(false);
     expect(
-      StreamWsReplyMetaSchema.safeParse({
-        type: 'stream_write_ack',
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'write',
         reqId: 1,
-        status: 400,
-        nextIndex: 8,
+        chunkSeq: 1.5,
+        numChunks: 1,
       }).success
     ).toBe(false);
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'write',
+        reqId: 1,
+        chunkSeq: 0,
+        numChunks: 0,
+      }).success
+    ).toBe(false);
+  });
+
+  it('validates and encodes the observational writer id', () => {
+    const writerId = 'wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    expect(StreamWriterIdSchema.parse(writerId)).toBe(writerId);
+    expect(
+      getStreamWsProtocolV1Url(
+        'https://example.test/api/',
+        'run/1',
+        'stream name',
+        writerId
+      ).toString()
+    ).toBe(
+      'wss://example.test/api/websockets/v1/runs/run%2F1/streams/stream%20name?writerId=wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    );
+    expect(StreamWriterIdSchema.safeParse(writerId.toLowerCase()).success).toBe(
+      false
+    );
   });
 });
+
+function decodeMultiChunks(body: Uint8Array): Uint8Array[] {
+  const chunks: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < body.byteLength) {
+    if (body.byteLength - offset < 4) throw new Error('truncated chunk length');
+    const length = new DataView(
+      body.buffer,
+      body.byteOffset + offset,
+      4
+    ).getUint32(0, false);
+    offset += 4;
+    if (body.byteLength - offset < length) throw new Error('truncated chunk');
+    chunks.push(body.slice(offset, offset + length));
+    offset += length;
+  }
+  return chunks;
+}

--- a/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import fixture from './__fixtures__/workflow-stream-ws-v1.json';
+import { decodeFrames } from './frames.js';
+import {
+  encodeStreamWsWriteRequest,
+  STREAM_WS_PROTOCOL_V1,
+  StreamWsReplyMetaSchema,
+  StreamWsWriteRequestMetaSchema,
+} from './stream-ws-protocol-v1.js';
+
+type FixtureFrame = {
+  direction: 'client_to_server' | 'server_to_client';
+  meta: Record<string, unknown>;
+  bodyHex: string;
+  frameHex: string;
+};
+
+function fromHex(hex: string): Uint8Array {
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+async function decodeOne(raw: Uint8Array) {
+  for await (const frame of decodeFrames(
+    (async function* () {
+      yield raw;
+    })()
+  )) {
+    return frame;
+  }
+  throw new Error('frame contained no envelope');
+}
+
+describe('workflow-stream-ws/v1 contract', () => {
+  it('uses a protocol name independent from REST and workflow spec versions', () => {
+    expect(STREAM_WS_PROTOCOL_V1).toBe('workflow-stream-ws/v1');
+  });
+
+  it('matches workflow-server’s canonical fixture byte-for-byte', async () => {
+    const fixtureBytes = await readFile(
+      new URL('./__fixtures__/workflow-stream-ws-v1.json', import.meta.url)
+    );
+    expect(createHash('sha256').update(fixtureBytes).digest('hex')).toBe(
+      'd2bbd72c24d18ff11263610dcae968c54273eff2133fa4fb9303ef181834e508'
+    );
+
+    expect(fixture.protocol).toBe(STREAM_WS_PROTOCOL_V1);
+    expect(fixture.version).toBe(1);
+    for (const frame of fixture.frames as FixtureFrame[]) {
+      const raw = fromHex(frame.frameHex);
+      const decoded = await decodeOne(raw);
+      expect(decoded).toEqual({
+        meta: frame.meta,
+        body: fromHex(frame.bodyHex),
+      });
+      if (frame.direction === 'client_to_server') {
+        const requestMeta = StreamWsWriteRequestMetaSchema.parse(decoded.meta);
+        expect(encodeStreamWsWriteRequest(requestMeta, decoded.body)).toEqual(
+          raw
+        );
+      } else {
+        expect(StreamWsReplyMetaSchema.parse(decoded.meta)).toEqual(frame.meta);
+      }
+    }
+  });
+
+  it('encodes a stream write in the shared binary envelope', async () => {
+    const body = new Uint8Array([0x01, 0x02]);
+    const raw = encodeStreamWsWriteRequest(
+      { type: 'stream_write', reqId: 1 },
+      body
+    );
+
+    await expect(decodeOne(raw)).resolves.toEqual({
+      meta: { type: 'stream_write', reqId: 1 },
+      body,
+    });
+  });
+
+  it('accepts only nonnegative integral request ids', () => {
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'stream_write',
+        reqId: -1,
+      }).success
+    ).toBe(false);
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'stream_write',
+        reqId: 1.5,
+      }).success
+    ).toBe(false);
+  });
+
+  it('accepts successful and error replies with their required status fields', () => {
+    expect(
+      StreamWsReplyMetaSchema.parse({
+        type: 'stream_write_ack',
+        reqId: 1,
+        status: 200,
+        nextIndex: 8,
+      })
+    ).toEqual({
+      type: 'stream_write_ack',
+      reqId: 1,
+      status: 200,
+      nextIndex: 8,
+    });
+    expect(
+      StreamWsReplyMetaSchema.parse({
+        type: 'error',
+        reqId: 1,
+        status: 400,
+      })
+    ).toEqual({ type: 'error', reqId: 1, status: 400 });
+    expect(
+      StreamWsReplyMetaSchema.safeParse({
+        type: 'stream_write_ack',
+        reqId: 1,
+        status: 200,
+      }).success
+    ).toBe(false);
+    expect(
+      StreamWsReplyMetaSchema.safeParse({
+        type: 'stream_write_ack',
+        reqId: 1,
+        status: 400,
+        nextIndex: 8,
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.test.ts
@@ -9,6 +9,8 @@ import {
   getStreamWsProtocolV1Url,
   parseStreamWsReply,
   STREAM_WS_PROTOCOL_V1,
+  STREAM_WS_V1_MAX_CHUNK_BYTES,
+  STREAM_WS_V1_MAX_CHUNKS_PER_WRITE,
   StreamWriterIdSchema,
   StreamWsCloseRequestMetaSchema,
   StreamWsRequestMetaSchema,
@@ -46,6 +48,8 @@ describe('workflow-stream-ws/v1 contract', () => {
     const fixtureBytes = await readFile(
       new URL('./__fixtures__/workflow-stream-ws-v1.json', import.meta.url)
     );
+    // Canonical source: workflow-server#848
+    // test/fixtures/workflow-stream-ws-v1.json
     expect(createHash('sha256').update(fixtureBytes).digest('hex')).toBe(
       'deaa70651a43039322eb0eb5700c8daaa1cb8efbd8c9f5cbf25f671a78b0e38d'
     );
@@ -107,6 +111,36 @@ describe('workflow-stream-ws/v1 contract', () => {
     ).toThrow('declares 2 chunks but received 1');
   });
 
+  it('bounds request work at 1000 chunks rather than 1000 writes/second', () => {
+    expect(STREAM_WS_V1_MAX_CHUNKS_PER_WRITE).toBe(1000);
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'write',
+        reqId: 1,
+        chunkSeq: 0,
+        numChunks: 1000,
+      }).success
+    ).toBe(true);
+    expect(
+      StreamWsWriteRequestMetaSchema.safeParse({
+        type: 'write',
+        reqId: 1,
+        chunkSeq: 0,
+        numChunks: 1001,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects chunks over the shared 10 MiB per-chunk limit', () => {
+    expect(STREAM_WS_V1_MAX_CHUNK_BYTES).toBe(10 * 1024 * 1024);
+    expect(() =>
+      encodeStreamWsWriteRequest(
+        { type: 'write', reqId: 1, chunkSeq: 0, numChunks: 1 },
+        [new Uint8Array(STREAM_WS_V1_MAX_CHUNK_BYTES + 1)]
+      )
+    ).toThrow('maximum is 10485760');
+  });
+
   it('encodes close with an empty body', async () => {
     await expect(
       decodeOne(encodeStreamWsCloseRequest({ type: 'close', reqId: 2 }))
@@ -155,6 +189,30 @@ describe('workflow-stream-ws/v1 contract', () => {
     ).toBe(false);
   });
 
+  it('treats duplicate and discontinuous writer-local sequences as observational', () => {
+    const first = {
+      type: 'write' as const,
+      reqId: 1,
+      chunkSeq: 0,
+      numChunks: 2,
+    };
+    expect(StreamWsWriteRequestMetaSchema.parse(first)).toEqual(first);
+    expect(
+      StreamWsWriteRequestMetaSchema.parse({
+        ...first,
+        reqId: 2,
+        chunkSeq: 0,
+      })
+    ).toEqual({ ...first, reqId: 2, chunkSeq: 0 });
+    expect(
+      StreamWsWriteRequestMetaSchema.parse({
+        ...first,
+        reqId: 3,
+        chunkSeq: 99,
+      })
+    ).toEqual({ ...first, reqId: 3, chunkSeq: 99 });
+  });
+
   it('validates request counters as nonnegative integers', () => {
     expect(
       StreamWsWriteRequestMetaSchema.safeParse({
@@ -182,19 +240,26 @@ describe('workflow-stream-ws/v1 contract', () => {
     ).toBe(false);
   });
 
-  it('validates and encodes the observational writer id', () => {
+  it('validates and encodes the non-fencing observational writer id', () => {
     const writerId = 'wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV';
     expect(StreamWriterIdSchema.parse(writerId)).toBe(writerId);
+    const url = getStreamWsProtocolV1Url(
+      'https://example.test/api/',
+      'run/1',
+      'stream name',
+      writerId
+    );
+    expect(url.toString()).toBe(
+      'wss://example.test/api/websockets/v1/runs/run%2F1/streams/stream%20name?writerId=wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    );
     expect(
       getStreamWsProtocolV1Url(
         'https://example.test/api/',
         'run/1',
         'stream name',
         writerId
-      ).toString()
-    ).toBe(
-      'wss://example.test/api/websockets/v1/runs/run%2F1/streams/stream%20name?writerId=wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV'
-    );
+      ).searchParams.get('writerId')
+    ).toBe(writerId);
     expect(StreamWriterIdSchema.safeParse(writerId.toLowerCase()).success).toBe(
       false
     );

--- a/packages/world-vercel/src/stream-ws-protocol-v1.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { encodeFrame } from './frames.js';
+
+/**
+ * The independently versioned WebSocket protocol for stream writes.
+ *
+ * This is not a REST API or persisted workflow-spec version. A breaking change
+ * to framing, ordering, acknowledgements, retries, or mandatory control frames
+ * needs a new `/websockets/vN` endpoint rather than a spec-version bump.
+ */
+export const STREAM_WS_PROTOCOL_V1 = 'workflow-stream-ws/v1';
+
+const RequestIdSchema = z.number().int().nonnegative();
+const HttpStatusSchema = z.number().int().min(100).max(599);
+const SuccessStatusSchema = z.number().int().min(200).max(299);
+
+/** v1 request metadata. The binary frame body is the stream chunk. */
+export const StreamWsWriteRequestMetaSchema = z.object({
+  type: z.literal('stream_write'),
+  reqId: RequestIdSchema,
+});
+
+/** Successful v1 reply metadata. `nextIndex` is server-assigned and dense. */
+export const StreamWsWriteAckMetaSchema = z.object({
+  type: z.literal('stream_write_ack'),
+  reqId: RequestIdSchema,
+  status: SuccessStatusSchema,
+  nextIndex: RequestIdSchema,
+});
+
+/** Error v1 reply metadata. Its frame body is deliberately opaque. */
+export const StreamWsErrorMetaSchema = z.object({
+  type: z.literal('error'),
+  reqId: RequestIdSchema,
+  status: HttpStatusSchema,
+});
+
+export const StreamWsReplyMetaSchema = z.discriminatedUnion('type', [
+  StreamWsWriteAckMetaSchema,
+  StreamWsErrorMetaSchema,
+]);
+
+export type StreamWsWriteRequestMeta = z.infer<
+  typeof StreamWsWriteRequestMetaSchema
+>;
+export type StreamWsWriteAckMeta = z.infer<typeof StreamWsWriteAckMetaSchema>;
+export type StreamWsErrorMeta = z.infer<typeof StreamWsErrorMetaSchema>;
+export type StreamWsReplyMeta = z.infer<typeof StreamWsReplyMetaSchema>;
+
+/**
+ * Encodes one complete v1 WebSocket message using the shared binary envelope:
+ * `u32be(cbor-meta length) || cbor-meta || u32be(body length) || body`.
+ */
+export function encodeStreamWsWriteRequest(
+  meta: StreamWsWriteRequestMeta,
+  body: Uint8Array
+): Uint8Array {
+  return encodeFrame(StreamWsWriteRequestMetaSchema.parse(meta), body);
+}

--- a/packages/world-vercel/src/stream-ws-protocol-v1.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { encodeFrame } from './frames.js';
+import { encodeMultiChunks } from './streamer.js';
 
 /**
  * The independently versioned WebSocket protocol for stream writes.
@@ -10,50 +11,119 @@ import { encodeFrame } from './frames.js';
  */
 export const STREAM_WS_PROTOCOL_V1 = 'workflow-stream-ws/v1';
 
-const RequestIdSchema = z.number().int().nonnegative();
-const HttpStatusSchema = z.number().int().min(100).max(599);
-const SuccessStatusSchema = z.number().int().min(200).max(299);
+const NonnegativeIntegerSchema = z.number().int().nonnegative();
+const RequestIdSchema = NonnegativeIntegerSchema;
 
-/** v1 request metadata. The binary frame body is the stream chunk. */
+/** One in-memory WritableStream lifetime, including HTTP/WS transitions. */
+export const StreamWriterIdSchema = z
+  .string()
+  .regex(/^wrtr_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/);
+
+/** v1 write metadata. `chunkSeq` identifies the first body chunk. */
 export const StreamWsWriteRequestMetaSchema = z.object({
-  type: z.literal('stream_write'),
+  type: z.literal('write'),
+  reqId: RequestIdSchema,
+  chunkSeq: NonnegativeIntegerSchema,
+  numChunks: z.number().int().positive(),
+});
+
+/** v1 close metadata. Its frame body must be empty. */
+export const StreamWsCloseRequestMetaSchema = z.object({
+  type: z.literal('close'),
   reqId: RequestIdSchema,
 });
 
-/** Successful v1 reply metadata. `nextIndex` is server-assigned and dense. */
+export const StreamWsRequestMetaSchema = z.discriminatedUnion('type', [
+  StreamWsWriteRequestMetaSchema,
+  StreamWsCloseRequestMetaSchema,
+]);
+
 export const StreamWsWriteAckMetaSchema = z.object({
-  type: z.literal('stream_write_ack'),
+  type: z.literal('write_ack'),
   reqId: RequestIdSchema,
-  status: SuccessStatusSchema,
-  nextIndex: RequestIdSchema,
 });
 
-/** Error v1 reply metadata. Its frame body is deliberately opaque. */
+export const StreamWsCloseAckMetaSchema = z.object({
+  type: z.literal('close_ack'),
+  reqId: RequestIdSchema,
+});
+
+/** An absent request id makes the error connection-fatal. */
 export const StreamWsErrorMetaSchema = z.object({
   type: z.literal('error'),
-  reqId: RequestIdSchema,
-  status: HttpStatusSchema,
+  reqId: RequestIdSchema.optional(),
+  status: z.number().int(),
+  message: z.string().optional(),
 });
 
 export const StreamWsReplyMetaSchema = z.discriminatedUnion('type', [
   StreamWsWriteAckMetaSchema,
+  StreamWsCloseAckMetaSchema,
   StreamWsErrorMetaSchema,
 ]);
 
+export type StreamWriterId = z.infer<typeof StreamWriterIdSchema>;
 export type StreamWsWriteRequestMeta = z.infer<
   typeof StreamWsWriteRequestMetaSchema
 >;
+export type StreamWsCloseRequestMeta = z.infer<
+  typeof StreamWsCloseRequestMetaSchema
+>;
+export type StreamWsRequestMeta = z.infer<typeof StreamWsRequestMetaSchema>;
 export type StreamWsWriteAckMeta = z.infer<typeof StreamWsWriteAckMetaSchema>;
+export type StreamWsCloseAckMeta = z.infer<typeof StreamWsCloseAckMetaSchema>;
 export type StreamWsErrorMeta = z.infer<typeof StreamWsErrorMetaSchema>;
 export type StreamWsReplyMeta = z.infer<typeof StreamWsReplyMetaSchema>;
 
+/** Builds the independently versioned, writer-observability-aware v1 URL. */
+export function getStreamWsProtocolV1Url(
+  baseUrl: string,
+  runId: string,
+  streamId: string,
+  writerId: StreamWriterId
+): URL {
+  const parsedWriterId = StreamWriterIdSchema.parse(writerId);
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/websockets/v1/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(streamId)}`;
+  url.search = new URLSearchParams({ writerId: parsedWriterId }).toString();
+  return url;
+}
+
 /**
- * Encodes one complete v1 WebSocket message using the shared binary envelope:
- * `u32be(cbor-meta length) || cbor-meta || u32be(body length) || body`.
+ * Encodes one complete v1 write message. The outer envelope is the shared
+ * frame codec; its body is the existing stream multi-chunk representation.
  */
 export function encodeStreamWsWriteRequest(
   meta: StreamWsWriteRequestMeta,
-  body: Uint8Array
+  chunks: (string | Uint8Array)[]
 ): Uint8Array {
-  return encodeFrame(StreamWsWriteRequestMetaSchema.parse(meta), body);
+  const parsed = StreamWsWriteRequestMetaSchema.parse(meta);
+  if (parsed.numChunks !== chunks.length) {
+    throw new Error(
+      `stream WebSocket write declares ${parsed.numChunks} chunks but received ${chunks.length}`
+    );
+  }
+  return encodeFrame(parsed, encodeMultiChunks(chunks));
+}
+
+/** Encodes one complete v1 close message with an empty body. */
+export function encodeStreamWsCloseRequest(
+  meta: StreamWsCloseRequestMeta
+): Uint8Array {
+  return encodeFrame(
+    StreamWsCloseRequestMetaSchema.parse(meta),
+    new Uint8Array()
+  );
+}
+
+/** Validates a v1 response envelope, whose body is always empty. */
+export function parseStreamWsReply(
+  meta: Record<string, unknown>,
+  body: Uint8Array
+): StreamWsReplyMeta {
+  if (body.byteLength !== 0) {
+    throw new Error('stream WebSocket reply body must be empty');
+  }
+  return StreamWsReplyMetaSchema.parse(meta);
 }

--- a/packages/world-vercel/src/stream-ws-protocol-v1.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { encodeFrame } from './frames.js';
-import { encodeMultiChunks } from './streamer.js';
+import { encodeMultiChunks } from './stream-chunks.js';
 
 /**
  * The independently versioned WebSocket protocol for stream writes.

--- a/packages/world-vercel/src/stream-ws-protocol-v1.ts
+++ b/packages/world-vercel/src/stream-ws-protocol-v1.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { encodeFrame } from './frames.js';
-import { encodeMultiChunks } from './stream-chunks.js';
+import {
+  encodeNormalizedMultiChunks,
+  MAX_CHUNKS_PER_STREAM_WRITE,
+  normalizeStreamChunks,
+} from './stream-chunks.js';
 
 /**
  * The independently versioned WebSocket protocol for stream writes.
@@ -11,20 +15,36 @@ import { encodeMultiChunks } from './stream-chunks.js';
  */
 export const STREAM_WS_PROTOCOL_V1 = 'workflow-stream-ws/v1';
 
+/** Shared v1 request-work bound; this is not a per-second rate limit. */
+export const STREAM_WS_V1_MAX_CHUNKS_PER_WRITE = MAX_CHUNKS_PER_STREAM_WRITE;
+/** Shared v1 size bound for each decoded chunk. */
+export const STREAM_WS_V1_MAX_CHUNK_BYTES = 10 * 1024 * 1024;
+
 const NonnegativeIntegerSchema = z.number().int().nonnegative();
 const RequestIdSchema = NonnegativeIntegerSchema;
 
-/** One in-memory WritableStream lifetime, including HTTP/WS transitions. */
+/**
+ * One in-memory WritableStream lifetime, including HTTP/WS transitions.
+ *
+ * This id is observational, not a fence: the same writer id can appear on
+ * multiple connections, and v1 does not use it to reject either connection.
+ */
 export const StreamWriterIdSchema = z
   .string()
   .regex(/^wrtr_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/);
 
-/** v1 write metadata. `chunkSeq` identifies the first body chunk. */
+/**
+ * v1 write metadata. `chunkSeq` is the first writer-local sequence in this
+ * body, not a persisted stream-global index. It advances by `numChunks` across
+ * HTTP/WS transitions. v1 observes but does not enforce continuity or
+ * uniqueness: an accepted duplicate/discontinuous sequence appends its chunks
+ * again rather than replaying, filling a gap, or fencing another connection.
+ */
 export const StreamWsWriteRequestMetaSchema = z.object({
   type: z.literal('write'),
   reqId: RequestIdSchema,
   chunkSeq: NonnegativeIntegerSchema,
-  numChunks: z.number().int().positive(),
+  numChunks: z.number().int().positive().max(STREAM_WS_V1_MAX_CHUNKS_PER_WRITE),
 });
 
 /** v1 close metadata. Its frame body must be empty. */
@@ -62,6 +82,14 @@ export const StreamWsReplyMetaSchema = z.discriminatedUnion('type', [
   StreamWsErrorMetaSchema,
 ]);
 
+/*
+ * v1 pipelining is ordered and fail-stop. The server executes requests serially
+ * in receive order. Its first failed request prevents later queued writes or
+ * closes from executing and poisons the writer. An unknown client outcome is
+ * likewise never replayed. The whole WebSocket-message ceiling is deliberately
+ * implementation- and measurement-defined beyond the per-chunk/count bounds.
+ */
+
 export type StreamWriterId = z.infer<typeof StreamWriterIdSchema>;
 export type StreamWsWriteRequestMeta = z.infer<
   typeof StreamWsWriteRequestMetaSchema
@@ -98,13 +126,23 @@ export function encodeStreamWsWriteRequest(
   meta: StreamWsWriteRequestMeta,
   chunks: (string | Uint8Array)[]
 ): Uint8Array {
+  // Parsing also canonicalizes metadata key order for byte-exact fixtures.
   const parsed = StreamWsWriteRequestMetaSchema.parse(meta);
   if (parsed.numChunks !== chunks.length) {
     throw new Error(
       `stream WebSocket write declares ${parsed.numChunks} chunks but received ${chunks.length}`
     );
   }
-  return encodeFrame(parsed, encodeMultiChunks(chunks));
+  const binaryChunks = normalizeStreamChunks(chunks);
+  for (const chunk of binaryChunks) {
+    const byteLength = chunk.byteLength;
+    if (byteLength > STREAM_WS_V1_MAX_CHUNK_BYTES) {
+      throw new Error(
+        `stream WebSocket chunk is ${byteLength} bytes; maximum is ${STREAM_WS_V1_MAX_CHUNK_BYTES}`
+      );
+    }
+  }
+  return encodeFrame(parsed, encodeNormalizedMultiChunks(binaryChunks));
 }
 
 /** Encodes one complete v1 close message with an empty body. */

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -25,6 +25,7 @@ import {
   getVercelDiagnostics,
   instrumentedFetch,
 } from './http-core.js';
+import { encodeMultiChunks } from './stream-chunks.js';
 import {
   WorkflowRunId,
   WorkflowStreamName,
@@ -171,42 +172,7 @@ function createStreamRequestError(
   );
 }
 
-/**
- * Encode multiple chunks into a length-prefixed binary format.
- * Format: [4 bytes big-endian length][chunk bytes][4 bytes length][chunk bytes]...
- *
- * This preserves chunk boundaries so the server can store them as separate
- * chunks, maintaining correct startIndex semantics for readers.
- *
- * @internal Exported for testing purposes
- */
-export function encodeMultiChunks(chunks: (string | Uint8Array)[]): Uint8Array {
-  const encoder = new TextEncoder();
-
-  // Convert all chunks to Uint8Array and calculate total size
-  const binaryChunks: Uint8Array[] = [];
-  let totalSize = 0;
-
-  for (const chunk of chunks) {
-    const binary = typeof chunk === 'string' ? encoder.encode(chunk) : chunk;
-    binaryChunks.push(binary);
-    totalSize += 4 + binary.length; // 4 bytes for length prefix
-  }
-
-  // Allocate buffer and write length-prefixed chunks
-  const result = new Uint8Array(totalSize);
-  const view = new DataView(result.buffer);
-  let offset = 0;
-
-  for (const binary of binaryChunks) {
-    view.setUint32(offset, binary.length, false); // big-endian
-    offset += 4;
-    result.set(binary, offset);
-    offset += binary.length;
-  }
-
-  return result;
-}
+export { encodeMultiChunks } from './stream-chunks.js';
 
 const StreamInfoResponseSchema = z.object({
   tailIndex: z.number(),

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -25,7 +25,10 @@ import {
   getVercelDiagnostics,
   instrumentedFetch,
 } from './http-core.js';
-import { encodeMultiChunks } from './stream-chunks.js';
+import {
+  encodeMultiChunks,
+  MAX_CHUNKS_PER_STREAM_WRITE,
+} from './stream-chunks.js';
 import {
   WorkflowRunId,
   WorkflowStreamName,
@@ -43,7 +46,7 @@ import {
  * Maximum number of chunks per request, matching the server-side
  * MAX_CHUNKS_PER_BATCH. Larger batches are split into multiple requests.
  */
-export const MAX_CHUNKS_PER_REQUEST = 1000;
+export const MAX_CHUNKS_PER_REQUEST = MAX_CHUNKS_PER_STREAM_WRITE;
 
 /**
  * Effective max chunks per write request. Override via


### PR DESCRIPTION
## Summary & Motivation

Defines the `workflow-stream-ws/v1` frame schemas and encoder in `@workflow/world-vercel`, versioned independently of the REST API and workflow spec so a framing or acknowledgement change needs a new endpoint rather than a spec bump. Nothing calls it yet.

## Test Plan

Protocol tests added, including a byte-for-byte check against workflow-server's canonical frame fixture.
