### PR TITLE
[world-local] Skip chmod-based permission tests where the bits aren't enforced

### DIFF
--- a/.changeset/skip-perm-tests-when-dac-bypassed.md
+++ b/.changeset/skip-perm-tests-when-dac-bypassed.md
@@ -1,5 +1,0 @@
----
-'@workflow/world-local': patch
----
-
-Skip the `chmod`-based permission tests when the process bypasses the permission bits (root / `CAP_DAC_OVERRIDE`), instead of failing the suite.

--- a/.changeset/skip-perm-tests-when-dac-bypassed.md
+++ b/.changeset/skip-perm-tests-when-dac-bypassed.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Skip the `chmod`-based permission tests when the process bypasses the permission bits (root / `CAP_DAC_OVERRIDE`), instead of failing the suite.

--- a/packages/world-local/src/init.test.ts
+++ b/packages/world-local/src/init.test.ts
@@ -22,6 +22,7 @@ import {
   parseVersionFile,
   upgradeVersion,
 } from './init.js';
+import { permissionEnforcement } from './test-helpers.js';
 
 describe('parseVersion', () => {
   it('should parse a simple version string', () => {
@@ -208,9 +209,10 @@ describe('ensureDataDir', () => {
   });
 
   describe('permission errors', () => {
-    const isWindows = process.platform === 'win32';
-
-    it.skipIf(isWindows)(
+    // These cases simulate the failure with `chmod`, so they can only run
+    // where the permission bits are actually enforced — see
+    // `permissionEnforcement`.
+    it.skipIf(!permissionEnforcement.accessCheck)(
       'should throw DataDirAccessError if directory is not readable',
       async () => {
         const dataDir = path.join(testBaseDir, 'unreadable-dir');
@@ -228,7 +230,7 @@ describe('ensureDataDir', () => {
       }
     );
 
-    it.skipIf(isWindows)(
+    it.skipIf(!permissionEnforcement.write)(
       'should throw DataDirAccessError if directory is not writable',
       async () => {
         const dataDir = path.join(testBaseDir, 'readonly-dir');
@@ -246,7 +248,7 @@ describe('ensureDataDir', () => {
       }
     );
 
-    it.skipIf(isWindows)(
+    it.skipIf(!permissionEnforcement.write)(
       'should throw DataDirAccessError if parent directory is not writable',
       async () => {
         const parentDir = path.join(testBaseDir, 'readonly-parent');

--- a/packages/world-local/src/storage.test.ts
+++ b/packages/world-local/src/storage.test.ts
@@ -26,6 +26,7 @@ import {
   createStep,
   createWait,
   disposeHook,
+  permissionEnforcement,
   updateRun,
   updateStep,
 } from './test-helpers.js';
@@ -5399,8 +5400,10 @@ describe('Storage', () => {
     });
 
     // chmod-based permission simulation is a no-op for directories on
-    // Windows, so these two abort-path tests only run on POSIX platforms.
-    it.skipIf(process.platform === 'win32')(
+    // Windows, and is bypassed outright by root / CAP_DAC_OVERRIDE, so these
+    // two abort-path tests only run where the permission bits are actually
+    // enforced — see `permissionEnforcement`.
+    it.skipIf(!permissionEnforcement.write)(
       'should abort the terminal transition when the staging reap fails',
       async () => {
         // The reap is the correctness-critical half of the arbitration: if
@@ -5449,7 +5452,7 @@ describe('Storage', () => {
       }
     );
 
-    it.skipIf(process.platform === 'win32')(
+    it.skipIf(!permissionEnforcement.read)(
       'should abort the terminal transition when the dominance scan fails',
       async () => {
         // mintRunDominantEventKey's ordering guarantee depends on seeing

--- a/packages/world-local/src/test-helpers.ts
+++ b/packages/world-local/src/test-helpers.ts
@@ -1,3 +1,15 @@
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import type {
   Hook,
   SerializedData,
@@ -12,6 +24,80 @@ import { SPEC_VERSION_CURRENT } from '@workflow/world';
  * Test helper functions for creating and updating storage entities through events.
  * These helpers simplify test setup by providing a convenient API for common operations.
  */
+
+/**
+ * Which parts of the POSIX permission model this process is actually subject
+ * to, probed once at import time.
+ *
+ * Tests that simulate an I/O failure with `chmod` need the filesystem to
+ * genuinely refuse the operation, and that is not a given. `chmod` itself
+ * still succeeds for root and for any process holding CAP_DAC_OVERRIDE /
+ * CAP_DAC_READ_SEARCH — common when the suite runs as root in a container or
+ * inside a dev sandbox — but the bits it sets are then ignored, so the
+ * simulation silently becomes a no-op and the assertion fails for a reason
+ * that has nothing to do with the code under test. On Windows, `chmod` on a
+ * directory is a no-op to begin with.
+ *
+ * The three capabilities are probed separately because they are bypassed
+ * independently: with CAP_DAC_OVERRIDE a real read or write of a mode-000
+ * directory succeeds while `access()` still reports EACCES, because that
+ * check is made against the real UID.
+ */
+export const permissionEnforcement = probePermissionEnforcement();
+
+function probePermissionEnforcement(): {
+  /** `fs.access()` reports EACCES for a mode the permission bits deny. */
+  accessCheck: boolean;
+  /** A real read of an unreadable directory is refused. */
+  read: boolean;
+  /** A real write into a non-writable directory is refused. */
+  write: boolean;
+} {
+  if (process.platform === 'win32') {
+    return { accessCheck: false, read: false, write: false };
+  }
+
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'workflow-perm-probe-'));
+  const unreadableDir = path.join(probeDir, 'unreadable');
+  const readOnlyDir = path.join(probeDir, 'read-only');
+
+  try {
+    mkdirSync(unreadableDir);
+    writeFileSync(path.join(unreadableDir, 'entry'), '');
+    chmodSync(unreadableDir, 0o000);
+
+    mkdirSync(readOnlyDir);
+    chmodSync(readOnlyDir, 0o555);
+
+    return {
+      accessCheck: isRefused(() => accessSync(unreadableDir, constants.R_OK)),
+      read: isRefused(() => readdirSync(unreadableDir)),
+      write: isRefused(() =>
+        writeFileSync(path.join(readOnlyDir, 'probe'), '')
+      ),
+    };
+  } finally {
+    // Restore the bits before removing the probe tree, so cleanup works on the
+    // platforms where those bits are enforced.
+    for (const dir of [unreadableDir, readOnlyDir]) {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        // The directory was never created; nothing to restore.
+      }
+    }
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+function isRefused(operation: () => unknown): boolean {
+  try {
+    operation();
+    return false;
+  } catch {
+    return true;
+  }
+}
 
 /**
  * Create a new workflow run through the run_created event.


### PR DESCRIPTION
### Description

Running the unit suite (`pnpm test --filter='!./docs' --filter='!./workbench/vitest'`) fails four tests in `@workflow/world-local` on any machine where the process bypasses POSIX permission bits — as root in a container, or in a dev sandbox holding `CAP_DAC_OVERRIDE` / `CAP_DAC_READ_SEARCH`:

```
FAIL src/init.test.ts > ensureDataDir > permission errors > should throw DataDirAccessError if directory is not writable
FAIL src/init.test.ts > ensureDataDir > permission errors > should throw DataDirAccessError if parent directory is not writable
FAIL src/storage.test.ts > Storage > … > should abort the terminal transition when the staging reap fails
FAIL src/storage.test.ts > Storage > … > should abort the terminal transition when the dominance scan fails
```

Those tests simulate an I/O failure by `chmod`-ing a directory and asserting the operation is refused. `chmod` itself still succeeds for such a process, but the bits it sets are then ignored — so the simulation silently becomes a no-op and the assertion fails for a reason that has nothing to do with the code under test.

`permissionEnforcement` (in `src/test-helpers.ts`) probes once at import time whether the bits actually bite, and the tests are gated on it. This generalizes the `win32` guard those tests already carried: Windows was the same problem — `chmod` on a directory is a no-op there — detected by platform name rather than by behavior.

The three capabilities are probed separately because they are bypassed independently: with `CAP_DAC_OVERRIDE` a real read or write of a mode-000 directory succeeds while `access()` still reports `EACCES`, since that check is made against the real UID. `ensureDataDir` checks readability with `access(R_OK)` but writability with an actual write, so a single flag would have skipped the still-meaningful readability case.

No non-test code changes.

### How did you test your changes?

Both directions were verified, since the risk of a probe like this is that it silently skips in CI:

- **As-is on an unprivileged process** (`capsh --caps="=" --`, i.e. what a GitHub runner looks like) the probe returns `{accessCheck: true, read: true, write: true}` and `world-local` reports **546 passed, 0 skipped** — all five permission tests still run, so CI coverage is unchanged by this PR.
- **On this privileged box** the same suite goes from 4 failed / 542 passed to **542 passed, 4 skipped** (the `access()`-based readability case still runs and passes, because `access()` is enforced here).

The rest of the locally-runnable CI surface was run to confirm nothing else was broken, all green:

| CI job | Result |
| --- | --- |
| Unit Tests (ubuntu) — `pnpm test --filter='!./docs' --filter='!./workbench/vitest'` | 47/47 tasks (incl. 173 `swc_workflow` Rust tests) |
| `pnpm typecheck` | 43/43 |
| Biome — `biome ci --max-diagnostics=200` | 1511 files, 0 errors |
| No Test Overrides / CI Scripts Tests | pass / 51 pass |
| Serializable Reviver Compatibility | 3 pass |
| Node.js Module Build Errors + Route Bundle Isolation | 4 pass + 1 pass |
| Vitest Plugin (`WORKFLOW_VM=node`, `=quickjs`) | 39 each |
| E2E Local Dev (nextjs-turbopack) — `dev.test.ts` + `test:e2e` | 7 pass/2 skip, then 156 pass |
| E2E Local Prod (nextjs-turbopack) — `local-build.test.ts` + `test:e2e` | 13 pass, then 156 pass |
| Docs Code Samples — `pnpm test:docs` | 981 pass/289 skip |
| Docs Links — `bun ./scripts/lint.ts` | 0 errors |

The Vercel-deployment lanes (`e2e-vercel-prod`, multi-region, ws-transport, Windows, Python, community worlds) were not run — they need deployment credentials.

One aside worth recording: an initial local-prod run failed 3 pages-router tests with 500s from a stale `.next` referencing a deleted `workflow-sourcemap-warning-fixture-*` package. That was an artifact of running several CI jobs in a single workspace — CI gives each job a fresh checkout — and the tests pass on a clean production build. Not a defect, and nothing in this PR addresses it.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete