### PR TITLE
fix(builders): dedupe pnpm peer-variant copies instead of failing on duplicate step IDs

### DIFF
--- a/.changeset/dedupe-pnpm-peer-variant-step-ids.md
+++ b/.changeset/dedupe-pnpm-peer-variant-step-ids.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Deduplicate identical pnpm peer-variant copies of a package instead of failing the build with a duplicate step/workflow ID error. Genuinely different implementations that map to the same ID still fail.

--- a/.changeset/dedupe-pnpm-peer-variant-step-ids.md
+++ b/.changeset/dedupe-pnpm-peer-variant-step-ids.md
@@ -2,4 +2,4 @@
 '@workflow/builders': patch
 ---
 
-Deduplicate identical pnpm peer-variant copies of a package instead of failing the build with a duplicate step/workflow ID error. Genuinely different implementations that map to the same ID still fail.
+Deduplicate identical pnpm peer-variant copies of a package instead of failing the build with a duplicate step/workflow ID error. Different implementations that map to the same ID still fail.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -33,6 +33,11 @@ import {
   fastDiscoverEntries,
 } from './fast-discovery.js';
 import {
+  hashManifestSource,
+  type ManifestEntryLocation,
+  mergeWorkflowManifest,
+} from './manifest-ids.js';
+import {
   getImportPath,
   resolveModuleSpecifier,
   stripPackageVersion,
@@ -185,80 +190,17 @@ function moduleIdentityKey(file: string, moduleSpecifierRoot: string): string {
   return file.replace(/\\/g, '/');
 }
 
-type ManifestEntryLocation = {
-  filePath: string;
-  name: string;
-};
-
 type CachedManifestTransform = {
   size: number;
   mtimeMs: number;
   manifest: WorkflowManifest;
+  /**
+   * Fingerprint of the source contents that produced `manifest`, used to
+   * deduplicate equivalent copies of the same module across files (see
+   * `mergeWorkflowManifest` in `manifest-ids.ts`).
+   */
+  contentHash: string;
 };
-
-function formatIdLocation(location: ManifestEntryLocation): string {
-  return `${location.filePath}#${location.name}`;
-}
-
-function assertUniqueManifestIds<TEntry>(
-  entriesByFile: Record<string, Record<string, TEntry>> | undefined,
-  ids: Map<string, ManifestEntryLocation>,
-  getId: (entry: TEntry) => string,
-  label: 'step' | 'workflow'
-): void {
-  for (const [filePath, entries] of Object.entries(entriesByFile || {})) {
-    for (const [name, data] of Object.entries(entries)) {
-      const id = getId(data);
-      const existing = ids.get(id);
-      const current = { filePath, name };
-      if (
-        existing &&
-        (existing.filePath !== current.filePath ||
-          existing.name !== current.name)
-      ) {
-        const idName = label === 'step' ? 'workflow step ID' : 'workflow ID';
-        const functionName = `${label} function`;
-        const capitalizedLabel = label === 'step' ? 'Step' : 'Workflow';
-        throw new WorkflowBuildError(
-          `Duplicate ${idName} "${id}" generated for ${formatIdLocation(existing)} and ${formatIdLocation(current)}.`,
-          {
-            hint:
-              `${capitalizedLabel} IDs must be unique across a build. ` +
-              `If you own one of the colliding files, rename the ${functionName} or export ` +
-              `the package file through a unique package subpath. If the collision is in a ` +
-              `transitive dependency you don't control, file an issue with the upstream ` +
-              `package or pin to a non-colliding version.`,
-          }
-        );
-      }
-      ids.set(id, current);
-    }
-  }
-}
-
-function mergeWorkflowManifest(
-  target: WorkflowManifest,
-  incoming: WorkflowManifest,
-  stepIds: Map<string, ManifestEntryLocation>,
-  workflowIds: Map<string, ManifestEntryLocation>
-): void {
-  assertUniqueManifestIds(
-    incoming.steps,
-    stepIds,
-    (data) => data.stepId,
-    'step'
-  );
-  assertUniqueManifestIds(
-    incoming.workflows,
-    workflowIds,
-    (data) => data.workflowId,
-    'workflow'
-  );
-
-  target.workflows = Object.assign(target.workflows || {}, incoming.workflows);
-  target.steps = Object.assign(target.steps || {}, incoming.steps);
-  target.classes = Object.assign(target.classes || {}, incoming.classes);
-}
 
 /**
  * Base class for workflow builders. Provides common build logic for transforming
@@ -784,7 +726,7 @@ export abstract class BaseBuilder {
   private async getCachedManifestTransform(
     file: string,
     mode: 'workflow' | 'step'
-  ): Promise<WorkflowManifest> {
+  ): Promise<{ manifest: WorkflowManifest; contentHash: string }> {
     const stats = await stat(file);
     const cacheKey = `${mode}:${file}`;
     const cached = this.manifestTransformCache.get(cacheKey);
@@ -793,7 +735,7 @@ export abstract class BaseBuilder {
       cached.size === stats.size &&
       cached.mtimeMs === stats.mtimeMs
     ) {
-      return cached.manifest;
+      return { manifest: cached.manifest, contentHash: cached.contentHash };
     }
 
     const source = await readFile(file, 'utf8');
@@ -806,12 +748,14 @@ export abstract class BaseBuilder {
       this.transformProjectRoot,
       this.moduleSpecifierRoot
     );
+    const contentHash = hashManifestSource(source);
     this.manifestTransformCache.set(cacheKey, {
       size: stats.size,
       mtimeMs: stats.mtimeMs,
       manifest: workflowManifest,
+      contentHash,
     });
-    return workflowManifest;
+    return { manifest: workflowManifest, contentHash };
   }
 
   protected createRouteImportSpecifier(file: string, routeDir: string): string {
@@ -912,15 +856,14 @@ export const __steps_registered = true;
     const workflowIds = new Map<string, ManifestEntryLocation>();
     await Promise.all(
       manifestFiles.map(async (file) => {
-        const fileManifest = await this.getCachedManifestTransform(
-          file,
-          'step'
-        );
+        const { manifest: fileManifest, contentHash } =
+          await this.getCachedManifestTransform(file, 'step');
         mergeWorkflowManifest(
           workflowManifest,
           fileManifest,
           stepIds,
-          workflowIds
+          workflowIds,
+          contentHash
         );
       })
     );
@@ -1239,10 +1182,8 @@ export const __steps_registered = true;
     await Promise.all(
       workflowOnlyFiles.map(async (workflowFile) => {
         try {
-          const fileManifest = await this.getCachedManifestTransform(
-            workflowFile,
-            'workflow'
-          );
+          const { manifest: fileManifest } =
+            await this.getCachedManifestTransform(workflowFile, 'workflow');
           if (fileManifest.workflows) {
             workflowManifest.workflows = Object.assign(
               workflowManifest.workflows || {},

--- a/packages/builders/src/manifest-ids.test.ts
+++ b/packages/builders/src/manifest-ids.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowManifest } from './apply-swc-transform.js';
+import {
+  hashManifestSource,
+  type ManifestEntryLocation,
+  mergeWorkflowManifest,
+} from './manifest-ids.js';
+
+function createMaps() {
+  return {
+    stepIds: new Map<string, ManifestEntryLocation>(),
+    workflowIds: new Map<string, ManifestEntryLocation>(),
+  };
+}
+
+function stepManifest(filePath: string, name: string, stepId: string) {
+  return {
+    steps: {
+      [filePath]: {
+        [name]: { stepId },
+      },
+    },
+  } satisfies WorkflowManifest;
+}
+
+function workflowManifest(filePath: string, name: string, workflowId: string) {
+  return {
+    workflows: {
+      [filePath]: {
+        [name]: { workflowId },
+      },
+    },
+  } satisfies WorkflowManifest;
+}
+
+const PEER_A_FILE =
+  'node_modules/.pnpm/pkg@1.0.0_peer-a@1.0.0/node_modules/pkg/dist/steps.js';
+const PEER_B_FILE =
+  'node_modules/.pnpm/pkg@1.0.0_peer-b@2.0.0/node_modules/pkg/dist/steps.js';
+const STEP_ID = 'step//pkg/steps@1.0.0//doWork';
+const WORKFLOW_ID = 'workflow//pkg/steps@1.0.0//orchestrate';
+
+describe('mergeWorkflowManifest duplicate ID handling', () => {
+  it('throws when two different files emit the same step ID with different contents', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+
+    mergeWorkflowManifest(
+      target,
+      stepManifest(PEER_A_FILE, 'doWork', STEP_ID),
+      stepIds,
+      workflowIds,
+      hashManifestSource('export const doWork = 1;')
+    );
+
+    expect(() =>
+      mergeWorkflowManifest(
+        target,
+        stepManifest(PEER_B_FILE, 'doWork', STEP_ID),
+        stepIds,
+        workflowIds,
+        hashManifestSource('export const doWork = 2;')
+      )
+    ).toThrow(/Duplicate workflow step ID/);
+  });
+
+  it('deduplicates identical copies of the same module emitting the same step ID', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+    const contentHash = hashManifestSource('export const doWork = 1;');
+
+    mergeWorkflowManifest(
+      target,
+      stepManifest(PEER_A_FILE, 'doWork', STEP_ID),
+      stepIds,
+      workflowIds,
+      contentHash
+    );
+    mergeWorkflowManifest(
+      target,
+      stepManifest(PEER_B_FILE, 'doWork', STEP_ID),
+      stepIds,
+      workflowIds,
+      contentHash
+    );
+
+    // The first registration wins in the ID map...
+    expect(stepIds.get(STEP_ID)?.filePath).toBe(PEER_A_FILE);
+    // ...but both file entries stay in the manifest (both copies register
+    // the same ID at runtime, which is harmless for identical code).
+    expect(Object.keys(target.steps ?? {})).toEqual([PEER_A_FILE, PEER_B_FILE]);
+  });
+
+  it('deduplicates identical copies emitting the same workflow ID', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+    const contentHash = hashManifestSource('export const orchestrate = 1;');
+
+    mergeWorkflowManifest(
+      target,
+      workflowManifest(PEER_A_FILE, 'orchestrate', WORKFLOW_ID),
+      stepIds,
+      workflowIds,
+      contentHash
+    );
+    expect(() =>
+      mergeWorkflowManifest(
+        target,
+        workflowManifest(PEER_B_FILE, 'orchestrate', WORKFLOW_ID),
+        stepIds,
+        workflowIds,
+        contentHash
+      )
+    ).not.toThrow();
+    expect(workflowIds.get(WORKFLOW_ID)?.filePath).toBe(PEER_A_FILE);
+  });
+
+  it('throws when the same workflow ID comes from different contents', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+
+    mergeWorkflowManifest(
+      target,
+      workflowManifest(PEER_A_FILE, 'orchestrate', WORKFLOW_ID),
+      stepIds,
+      workflowIds,
+      hashManifestSource('a')
+    );
+    expect(() =>
+      mergeWorkflowManifest(
+        target,
+        workflowManifest(PEER_B_FILE, 'orchestrate', WORKFLOW_ID),
+        stepIds,
+        workflowIds,
+        hashManifestSource('b')
+      )
+    ).toThrow(/Duplicate workflow ID/);
+  });
+
+  it('throws when content hashes are unavailable, even for equal names', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+
+    mergeWorkflowManifest(
+      target,
+      stepManifest(PEER_A_FILE, 'doWork', STEP_ID),
+      stepIds,
+      workflowIds
+    );
+    expect(() =>
+      mergeWorkflowManifest(
+        target,
+        stepManifest(PEER_B_FILE, 'doWork', STEP_ID),
+        stepIds,
+        workflowIds
+      )
+    ).toThrow(/Duplicate workflow step ID/);
+  });
+
+  it('throws when identical contents map the same ID to different symbol names', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+    const contentHash = hashManifestSource('shared');
+
+    mergeWorkflowManifest(
+      target,
+      stepManifest(PEER_A_FILE, 'doWork', STEP_ID),
+      stepIds,
+      workflowIds,
+      contentHash
+    );
+    expect(() =>
+      mergeWorkflowManifest(
+        target,
+        stepManifest(PEER_B_FILE, 'doOtherWork', STEP_ID),
+        stepIds,
+        workflowIds,
+        contentHash
+      )
+    ).toThrow(/Duplicate workflow step ID/);
+  });
+
+  it('allows re-merging the same file without error', () => {
+    const { stepIds, workflowIds } = createMaps();
+    const target: WorkflowManifest = {};
+    const manifest = stepManifest(PEER_A_FILE, 'doWork', STEP_ID);
+    const contentHash = hashManifestSource('export const doWork = 1;');
+
+    mergeWorkflowManifest(target, manifest, stepIds, workflowIds, contentHash);
+    expect(() =>
+      mergeWorkflowManifest(target, manifest, stepIds, workflowIds, contentHash)
+    ).not.toThrow();
+  });
+});

--- a/packages/builders/src/manifest-ids.ts
+++ b/packages/builders/src/manifest-ids.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto';
+import { WorkflowBuildError } from '@workflow/errors';
+import type { WorkflowManifest } from './apply-swc-transform.js';
+
+/**
+ * Location (and identity fingerprint) of a manifest entry that produced a
+ * workflow/step ID during a build. Shared by the duplicate-ID checks in
+ * `swc-esbuild-plugin.ts` (esbuild bundling path) and `base-builder.ts`
+ * (source registration path).
+ */
+export type ManifestEntryLocation = {
+  filePath: string;
+  name: string;
+  /**
+   * Fingerprint (SHA-256) of the source file contents that produced this
+   * entry. Used to recognize equivalent duplicate copies of the same module
+   * (see `assertUniqueManifestIds`). `undefined` when the caller cannot
+   * provide the source contents, which disables deduplication and preserves
+   * the collision error.
+   */
+  contentHash?: string;
+};
+
+/**
+ * Hash source file contents for manifest-entry equivalence comparison.
+ */
+export function hashManifestSource(source: string): string {
+  return createHash('sha256').update(source).digest('hex');
+}
+
+function formatIdLocation(location: ManifestEntryLocation): string {
+  return `${location.filePath}#${location.name}`;
+}
+
+function assertUniqueManifestIds<TEntry>(
+  entriesByFile: Record<string, Record<string, TEntry>> | undefined,
+  ids: Map<string, ManifestEntryLocation>,
+  getId: (entry: TEntry) => string,
+  label: 'step' | 'workflow',
+  contentHash: string | undefined
+): void {
+  for (const [filePath, entries] of Object.entries(entriesByFile || {})) {
+    for (const [name, data] of Object.entries(entries)) {
+      const id = getId(data);
+      const existing = ids.get(id);
+      const current = { filePath, name, contentHash };
+      if (
+        existing &&
+        (existing.filePath !== current.filePath ||
+          existing.name !== current.name)
+      ) {
+        // Two *different* files generated the same ID. If both files have
+        // identical contents and the ID belongs to the same symbol, they are
+        // duplicate copies of the same logical module rather than a genuine
+        // collision. The main producer of such copies is pnpm, which
+        // materializes one package version once per peer-dependency
+        // resolution (node_modules/.pnpm/pkg@1.0.0_peer-a@.../ and
+        // .../pkg@1.0.0_peer-b@.../ hard-link the same store files), while
+        // the canonical ID intentionally describes the logical module
+        // (`name/subpath@version`) and ignores installation topology.
+        // Registering equivalent definitions is harmless — they run the same
+        // code under the same ID — so keep the first one and continue.
+        if (
+          existing.name === current.name &&
+          existing.contentHash !== undefined &&
+          existing.contentHash === current.contentHash
+        ) {
+          continue;
+        }
+        const idName = label === 'step' ? 'workflow step ID' : 'workflow ID';
+        const functionName = `${label} function`;
+        const capitalizedLabel = label === 'step' ? 'Step' : 'Workflow';
+        throw new WorkflowBuildError(
+          `Duplicate ${idName} "${id}" generated for ${formatIdLocation(existing)} and ${formatIdLocation(current)}.`,
+          {
+            hint:
+              `${capitalizedLabel} IDs must be unique across a build. ` +
+              `If you own one of the colliding files, rename the ${functionName} or export ` +
+              `the package file through a unique package subpath. If the collision is in a ` +
+              `transitive dependency you don't control, file an issue with the upstream ` +
+              `package or pin to a non-colliding version.`,
+          }
+        );
+      }
+      ids.set(id, current);
+    }
+  }
+}
+
+/**
+ * Merge one file's transform manifest into the build-wide manifest, failing
+ * the build on genuine duplicate step/workflow IDs while deduplicating
+ * equivalent copies of the same module (e.g. pnpm peer-dependency variants
+ * of one package version).
+ *
+ * @param contentHash - Fingerprint of the source file that produced
+ * `incoming` (see {@link hashManifestSource}). Callers merge one file's
+ * manifest at a time, so a single hash covers every incoming entry.
+ */
+export function mergeWorkflowManifest(
+  target: WorkflowManifest,
+  incoming: WorkflowManifest,
+  stepIds: Map<string, ManifestEntryLocation>,
+  workflowIds: Map<string, ManifestEntryLocation>,
+  contentHash?: string
+): void {
+  assertUniqueManifestIds(
+    incoming.steps,
+    stepIds,
+    (data) => data.stepId,
+    'step',
+    contentHash
+  );
+  assertUniqueManifestIds(
+    incoming.workflows,
+    workflowIds,
+    (data) => data.workflowId,
+    'workflow',
+    contentHash
+  );
+
+  target.workflows = Object.assign(target.workflows || {}, incoming.workflows);
+  target.steps = Object.assign(target.steps || {}, incoming.steps);
+  target.classes = Object.assign(target.classes || {}, incoming.classes);
+}

--- a/packages/builders/src/step-source-registration.test.ts
+++ b/packages/builders/src/step-source-registration.test.ts
@@ -117,4 +117,101 @@ describe('step source registration', () => {
     expect(generated).toContain('import "../src/serde.ts";');
     expect(Object.keys(manifest.classes ?? {})).toContain('src/serde.ts');
   });
+
+  /**
+   * pnpm materializes the same package version once per peer-dependency
+   * resolution (e.g. `.pnpm/step-pkg@1.0.0_peer-a@1.0.0/...` and
+   * `.pnpm/step-pkg@1.0.0_peer-b@2.0.0/...`), with byte-identical files.
+   * Both copies generate the same canonical step ID.
+   */
+  function writePnpmVirtualInstance(
+    peerSuffix: string,
+    stepSource: string
+  ): string {
+    const pkgDir = join(
+      testRoot,
+      'node_modules',
+      '.pnpm',
+      `step-pkg@1.0.0_${peerSuffix}`,
+      'node_modules',
+      'step-pkg'
+    );
+    writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: 'step-pkg',
+        version: '1.0.0',
+        exports: { '.': './index.js' },
+      })
+    );
+    const stepFile = join(pkgDir, 'index.js');
+    writeFile(stepFile, stepSource);
+    return stepFile;
+  }
+
+  it('deduplicates identical pnpm peer-variant package copies', async () => {
+    const stepSource = `export async function runPackagedStep() {
+  'use step';
+  return 1;
+}
+`;
+    const copyA = writePnpmVirtualInstance('peer-a@1.0.0', stepSource);
+    const copyB = writePnpmVirtualInstance('peer-b@2.0.0', stepSource);
+    const outfile = join(testRoot, '.workflow', 'steps.js');
+    mkdirSync(dirname(outfile), { recursive: true });
+
+    const discoveredEntries: DiscoveredEntries = {
+      discoveredSteps: new Set([copyA, copyB]),
+      discoveredWorkflows: new Set(),
+      discoveredSerdeFiles: new Set(),
+    };
+
+    const { manifest } = await createBuilder(
+      testRoot
+    ).createSourceStepRegistrations([copyA, copyB], outfile, discoveredEntries);
+
+    // Both copies land in the manifest under the same canonical step ID.
+    const stepEntries = Object.values(manifest.steps ?? {});
+    expect(stepEntries).toHaveLength(2);
+    for (const entries of stepEntries) {
+      expect(entries.runPackagedStep.stepId).toBe(
+        'step//step-pkg@1.0.0//runPackagedStep'
+      );
+    }
+  });
+
+  it('still rejects pnpm-style package copies whose implementations differ', async () => {
+    const copyA = writePnpmVirtualInstance(
+      'peer-a@1.0.0',
+      `export async function runPackagedStep() {
+  'use step';
+  return 1;
+}
+`
+    );
+    const copyB = writePnpmVirtualInstance(
+      'peer-b@2.0.0',
+      `export async function runPackagedStep() {
+  'use step';
+  return 2;
+}
+`
+    );
+    const outfile = join(testRoot, '.workflow', 'steps.js');
+    mkdirSync(dirname(outfile), { recursive: true });
+
+    const discoveredEntries: DiscoveredEntries = {
+      discoveredSteps: new Set([copyA, copyB]),
+      discoveredWorkflows: new Set(),
+      discoveredSerdeFiles: new Set(),
+    };
+
+    await expect(
+      createBuilder(testRoot).createSourceStepRegistrations(
+        [copyA, copyB],
+        outfile,
+        discoveredEntries
+      )
+    ).rejects.toThrow(/Duplicate workflow step ID/);
+  });
 });

