### PR TITLE
fix(world-local): abort deliveries on shutdown

### DIFF
--- a/.changeset/tidy-local-shutdown.md
+++ b/.changeset/tidy-local-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Abort active local queue deliveries when the World closes, including when transport timeouts are disabled.

--- a/packages/world-local/src/queue.test.ts
+++ b/packages/world-local/src/queue.test.ts
@@ -557,6 +557,40 @@ describe('queue transport timeouts', () => {
     });
   });
 
+  it('aborts an in-flight delivery when the queue closes', async () => {
+    let requestReceived = false;
+    server = createServer(() => {
+      requestReceived = true;
+    });
+    await new Promise<void>((resolve) => {
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS = '0';
+    process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS = '0';
+    const localQueue = createQueue({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+
+    await localQueue.queue('__wkf_workflow_test' as any, workflowPayload);
+    await vi.waitFor(() => expect(requestReceived).toBe(true));
+    const closePromise = localQueue.close();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      closePromise.then(() => 'closed' as const),
+      new Promise<'timed-out'>((resolve) => {
+        timeout = setTimeout(() => resolve('timed-out'), 1_000);
+      }),
+    ]);
+    clearTimeout(timeout);
+    if (outcome === 'timed-out') {
+      server.closeAllConnections();
+      await closePromise;
+    }
+    expect(outcome).toBe('closed');
+  });
+
   it('redelivers when a handler accepts a request but never responds', async () => {
     let requests = 0;
     server = createServer((_request, response) => {

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -259,6 +259,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
                     headers: new Headers(headers),
                     body,
                     agents: nodeHttpAgents,
+                    signal: closeSignal,
                     headersTimeoutMs: agentOptions.headersTimeout,
                     bodyTimeoutMs: agentOptions.bodyTimeout,
                   })
@@ -269,6 +270,7 @@ export function createQueue(config: Partial<Config>): LocalQueue {
                     dispatcher: httpAgent,
                     headers,
                     body,
+                    signal: closeSignal,
                   } as any);
             }
             delivery++;


### PR DESCRIPTION
### Description

`world-local` creates a shutdown `AbortController`, but the controller was only connected to delivery delays and retry backoffs. An HTTP delivery with disabled transport timeouts therefore remained active when the World closed, and undici's graceful `Agent.close()` waited indefinitely for that request to finish.

Pass the existing close signal to both HTTP transports. Closing the World now aborts its active delivery requests before releasing the transport pool, while preserving graceful agent cleanup and the durable message for recovery after restart.

This was exposed by [vercel/eve#2609](https://github.com/vercel/eve/pull/2609), which disables local delivery timeouts to prevent healthy long-running agent turns from being redelivered.

### How did you test your changes?

Added a `world-local` queue regression test with both transport timeouts disabled and a server that accepts but never completes the delivery. The test reports `timed-out` on `main` and closes immediately with this change.

- `pnpm exec turbo build --filter=@workflow/world-local...`
- `pnpm --filter @workflow/world-local exec vitest run src/queue.test.ts` — 26 passed
- `pnpm --filter @workflow/world-local typecheck`
- `pnpm exec biome check packages/world-local/src/queue.ts packages/world-local/src/queue.test.ts` — passed with the two existing complexity warnings

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
