### PR TITLE
[core] Send the disposed hook's token from the QuickJS engine

### DIFF
--- a/.changeset/quickjs-hook-dispose-token.md
+++ b/.changeset/quickjs-hook-dispose-token.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Send the disposed hook's token on `hook_disposed` from the QuickJS engine, matching the node:vm engine

--- a/packages/core/src/runtime/quickjs-entrypoint.ts
+++ b/packages/core/src/runtime/quickjs-entrypoint.ts
@@ -455,6 +455,13 @@ async function dispatchPendingOps(params: {
         eventType: 'hook_disposed',
         specVersion: SPEC_VERSION_CURRENT,
         correlationId: op.correlationId,
+        // The hook's token, which the node:vm engine has always sent. A world
+        // that keys a hook's token claim separately from the hook itself needs
+        // it to release both, and the only alternative is for it to look the
+        // token up first. Omitted rather than sent as undefined when the op
+        // carries none, so a world that reads it cannot tell the difference
+        // between this engine and a client too old to send one.
+        ...(op.token === undefined ? {} : { eventData: { token: op.token } }),
       });
     } catch (err) {
       if (EntityConflictError.is(err)) return;

--- a/packages/core/src/runtime/quickjs-hook-dispose-token.test.ts
+++ b/packages/core/src/runtime/quickjs-hook-dispose-token.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Pins that the QuickJS engine sends the disposed hook's token on
+ * `hook_disposed`, the way the node:vm engine always has.
+ *
+ * A hook's token can be claimed separately from the hook itself, so a world
+ * that has to release both needs to be told which token this disposal is for.
+ * The two engines disagreeing about that means the same workflow does different
+ * work depending on which VM ran it, which is the kind of difference that shows
+ * up as a backend-only bug report.
+ *
+ * The QuickJS VM is mocked: what is under test is the request the entrypoint
+ * builds from a pending operation, not the VM that produced the operation.
+ */
+import {
+  type CreateEventRequest,
+  SPEC_VERSION_CURRENT,
+  type WorkflowRun,
+  type World,
+} from '@workflow/world';
+import { describe, expect, it, vi } from 'vitest';
+import { setWorld } from './world.js';
+
+vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }));
+vi.mock('./get-port-lazy.js', () => ({
+  getPortLazy: vi.fn().mockResolvedValue(3000),
+}));
+
+const startQuickJSWorkflow = vi.fn();
+vi.mock('./quickjs-runtime.js', () => ({
+  startQuickJSWorkflow: (...args: unknown[]) => startQuickJSWorkflow(...args),
+}));
+
+/** Drive the entrypoint over a single `hook_dispose` pending operation. */
+async function disposeWith(op: Record<string, unknown>) {
+  const runId = 'wrun_dispose_token';
+  const startedAt = new Date('2026-05-19T12:00:00.000Z');
+  const workflowRun: WorkflowRun = {
+    runId,
+    workflowName: 'workflow',
+    status: 'running',
+    input: [],
+    deploymentId: 'dpl_dispose_token',
+    specVersion: SPEC_VERSION_CURRENT,
+    startedAt,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+  };
+
+  const createdEvents: CreateEventRequest[] = [];
+  setWorld({
+    specVersion: SPEC_VERSION_CURRENT,
+    capabilities: {},
+    events: {
+      list: vi.fn(async () => ({ data: [], cursor: null, hasMore: false })),
+      create: vi.fn(async (_runId: string, request: CreateEventRequest) => {
+        createdEvents.push(request);
+        return { event: { ...request, runId, eventId: 'evnt_created' } };
+      }),
+    },
+    runs: { get: vi.fn(async () => workflowRun) },
+    queue: vi.fn().mockResolvedValue({ messageId: 'msg_dispose_token' }),
+    getEncryptionKeyForRun: vi.fn().mockResolvedValue(undefined),
+  } as unknown as World);
+
+  startQuickJSWorkflow.mockResolvedValue({
+    result: { suspended: { pendingOperations: [op] } },
+    continueWithEvents: vi.fn(),
+    dispose: vi.fn(),
+  });
+
+  const { runWorkflowWithQuickJS } = await import('./quickjs-entrypoint.js');
+  await runWorkflowWithQuickJS({
+    workflowCode: '// not evaluated: the VM is mocked',
+    workflowName: 'workflow',
+    workflowRun,
+    preloadedEvents: [],
+  });
+
+  return createdEvents.filter((e) => e.eventType === 'hook_disposed');
+}
+
+describe('QuickJS hook_disposed', () => {
+  it('carries the disposed hook’s token', async () => {
+    const disposals = await disposeWith({
+      type: 'hook_dispose',
+      correlationId: 'hook_01JCHOOK',
+      token: 'order-42-approve',
+      hasCreatedEvent: false,
+    });
+
+    expect(disposals).toHaveLength(1);
+    expect(disposals[0].eventData).toEqual({ token: 'order-42-approve' });
+  });
+
+  it('omits eventData entirely when the operation carries no token', async () => {
+    // `PendingHookDispose.token` is optional. Sending `{ token: undefined }`
+    // would encode differently across the JSON and CBOR wire formats, so the
+    // field is left off instead — indistinguishable from a client too old to
+    // send one, which is the case a world already has to handle.
+    const disposals = await disposeWith({
+      type: 'hook_dispose',
+      correlationId: 'hook_01JCHOOK',
+      hasCreatedEvent: false,
+    });
+
+    expect(disposals).toHaveLength(1);
+    expect(disposals[0].eventData).toBeUndefined();
+    expect('eventData' in disposals[0]).toBe(false);
+  });
+});

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -868,6 +868,86 @@ describe('AbortController (hook-backed)', () => {
     expect(value.observed).toEqual(['listener:stop it']);
   });
 
