### PR TITLE
Serialize WebSocket stream batches

### DIFF
--- a/packages/world-vercel/src/ws-streamer.ts
+++ b/packages/world-vercel/src/ws-streamer.ts
@@ -9,7 +9,7 @@ import { getHttpConfig, getHttpUrl } from './utils.js';
 import { version } from './version.js';
 
 const EMPTY = new Uint8Array(0);
-const MAX_IN_FLIGHT_BATCHES = 5;
+const MAX_IN_FLIGHT_BATCHES = 1;
 const IDLE_TIMEOUT_MS = 30_000;
 
 type Reply = { meta: Record<string, unknown>; body: Uint8Array };


### PR DESCRIPTION
## Summary & Motivation

Matches the HTTP stream path's serial delivery, so a WebSocket comparison measures transport behavior rather than pipeline depth. The server's socket handler is serial anyway, so extra in-flight frames only queue behind it.

## Test Plan

Existing coverage runs in CI.