--- a/packages/builders/src/swc-esbuild-plugin.test.ts
+++ b/packages/builders/src/swc-esbuild-plugin.test.ts
@@ -211,6 +211,119 @@ describe('createSwcPlugin externalizeNonSteps', () => {
     expect(onAfterTransform).toHaveBeenCalledOnce();
   });
 
+  it('deduplicates identical pnpm peer-variant copies emitting the same step id', async () => {
+    // pnpm materializes the same package version once per peer-dependency
+    // resolution. Both copies are byte-identical and generate the same
+    // canonical step ID, which must not fail the build.
+    const source = `export const sendMessage = true;`;
+    const firstCopy = join(
+      testRoot,
+      'node_modules/.pnpm/shared-package@1.0.0_peer-a@1.0.0/node_modules/shared-package/index.ts'
+    );
+    const secondCopy = join(
+      testRoot,
+      'node_modules/.pnpm/shared-package@1.0.0_peer-b@2.0.0/node_modules/shared-package/index.ts'
+    );
+    const onAfterTransform = vi.fn();
+    const workflowManifest = {};
+
+    writeFile(firstCopy, source);
+    writeFile(secondCopy, source);
+
+    applySwcTransformMock.mockImplementation(
+      async (filename: string, fileSource: string) => ({
+        code: fileSource,
+        workflowManifest: {
+          steps: {
+            [filename]: {
+              sendMessage: {
+                stepId: 'step//shared-package@1.0.0//sendMessage',
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const result = await esbuild.build({
+      entryPoints: [firstCopy, secondCopy],
+      absWorkingDir: testRoot,
+      outdir: join(testRoot, 'out'),
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      write: false,
+      plugins: [
+        createSwcPlugin({
+          mode: 'step',
+          workflowManifest,
+          onAfterTransform,
+        }),
+      ],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(onAfterTransform).toHaveBeenCalledTimes(2);
+    // Both copies stay in the manifest under the same step ID.
+    const steps = (
+      workflowManifest as {
+        steps?: Record<string, Record<string, { stepId: string }>>;
+      }
+    ).steps;
+    expect(Object.keys(steps ?? {})).toHaveLength(2);
+    for (const entries of Object.values(steps ?? {})) {
+      expect(entries.sendMessage.stepId).toBe(
+        'step//shared-package@1.0.0//sendMessage'
+      );
+    }
+  });
+
+  it('fails the build when pnpm-style copies with different contents emit the same step id', async () => {
+    const firstCopy = join(
+      testRoot,
+      'node_modules/.pnpm/shared-package@1.0.0_peer-a@1.0.0/node_modules/shared-package/index.ts'
+    );
+    const secondCopy = join(
+      testRoot,
+      'node_modules/.pnpm/shared-package@1.0.0_peer-b@2.0.0/node_modules/shared-package/index.ts'
+    );
+
+    writeFile(firstCopy, `export const sendMessage = 1;`);
+    writeFile(secondCopy, `export const sendMessage = 2;`);
+
+    applySwcTransformMock.mockImplementation(
+      async (filename: string, fileSource: string) => ({
+        code: fileSource,
+        workflowManifest: {
+          steps: {
+            [filename]: {
+              sendMessage: {
+                stepId: 'step//shared-package@1.0.0//sendMessage',
+              },
+            },
+          },
+        },
+      })
+    );
+
+    await expect(
+      esbuild.build({
+        entryPoints: [firstCopy, secondCopy],
+        absWorkingDir: testRoot,
+        outdir: join(testRoot, 'out'),
+        bundle: true,
+        format: 'esm',
+        platform: 'node',
+        write: false,
+        plugins: [
+          createSwcPlugin({
+            mode: 'step',
+          }),
+        ],
+      })
+    ).rejects.toThrow(/Duplicate workflow step ID/);
+  });
+
   it('fails the build when two files emit the same workflow id', async () => {
     const srcDir = join(testRoot, 'src');
     const firstWorkflowFile = join(srcDir, 'confirmation.ts');

--- a/packages/builders/src/swc-esbuild-plugin.ts
+++ b/packages/builders/src/swc-esbuild-plugin.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { relative } from 'node:path';
 import { promisify } from 'node:util';
-import { WorkflowBuildError } from '@workflow/errors';
 import enhancedResolveOrig from 'enhanced-resolve';
 import type { Plugin } from 'esbuild';
 import {
@@ -12,6 +11,11 @@ import {
   jsTsRegex,
   parentHasChild,
 } from './discover-entries-esbuild-plugin.js';
+import {
+  hashManifestSource,
+  type ManifestEntryLocation,
+  mergeWorkflowManifest,
+} from './manifest-ids.js';
 import { resolveModuleSpecifier } from './module-specifier.js';
 import { resolveWorkflowAliasRelativePath } from './workflow-alias.js';
 
@@ -115,84 +119,12 @@ function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
-type IdLocation = {
-  filePath: string;
-  name: string;
-};
-
-function formatIdLocation(location: IdLocation): string {
-  return `${location.filePath}#${location.name}`;
-}
-
-function assertUniqueManifestIds(
-  entriesByFile: WorkflowManifest['steps'] | WorkflowManifest['workflows'],
-  ids: Map<string, IdLocation>,
-  getId: (data: { stepId: string } | { workflowId: string }) => string,
-  label: 'step' | 'workflow'
-): void {
-  const entriesByFileList = Object.entries(entriesByFile || {}) as Array<
-    [string, Record<string, { stepId: string } | { workflowId: string }>]
-  >;
-  for (const [filePath, entries] of entriesByFileList) {
-    for (const [name, data] of Object.entries(entries)) {
-      const id = getId(data);
-      const existing = ids.get(id);
-      const current = { filePath, name };
-      if (
-        existing &&
-        (existing.filePath !== current.filePath ||
-          existing.name !== current.name)
-      ) {
-        const idName = label === 'step' ? 'workflow step ID' : 'workflow ID';
-        const functionName = `${label} function`;
-        const capitalizedLabel = label === 'step' ? 'Step' : 'Workflow';
-        throw new WorkflowBuildError(
-          `Duplicate ${idName} "${id}" generated for ${formatIdLocation(existing)} and ${formatIdLocation(current)}.`,
-          {
-            hint:
-              `${capitalizedLabel} IDs must be unique across a build. ` +
-              `If you own one of the colliding files, rename the ${functionName} or export ` +
-              `the package file through a unique package subpath. If the collision is in a ` +
-              `transitive dependency you don't control, file an issue with the upstream ` +
-              `package or pin to a non-colliding version.`,
-          }
-        );
-      }
-      ids.set(id, current);
-    }
-  }
-}
-
-function mergeWorkflowManifest(
-  target: WorkflowManifest,
-  incoming: WorkflowManifest,
-  stepIds: Map<string, IdLocation>,
-  workflowIds: Map<string, IdLocation>
-): void {
-  assertUniqueManifestIds(
-    incoming.steps,
-    stepIds,
-    (data) => (data as { stepId: string }).stepId,
-    'step'
-  );
-  assertUniqueManifestIds(
-    incoming.workflows,
-    workflowIds,
-    (data) => (data as { workflowId: string }).workflowId,
-    'workflow'
-  );
-
-  target.workflows = Object.assign(target.workflows || {}, incoming.workflows);
-  target.steps = Object.assign(target.steps || {}, incoming.steps);
-  target.classes = Object.assign(target.classes || {}, incoming.classes);
-}
-
 export function createSwcPlugin(options: SwcPluginOptions): Plugin {
   return {
     name: 'swc-workflow-plugin',
     setup(build) {
-      let stepIdsForCurrentBuild = new Map<string, IdLocation>();
-      let workflowIdsForCurrentBuild = new Map<string, IdLocation>();
+      let stepIdsForCurrentBuild = new Map<string, ManifestEntryLocation>();
+      let workflowIdsForCurrentBuild = new Map<string, ManifestEntryLocation>();
 
       build.onStart(() => {
         stepIdsForCurrentBuild = new Map();
@@ -529,11 +461,21 @@ export function createSwcPlugin(options: SwcPluginOptions): Plugin {
             options.workflowManifest = {};
           }
 
+          // Fingerprint the source so equivalent duplicate copies of the
+          // same module (e.g. pnpm peer-dependency variants of one package
+          // version) can be deduplicated instead of failing the build with
+          // a duplicate-ID error.
+          const contentHash =
+            workflowManifest.steps || workflowManifest.workflows
+              ? hashManifestSource(normalizedSource)
+              : undefined;
+
           mergeWorkflowManifest(
             options.workflowManifest,
             workflowManifest,
             stepIdsForCurrentBuild,
-            workflowIdsForCurrentBuild
+            workflowIdsForCurrentBuild,
+            contentHash
           );
 
           await options.onAfterTransform?.({


### PR DESCRIPTION
## Problem

The workflow compiler fails with a fatal `Duplicate workflow step ID` error when the same package version appears more than once in a pnpm dependency graph with different peer-dependency resolutions:

```
Duplicate workflow step ID "step//@workflow/core/runtime/run@5.0.0-beta.42//Run#cancel" generated for

node_modules/.pnpm/@workflow+core@5.0.0-beta.42_..._ws@8.21.0/node_modules/@workflow/core/dist/runtime/run.js#Run#cancel
and
node_modules/.pnpm/@workflow+core@5.0.0-beta.42_..._ws@8.21.3/node_modules/@workflow/core/dist/runtime/run.js#Run#cancel
```

This was hit building `examples/next-workflow` in the `vercel/ai` monorepo, where `@ai-sdk/workflow` and the app itself both depend on `workflow`, and pnpm resolved a transitive optional peer (`ws`) differently for the two instances.

The compiler applies two inconsistent notions of module identity: graph traversal treats the two virtual-store paths as distinct modules, while ID generation canonicalizes both to the same logical module (`name/subpath@version`, deliberately ignoring installation topology). Byte-identical copies of the same module then collide.

## Fix

The duplicate-ID check now fingerprints (SHA-256) the source of each file that contributes manifest entries. When two *different* files emit the same ID for the same symbol:

- **identical contents** → equivalent copies of the same module; deduplicate the registration (first one wins) and continue
- **differing contents** → genuine collision; the existing `WorkflowBuildError` is preserved unchanged

Content hashing is used rather than `fs.realpath()` or inode identity because neither works for pnpm's virtual store: the variant directories are real directories (realpath only resolves symlinks), and on macOS pnpm's default `package-import-method=clone` allocates fresh inodes for APFS clones. Verified empirically against peer variants in this repo's own `node_modules`:

```
realpath equal: false
inode equal:    false
content equal:  true
```

Bundling, module resolution, and runtime registration are untouched — both copies stay in the bundle and manifest, each resolving its own peers; they simply register the same ID with identical code (runtime registration was already last-write-wins).

The previously duplicated merge/assert logic in `swc-esbuild-plugin.ts` and `base-builder.ts` is consolidated into a shared `manifest-ids.ts`, so both the esbuild bundling path and the source-registration path get the fix.

## Tests

- `manifest-ids.test.ts`: unit tests for the dedup/collision matrix (same hash, differing hash, missing hash, differing symbol names, same-file re-merge)
- `swc-esbuild-plugin.test.ts`: integration tests through esbuild with simulated `.pnpm` virtual-store paths — identical copies build successfully; differing copies still fail
- `step-source-registration.test.ts`: regression fixture using the **real SWC transform** with two pnpm virtual instances (`.pnpm/step-pkg@1.0.0_peer-a@1.0.0/...` and `..._peer-b@2.0.0/...`) — identical copies dedupe, differing implementations still reject

`workflow-bundle-boundary.test.ts` has one failure, but it also fails on unmodified `main` (pre-existing, unrelated).