+  it('carries the system hook token into the completion-drain disposal', async () => {
+    // The completion drain synthesizes a `hook_dispose` for a durable system
+    // hook the workflow never aborted, and the entrypoint turns that op into a
+    // `hook_disposed` event. The op therefore has to carry the token: the
+    // node:vm engine sends one here (its drain marks the queue item disposed
+    // and reuses it, token included), and a world that releases a hook's token
+    // claim alongside the hook needs to be told which token this is.
+    const code = `
+      var checkStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//test//check");
+      async function workflow() {
+        // Never aborted and never explicitly disposed: exactly the hook the
+        // completion drain has to clean up.
+        var controller = new AbortController();
+        await checkStep(1);
+        return controller.signal.aborted;
+      }
+      workflow.workflowId = "workflow//test//workflow";
+      globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+    `;
+    const run = makeRun();
+
+    const r1 = await runQuickJSWorkflow({
+      workflowCode: code,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: run,
+      events: [],
+    });
+    const hookOp = r1.suspended!.pendingOperations.find(
+      (o) => o.type === 'hook'
+    ) as any;
+    const stepOp = r1.suspended!.pendingOperations.find(
+      (o) => o.type === 'step'
+    ) as any;
+    expect(hookOp.isSystem).toBe(true);
+    expect(hookOp.token).toBeTruthy();
+
+    // Replay with the hook durably created and the step done, so the workflow
+    // returns and the drain runs.
+    const r2 = await runQuickJSWorkflow({
+      workflowCode: code,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: run,
+      events: [
+        runCreatedEvent(run),
+        {
+          eventId: 'evnt_001',
+          runId: run.runId,
+          eventType: 'hook_created',
+          correlationId: hookOp.correlationId,
+          eventData: { token: hookOp.token, isWebhook: false, isSystem: true },
+          createdAt: new Date('2025-01-01T00:00:01Z'),
+        },
+        {
+          eventId: 'evnt_002',
+          runId: run.runId,
+          eventType: 'step_created',
+          correlationId: stepOp.correlationId,
+          eventData: { stepName: 'step//test//check' },
+          createdAt: new Date('2025-01-01T00:00:02Z'),
+        },
+        {
+          eventId: 'evnt_003',
+          runId: run.runId,
+          eventType: 'step_completed',
+          correlationId: stepOp.correlationId,
+          eventData: { output: serialize(1) },
+          createdAt: new Date('2025-01-01T00:00:03Z'),
+        },
+      ],
+    });
+
+    expect(r2.completed).toBeDefined();
+    const disposal = r2.completed!.drainOperations?.find(
+      (o) => o.type === 'hook_dispose'
+    ) as any;
+    expect(disposal).toBeDefined();
+    expect(disposal.correlationId).toBe(hookOp.correlationId);
+    expect(disposal.token).toBe(hookOp.token);
+  });
+
   it('AbortSignal statics work in the VM', async () => {
     const result = await runQuickJSWorkflow({
       workflowCode: `

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -2621,6 +2621,12 @@ function collectDrainOperations(
           toDispose.push({
             type: "hook_dispose",
             correlationId: p.correlationId,
+            // Carried, not dropped: the entrypoint sends it on hook_disposed,
+            // and the node:vm engine does the same for this case — its
+            // completion drain marks the system hook disposed and reuses the
+            // queue item, token and all. Synthesizing a fresh object here is
+            // what makes it easy to lose.
+            token: p.token,
             hasCreatedEvent: false,
           });
         }


### PR DESCRIPTION
The two engines disagree about what a disposal says.

`suspension-handler.ts` (node:vm) has always sent the hook's token on `hook_disposed`:

```ts
const hookDisposedEvent: CreateEventRequest = {
  eventType: 'hook_disposed' as const,
  specVersion: SPEC_VERSION_CURRENT,
  correlationId: queueItem.correlationId,
  eventData: {
    token: queueItem.token,
  },
};
```

`quickjs-entrypoint.ts` sent no `eventData` at all — even though the pending operation already carries the token, and already uses it to order same-token hook operations so a dispose releases a token before a later hook's creation is validated against it.

## Why it matters

A world may key a hook's token claim separately from the hook itself, in which case retiring a hook means releasing both, and it needs to know which token this disposal is for. Told nothing, such a world has to look the token up before it can act — and the same workflow then does measurably different work depending on which VM ran it. `hook_disposed`'s `eventData.token` is optional in the schema, so neither engine is wrong on the wire; they are just inconsistent, which makes this the kind of thing that surfaces as a backend-shaped bug report rather than an engine one.

`world-vercel` is the case in hand: it uses the token to release the hook and its token claim together.

## The change

One field, from the operation the VM already populates:

```ts
...(op.token === undefined ? {} : { eventData: { token: op.token } }),
```

Omitted rather than sent as `undefined` when the operation carries none. `PendingHookDispose.token` is optional, and an explicit `undefined` encodes differently across the JSON and CBOR wire formats — leaving the field off keeps this engine indistinguishable from a client too old to send one, which is a case a world already has to handle.

## Tests

`packages/core/src/runtime/quickjs-hook-dispose-token.test.ts` drives the entrypoint over a single `hook_dispose` operation with the VM mocked, so what is under test is the request the entrypoint builds rather than the VM that produced the operation. Two cases: the token is carried, and `eventData` is absent entirely when the operation has none.

Verified the first case fails without the change:

```
× carries the disposed hook's token
AssertionError: expected undefined to deeply equal { token: 'order-42-approve' }
```

`packages/core/src/runtime` is green at 728 tests, and `hookDisposeTestWorkflow` already covers disposal end to end on the QuickJS lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)