### PR TITLE
fix(vite): rebuild changed workflow dependencies

### DIFF
--- a/.changeset/vite-hmr-dependencies.md
+++ b/.changeset/vite-hmr-dependencies.md
@@ -1,0 +1,6 @@
+---
+'@workflow/vite': patch
+'@workflow/builders': patch
+---
+
+Rebuild workflow outputs when a dependency changes through Vite HMR.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import {
   mkdir,
@@ -28,16 +27,16 @@ import {
   createWorkflowEntrypointOptionsCode,
   createWorkflowRouteHandlersCode,
 } from './constants.js';
+import {
+  importGraphHasChild,
+  importParents as legacyImportParents,
+} from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
   type CompleteDiscoveredEntries,
   type DiscoveredEntries,
   fastDiscoverEntries,
 } from './fast-discovery.js';
-import {
-  importGraphHasChild,
-  importParents as legacyImportParents,
-} from './discover-entries-esbuild-plugin.js';
 import {
   getImportPath,
   resolveModuleSpecifier,
@@ -50,6 +49,15 @@ import { detectWorkflowPatterns } from './transform-utils.js';
 import type { SourcemapMode, WorkflowConfig } from './types.js';
 import { extractWorkflowGraphs } from './workflows-extractor.js';
 import { hasSameContent, writeFileIfChanged } from './write-if-changed.js';
+
+export type WorkflowFileInfo =
+  | { kind: 'untracked' }
+  | { kind: 'asset' }
+  | {
+      kind: 'source';
+      affectsBuild: boolean;
+      importSignature: string;
+    };
 
 const enhancedResolve = promisify(enhancedResolveOriginal);
 const require = createRequire(import.meta.url);
@@ -446,11 +454,12 @@ export abstract class BaseBuilder {
 
   public clearDiscoveredEntriesCache(): void {
     this.discoveredEntries = new WeakMap();
+    this.latestDiscoveredEntries = undefined;
   }
 
-  public fileAffectsWorkflowBuild(file: string): boolean {
+  public getWorkflowFileInfo(file: string): WorkflowFileInfo {
     const discovered = this.latestDiscoveredEntries;
-    assert(discovered, 'Invariant: expected completed workflow discovery');
+    if (!discovered) return { kind: 'untracked' };
 
     const normalizedFile = resolve(this.config.workingDir, file).replace(
       /\\/g,
@@ -461,12 +470,17 @@ export abstract class BaseBuilder {
       ...discovered.discoveredWorkflows,
       ...discovered.discoveredSerdeFiles,
     ];
-    return roots.some(
+    const affectsBuild = roots.some(
       (root) =>
         root === normalizedFile ||
         importGraphHasChild(discovered.importParents, root, normalizedFile) ||
         importGraphHasChild(discovered.importParents, normalizedFile, root)
     );
+    const importSignature = discovered.importSignatures.get(normalizedFile);
+    if (importSignature !== undefined) {
+      return { kind: 'source', affectsBuild, importSignature };
+    }
+    return affectsBuild ? { kind: 'asset' } : { kind: 'untracked' };
   }
 
   public clearManifestTransformCache(): void {
@@ -598,6 +612,7 @@ export abstract class BaseBuilder {
       discoveredSerdeFiles: new Set(),
       discoveredFiles: new Set(),
       importParents: new Map(),
+      importSignatures: new Map(),
     };
 
     const discoverStart = Date.now();
@@ -1753,6 +1768,7 @@ ${createWorkflowRouteHandlersCode(`workflowEntrypoint(workflowCode${workflowEntr
             ...discoveredEntries,
             importParents:
               discoveredEntries.importParents ?? legacyImportParents,
+            importSignatures: discoveredEntries.importSignatures ?? new Map(),
             discoveredFiles: discoveredEntries.discoveredFiles ?? new Set(),
           };
 

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import {
   mkdir,
@@ -27,13 +28,16 @@ import {
   createWorkflowEntrypointOptionsCode,
   createWorkflowRouteHandlersCode,
 } from './constants.js';
-import { importParents as legacyImportParents } from './discover-entries-esbuild-plugin.js';
 import { getEsbuildTsconfigOptions } from './esbuild-tsconfig.js';
 import {
   type CompleteDiscoveredEntries,
   type DiscoveredEntries,
   fastDiscoverEntries,
 } from './fast-discovery.js';
+import {
+  importGraphHasChild,
+  importParents as legacyImportParents,
+} from './discover-entries-esbuild-plugin.js';
 import {
   getImportPath,
   resolveModuleSpecifier,
@@ -438,9 +442,31 @@ export abstract class BaseBuilder {
    */
   private discoveredEntries: WeakMap<string[], CompleteDiscoveredEntries> =
     new WeakMap();
+  private latestDiscoveredEntries: CompleteDiscoveredEntries | undefined;
 
   public clearDiscoveredEntriesCache(): void {
     this.discoveredEntries = new WeakMap();
+  }
+
+  public fileAffectsWorkflowBuild(file: string): boolean {
+    const discovered = this.latestDiscoveredEntries;
+    assert(discovered, 'Invariant: expected completed workflow discovery');
+
+    const normalizedFile = resolve(this.config.workingDir, file).replace(
+      /\\/g,
+      '/'
+    );
+    const roots = [
+      ...discovered.discoveredSteps,
+      ...discovered.discoveredWorkflows,
+      ...discovered.discoveredSerdeFiles,
+    ];
+    return roots.some(
+      (root) =>
+        root === normalizedFile ||
+        importGraphHasChild(discovered.importParents, root, normalizedFile) ||
+        importGraphHasChild(discovered.importParents, normalizedFile, root)
+    );
   }
 
   public clearManifestTransformCache(): void {
@@ -563,6 +589,7 @@ export abstract class BaseBuilder {
     const previousResult = this.discoveredEntries.get(inputs);
 
     if (previousResult) {
+      this.latestDiscoveredEntries = previousResult;
       return previousResult;
     }
     const state: CompleteDiscoveredEntries = {
@@ -611,6 +638,7 @@ export abstract class BaseBuilder {
     await this.warnAboutExternalWorkflowPackages();
 
     this.discoveredEntries.set(inputs, state);
+    this.latestDiscoveredEntries = state;
     return state;
   }
 

--- a/packages/builders/src/fast-discovery.test.ts
+++ b/packages/builders/src/fast-discovery.test.ts
@@ -91,7 +91,8 @@ describe('fast workflow discovery', () => {
 `
     );
 
-    const discovered = await createBuilder(testRoot).discoverEntriesPublic(
+    const builder = createBuilder(testRoot);
+    const discovered = await builder.discoverEntriesPublic(
       [entryFile],
       join(testRoot, 'out')
     );
@@ -107,6 +108,11 @@ describe('fast workflow discovery', () => {
     expect(parentHasChild(normalize(entryFile), normalize(stepFile))).toBe(
       true
     );
+    expect(builder.fileAffectsWorkflowBuild(stepFile)).toBe(true);
+    expect(builder.fileAffectsWorkflowBuild(entryFile)).toBe(true);
+    expect(
+      builder.fileAffectsWorkflowBuild(join(testRoot, 'unrelated.ts'))
+    ).toBe(false);
   });
 
   it('replaces the import graph on rediscovery', async () => {

--- a/packages/builders/src/fast-discovery.test.ts
+++ b/packages/builders/src/fast-discovery.test.ts
@@ -92,6 +92,9 @@ describe('fast workflow discovery', () => {
     );
 
     const builder = createBuilder(testRoot);
+    expect(builder.getWorkflowFileInfo(stepFile)).toEqual({
+      kind: 'untracked',
+    });
     const discovered = await builder.discoverEntriesPublic(
       [entryFile],
       join(testRoot, 'out')
@@ -108,11 +111,17 @@ describe('fast workflow discovery', () => {
     expect(parentHasChild(normalize(entryFile), normalize(stepFile))).toBe(
       true
     );
-    expect(builder.fileAffectsWorkflowBuild(stepFile)).toBe(true);
-    expect(builder.fileAffectsWorkflowBuild(entryFile)).toBe(true);
-    expect(
-      builder.fileAffectsWorkflowBuild(join(testRoot, 'unrelated.ts'))
-    ).toBe(false);
+    expect(builder.getWorkflowFileInfo(stepFile)).toMatchObject({
+      kind: 'source',
+      affectsBuild: true,
+    });
+    expect(builder.getWorkflowFileInfo(entryFile)).toMatchObject({
+      kind: 'source',
+      affectsBuild: true,
+    });
+    expect(builder.getWorkflowFileInfo(join(testRoot, 'unrelated.ts'))).toEqual(
+      { kind: 'untracked' }
+    );
   });
 
   it('replaces the import graph on rediscovery', async () => {
@@ -140,6 +149,9 @@ describe('fast workflow discovery', () => {
 
     writeFile(entryFile, `export const value = 1;\n`);
     builder.clearDiscoveredEntriesCache();
+    expect(builder.getWorkflowFileInfo(workflowFile)).toEqual({
+      kind: 'untracked',
+    });
     const second = await builder.discoverEntriesPublic(
       inputFiles,
       join(testRoot, 'out')

--- a/packages/builders/src/fast-discovery.ts
+++ b/packages/builders/src/fast-discovery.ts
@@ -53,12 +53,14 @@ export interface DiscoveredEntries {
   discoveredWorkflows: Set<string>;
   discoveredSerdeFiles: Set<string>;
   importParents?: ImportParents;
+  importSignatures?: Map<string, string>;
   /** Source files visited by discovery or consumed by the workflow bundle. */
   discoveredFiles?: Set<string>;
 }
 
 export interface CompleteDiscoveredEntries extends DiscoveredEntries {
   importParents: ImportParents;
+  importSignatures: Map<string, string>;
   discoveredFiles: Set<string>;
 }
 
@@ -381,7 +383,7 @@ function stripCommentsFromSource(source: string): string {
   return output;
 }
 
-function extractImportSpecifiers(source: string): string[] {
+export function extractImportSpecifiers(source: string): string[] {
   const sourceWithoutComments = stripCommentsFromSource(source);
   if (
     !sourceWithoutComments.includes('import') &&
@@ -402,7 +404,7 @@ function extractImportSpecifiers(source: string): string[] {
     }
   }
 
-  return Array.from(specifiers);
+  return Array.from(specifiers).sort();
 }
 
 function hasWorkflowDependency(dependencies: unknown): boolean {
@@ -1013,6 +1015,7 @@ export async function fastDiscoverEntries({
     }
 
     const specifiers = extractImportSpecifiers(source);
+    state.importSignatures.set(filePath, specifiers.join('\n'));
     if (specifiers.length === 0) {
       return;
     }

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -1,6 +1,6 @@
 export type { WorkflowManifest } from './apply-swc-transform.js';
 export { applySwcTransform } from './apply-swc-transform.js';
-export { BaseBuilder } from './base-builder.js';
+export { BaseBuilder, type WorkflowFileInfo } from './base-builder.js';
 export { createBuildQueue } from './build-queue.js';
 export {
   createBaseBuilderConfig,
@@ -24,6 +24,7 @@ export {
   importGraphHasChild,
   parentHasChild,
 } from './discover-entries-esbuild-plugin.js';
+export { extractImportSpecifiers } from './fast-discovery.js';
 export {
   clearModuleSpecifierCache,
   getImportPath,

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,6 +26,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "tsc --build --clean && rm -rf dist",
+    "test": "vitest run src",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -35,6 +36,7 @@
     "@types/node": "catalog:",
     "@workflow/tsconfig": "workspace:*",
     "typescript": "catalog:",
-    "vite": "7.3.6"
+    "vite": "7.3.6",
+    "vitest": "catalog:"
   }
 }

--- a/packages/vite/src/hot-update.test.ts
+++ b/packages/vite/src/hot-update.test.ts
@@ -1,0 +1,221 @@
+import type { WorkflowFileInfo } from '@workflow/builders';
+import type { EnvironmentModuleNode, Plugin } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+import { workflowHotUpdatePlugin } from './hot-update.js';
+
+function module(id: string, importers: EnvironmentModuleNode[] = []) {
+  return {
+    id,
+    importers: new Set(importers),
+    info: {
+      meta: {
+        'workflow:imports': '',
+        'workflow:module': false,
+      },
+    },
+  } as EnvironmentModuleNode;
+}
+
+function workflowModule(id: string) {
+  return {
+    id,
+    importers: new Set(),
+    info: { meta: { 'workflow:module': true } },
+  } as EnvironmentModuleNode;
+}
+
+type HotUpdateHook = (options: {
+  type: 'create' | 'update' | 'delete';
+  file: string;
+  modules: EnvironmentModuleNode[];
+  read(): string | Promise<string>;
+  timestamp: number;
+}) => Promise<void>;
+
+type TransformHook = (
+  code: string,
+  id: string
+) =>
+  | {
+      meta: {
+        'workflow:imports': string;
+        'workflow:module': boolean;
+      };
+    }
+  | undefined;
+
+function builder(build: () => Promise<void>, affects = false) {
+  return {
+    build,
+    getWorkflowFileInfo: (): WorkflowFileInfo =>
+      affects
+        ? { kind: 'source', affectsBuild: true, importSignature: '' }
+        : { kind: 'untracked' },
+  };
+}
+
+function hooks(plugin: Plugin): {
+  hotUpdate: HotUpdateHook;
+  transform: TransformHook;
+} {
+  return {
+    hotUpdate: plugin.hotUpdate as HotUpdateHook,
+    transform: plugin.transform as TransformHook,
+  };
+}
+
+describe('workflowHotUpdatePlugin', () => {
+  it('rebuilds when a workflow dependency changes', async () => {
+    const build = vi.fn();
+    const { hotUpdate, transform } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build) })
+    );
+    const workflowFile = '/app/workflow.ts';
+    const helperFile = '/app/helper.ts';
+    const root = workflowModule(workflowFile);
+
+    expect(
+      transform("export function run() {\n  'use workflow';\n}", workflowFile)
+    ).toEqual({
+      meta: {
+        'workflow:imports': '',
+        'workflow:module': true,
+      },
+    });
+    await hotUpdate({
+      type: 'update',
+      file: helperFile,
+      modules: [module(helperFile, [root])],
+      read: () => 'export const value = 2;',
+      timestamp: 1,
+    });
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it('uses the Vite graph for non-source dependencies', async () => {
+    const build = vi.fn();
+    const { hotUpdate, transform } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build) })
+    );
+    const workflowFile = '/app/workflow.ts';
+    const inputFile = '/app/input.json';
+    const root = workflowModule(workflowFile);
+
+    transform("export function run() {\n  'use workflow';\n}", workflowFile);
+    await hotUpdate({
+      type: 'update',
+      file: inputFile,
+      modules: [module(inputFile, [root])],
+      read: () => '{"value":2}',
+      timestamp: 1,
+    });
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it('ignores unrelated updates', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build) })
+    );
+
+    await hotUpdate({
+      type: 'update',
+      file: '/app/unrelated.ts',
+      modules: [module('/app/unrelated.ts')],
+      read: () => 'export const value = 2;',
+      timestamp: 1,
+    });
+    await hotUpdate({
+      type: 'update',
+      file: '/app/unvisited.ts',
+      modules: [],
+      read: () => 'export const value = 2;',
+      timestamp: 2,
+    });
+
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds when an updated source disappears before it is read', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build) })
+    );
+
+    await hotUpdate({
+      type: 'update',
+      file: '/app/workflow.ts',
+      modules: [],
+      read: () => Promise.reject(new Error('File not found')),
+      timestamp: 1,
+    });
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it('rebuilds once across Vite environments', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build, true) })
+    );
+    const update = {
+      type: 'update' as const,
+      file: '/app/helper.ts',
+      modules: [],
+      read: () => 'export const value = 2;',
+      timestamp: 1,
+    };
+
+    await hotUpdate(update);
+    await hotUpdate(update);
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it('uses builder discovery for dependencies absent from Vite', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build, true) })
+    );
+
+    await hotUpdate({
+      type: 'update',
+      file: '/app/unvisited-helper.ts',
+      modules: [],
+      read: () => 'export const value = 2;',
+      timestamp: 1,
+    });
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it('rebuilds when imports change', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build) })
+    );
+
+    await hotUpdate({
+      type: 'update',
+      file: '/app/page.ts',
+      modules: [
+        {
+          id: '/app/page.ts',
+          importers: new Set(),
+          info: {
+            meta: {
+              'workflow:imports': './old',
+              'workflow:module': false,
+            },
+          },
+        } as EnvironmentModuleNode,
+      ],
+      read: () => "import './workflow';",
+      timestamp: 1,
+    });
+
+    expect(build).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/vite/src/hot-update.test.ts
+++ b/packages/vite/src/hot-update.test.ts
@@ -174,6 +174,27 @@ describe('workflowHotUpdatePlugin', () => {
     expect(build).toHaveBeenCalledOnce();
   });
 
+  it('ignores an older environment update after a newer event', async () => {
+    const build = vi.fn();
+    const { hotUpdate } = hooks(
+      workflowHotUpdatePlugin({ builder: builder(build, true) })
+    );
+    const update = (timestamp: number) =>
+      hotUpdate({
+        type: 'update',
+        file: '/app/helper.ts',
+        modules: [],
+        read: () => 'export const value = 2;',
+        timestamp,
+      });
+
+    await update(1);
+    await update(2);
+    await update(1);
+
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+
   it('uses builder discovery for dependencies absent from Vite', async () => {
     const build = vi.fn();
     const { hotUpdate } = hooks(

--- a/packages/vite/src/hot-update.ts
+++ b/packages/vite/src/hot-update.ts
@@ -130,7 +130,8 @@ export function workflowHotUpdatePlugin(
       }
 
       if (!rebuild) return;
-      if (handledTimestamp === timestamp) return;
+      if (handledTimestamp !== undefined && timestamp <= handledTimestamp)
+        return;
       handledTimestamp = timestamp;
 
       console.log('Workflow file changed, rebuilding...');

--- a/packages/vite/src/hot-update.ts
+++ b/packages/vite/src/hot-update.ts
@@ -1,16 +1,42 @@
 import {
-  type BaseBuilder,
   detectWorkflowPatterns,
+  extractImportSpecifiers,
   isGeneratedWorkflowFile,
+  type WorkflowFileInfo,
 } from '@workflow/builders';
-import type { HotUpdateOptions, Plugin } from 'vite';
+import type { EnvironmentModuleNode, HotUpdateOptions, Plugin } from 'vite';
+
+const jsTsRegex = /\.[cm]?[jt]sx?(?:$|\?)/;
+const workflowImportsMeta = 'workflow:imports';
+const workflowModuleMeta = 'workflow:module';
+
+interface WorkflowBuilder {
+  build(): Promise<void>;
+  getWorkflowFileInfo(file: string): WorkflowFileInfo;
+}
+
+function importsWorkflow(modules: EnvironmentModuleNode[]): boolean {
+  const pending = [...modules];
+  const visited = new Set<EnvironmentModuleNode>();
+
+  while (pending.length > 0) {
+    const module = pending.pop()!;
+    if (visited.has(module)) continue;
+    visited.add(module);
+
+    if (module.info?.meta[workflowModuleMeta] === true) return true;
+    pending.push(...module.importers);
+  }
+
+  return false;
+}
 
 interface WorkflowHotUpdatePluginOptions {
   /**
    * Builder instance or a getter function.
    * Use a getter when the builder is created lazily (e.g., Nitro where it depends on the nitro object).
    */
-  builder: BaseBuilder | (() => BaseBuilder | undefined) | undefined;
+  builder: WorkflowBuilder | (() => WorkflowBuilder | undefined) | undefined;
   /**
    * Optional build queue function to prevent concurrent builds.
    * If not provided, builds will run directly.
@@ -21,9 +47,8 @@ interface WorkflowHotUpdatePluginOptions {
 /**
  * Vite plugin that watches for workflow/step file changes and triggers rebuilds.
  *
- * This plugin detects changes to files containing `"use workflow"` or `"use step"`
- * directives, or custom serialization patterns (`@workflow/serde` imports or
- * `Symbol.for('workflow-serialize')`), and calls the builder to regenerate routes.
+ * Directives and serialization files are marked during Vite transforms. Hot
+ * updates follow Vite's importer graph back to those files before rebuilding.
  */
 export function workflowHotUpdatePlugin(
   options: WorkflowHotUpdatePluginOptions
@@ -32,54 +57,84 @@ export function workflowHotUpdatePlugin(
 
   // Default enqueue runs the function directly
   const runBuild = enqueue ?? ((fn: () => Promise<void>) => fn());
+  let handledTimestamp: number | undefined;
 
   return {
     name: 'workflow:hot-update',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!jsTsRegex.test(id) || isGeneratedWorkflowFile(id)) return;
+
+      const patterns = detectWorkflowPatterns(code);
+      return {
+        meta: {
+          [workflowImportsMeta]: extractImportSpecifiers(code).join('\n'),
+          [workflowModuleMeta]: patterns.hasDirective || patterns.hasSerde,
+        },
+      };
+    },
     async hotUpdate(ctx: HotUpdateOptions) {
-      // Resolve builder (supports both direct instance and getter function)
-      const resolvedBuilder =
-        typeof builder === 'function' ? builder() : builder;
-
-      if (!resolvedBuilder) {
-        // Builder not available (e.g., production mode)
-        return;
-      }
-
-      const { file, read } = ctx;
-
-      // Check if this is a TS/JS file that might contain workflow directives
-      const jsTsRegex = /\.(ts|tsx|js|jsx|mjs|cjs)$/;
-      if (!jsTsRegex.test(file)) {
-        return;
-      }
-
-      // Skip generated workflow route files to avoid infinite rebuild loops
+      const { file, modules, read, timestamp, type: updateType } = ctx;
       if (isGeneratedWorkflowFile(file)) {
         return;
       }
 
-      // Read the file to check for workflow/step directives
-      let content: string;
-      try {
-        content = await read();
-      } catch {
-        // File might have been deleted - trigger rebuild to update generated routes
-        console.log('Workflow file changed, rebuilding...');
-        await runBuild(() => resolvedBuilder.build());
-        return;
+      const resolvedBuilder =
+        typeof builder === 'function' ? builder() : builder;
+      if (!resolvedBuilder) return;
+
+      const fileInfo = resolvedBuilder.getWorkflowFileInfo(file);
+      let rebuild = importsWorkflow(modules);
+      switch (fileInfo.kind) {
+        case 'untracked':
+          break;
+        case 'asset':
+          rebuild = true;
+          break;
+        case 'source':
+          rebuild ||= fileInfo.affectsBuild;
+          break;
+        default:
+          fileInfo satisfies never;
+          throw new Error('Unknown workflow file info');
       }
 
-      // Detect workflow patterns using shared utilities
-      const patterns = detectWorkflowPatterns(content);
-
-      if (!patterns.hasDirective && !patterns.hasSerde) {
-        return;
+      switch (updateType) {
+        case 'create':
+        case 'update': {
+          if (jsTsRegex.test(file)) {
+            try {
+              const source = await read();
+              const patterns = detectWorkflowPatterns(source);
+              const imports = extractImportSpecifiers(source).join('\n');
+              rebuild ||=
+                patterns.hasDirective ||
+                patterns.hasSerde ||
+                (updateType === 'create' && imports !== '') ||
+                (fileInfo.kind === 'source' &&
+                  fileInfo.importSignature !== imports) ||
+                modules.some(
+                  (module) => module.info?.meta[workflowImportsMeta] !== imports
+                );
+            } catch {
+              rebuild = true;
+            }
+          }
+          break;
+        }
+        case 'delete':
+          break;
+        default:
+          updateType satisfies never;
+          throw new Error('Unknown Vite hot update type');
       }
+
+      if (!rebuild) return;
+      if (handledTimestamp === timestamp) return;
+      handledTimestamp = timestamp;
 
       console.log('Workflow file changed, rebuilding...');
       await runBuild(() => resolvedBuilder.build());
-      // Let Vite handle the normal HMR for the changed file
-      return;
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,9 @@ importers:
       vite:
         specifier: 7.3.6
         version: 7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.6(@types/node@22.19.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
 
   packages/vitest:
     dependencies:
@@ -20839,7 +20842,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
-      semver: 7.8.2
+      semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -32505,7 +32508,7 @@ snapshots:
 
   node-abi@3.89.0:
     dependencies:
-      semver: 7.8.2
+      semver: 7.8.5
     optional: true
 
   node-abort-controller@3.1.1: {}
@@ -34778,8 +34781,7 @@ snapshots:
 
   semver@7.8.2: {}
 
-  semver@7.8.5:
-    optional: true
+  semver@7.8.5: {}
 
   send@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

- use Vite module metadata and importer edges for loaded workflow modules
- fall back to the builder's scoped discovery graph for lazy, unvisited routes
- rebuild on import-structure changes and deduplicate Vite's per-environment hot-update hooks

## Validation

- `pnpm --filter @workflow/builders build`
- `pnpm --filter @workflow/builders test`
- `pnpm --filter @workflow/vite build`
- `pnpm --filter @workflow/vite test`
- `autoreview` findings resolved; final packaging finding rejected because Vitest is already in `devDependencies`

Depends on #3333 for per-discovery import graphs.