### PR TITLE
[ci] Make Python CI e2e optional until it support specVersion 7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -321,6 +321,9 @@ jobs:
     name: E2E Vercel Prod Tests (${{ matrix.app.name }} - ${{ matrix.vm }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Keep cross-language coverage visible without blocking JavaScript SDK
+    # changes while the Python runtime catches up with the current protocol.
+    continue-on-error: ${{ matrix.app.name == 'python' }}
     needs: ci-scope
     if: ${{ needs.ci-scope.outputs.fast-path != 'true' }}
     permissions:
@@ -1320,10 +1323,10 @@ jobs:
   # `e2e-vercel-prod` lane, whose rows only need a URL, does carry `python` as an
   # ordinary matrix row.
   #
-  # What this lane protects is the gate, not the fixtures it happens to run: a
-  # test that stops skipping correctly, or a fixture declared in
-  # `e2e-conformance.json` that the app stops registering, fails here and nowhere
-  # else.
+  # This lane is advisory while the Python runtime catches up with the current
+  # protocol. A test that stops skipping correctly, or a fixture declared in
+  # `e2e-conformance.json` that the app stops registering, still fails visibly
+  # here and nowhere else.
   e2e-python:
     name: E2E Python Conformance
     runs-on: ubuntu-latest
@@ -1671,12 +1674,12 @@ jobs:
           header: e2e-test-results
           path: e2e-summary.md
 
-  # Final required check: passes only when unit + all E2E jobs succeed.
-  # Community worlds are intentionally excluded — they are disabled on main.
+  # Final required check: passes only when unit + required E2E jobs succeed.
+  # Python conformance is advisory, and community worlds are disabled on main.
   e2e-required-check:
     name: E2E Required Check
     runs-on: ubuntu-latest
-    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, unit, e2e-package-build, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-windows]
     if: always()
     timeout-minutes: 5
 
@@ -1691,7 +1694,6 @@ jobs:
           LOCAL_DEV_STATUS: ${{ needs.e2e-local-dev.result }}
           LOCAL_PROD_STATUS: ${{ needs.e2e-local-prod.result }}
           POSTGRES_STATUS: ${{ needs.e2e-local-postgres.result }}
-          PYTHON_STATUS: ${{ needs.e2e-python.result }}
           WINDOWS_STATUS: ${{ needs.e2e-windows.result }}
           FAST_PATH: ${{ needs.ci-scope.outputs.fast-path }}
           VALIDATION_FAST_PATH: ${{ needs.ci-scope.outputs.validation-fast-path }}
@@ -1726,10 +1728,9 @@ jobs:
             [[ "$LOCAL_DEV_STATUS" == "skipped" ]] || echo "Warning: e2e-local-dev was not skipped ($LOCAL_DEV_STATUS)"
             [[ "$LOCAL_PROD_STATUS" == "skipped" ]] || echo "Warning: e2e-local-prod was not skipped ($LOCAL_PROD_STATUS)"
             [[ "$POSTGRES_STATUS" == "skipped" ]] || echo "Warning: e2e-local-postgres was not skipped ($POSTGRES_STATUS)"
-            [[ "$PYTHON_STATUS" == "skipped" ]] || echo "Warning: e2e-python was not skipped ($PYTHON_STATUS)"
             [[ "$WINDOWS_STATUS" == "skipped" ]] || echo "Warning: e2e-windows was not skipped ($WINDOWS_STATUS)"
           else
-            echo "Standard PR - checking all jobs"
+            echo "Standard PR - checking all required jobs"
             [[ "$UNIT_STATUS" == "success" ]] || FAILED_JOBS+=("unit ($UNIT_STATUS)")
             [[ "$BUILD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-package-build ($BUILD_STATUS)")
             [[ "$VERCEL_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-vercel-prod ($VERCEL_STATUS)")
@@ -1738,7 +1739,6 @@ jobs:
             [[ "$LOCAL_DEV_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-dev ($LOCAL_DEV_STATUS)")
             [[ "$LOCAL_PROD_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-prod ($LOCAL_PROD_STATUS)")
             [[ "$POSTGRES_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-local-postgres ($POSTGRES_STATUS)")
-            [[ "$PYTHON_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-python ($PYTHON_STATUS)")
             [[ "$WINDOWS_STATUS" == "success" ]] || FAILED_JOBS+=("e2e-windows ($WINDOWS_STATUS)")
           fi
 


### PR DESCRIPTION
### Description

Makes the Python conformance lanes advisory while the pinned Python runtime catches up with the current workflow protocol. The TypeScript SDK now emits `specVersion: 7`, while the Python runtime currently accepts at most version 6, so unrelated SDK PRs are otherwise blocked by a known cross-repository compatibility gap.

- Keeps the standalone local Python conformance job running, red when broken, and included in the E2E summary, but removes it from `E2E Required Check`.
- Allows only the `python` row in the Vercel production matrix to fail; all JavaScript framework rows remain required.
- Leaves Python logs and artifacts available so the compatibility signal is not lost.

### Verification

- `git diff --check`
- Parsed `.github/workflows/tests.yml` as YAML
- The PR CI run should exercise the intended behavior directly: Python may remain red while `E2E Required Check` passes if every required lane succeeds.

### PR Checklist - Required to merge

- [x] No changeset is needed because this changes CI configuration only.
- [x] Commit is DCO signed off.