### PR TITLE
Make the python docs codeownership more targeted

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for the entire repository
 * @vercel/workflow
 
-./docs/**/python.mdx @vercel/workflow @msullivan @fantix
+/docs/**/python.mdx @vercel/workflow @msullivan @fantix

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for the entire repository
 * @vercel/workflow
 
-/docs @vercel/workflow @msullivan @fantix
+./docs/**/python.mdx @vercel/workflow @msullivan @fantix


### PR DESCRIPTION
I had originally left it broad so that things would be smooth when we
start reorganizing the python docs, but we'll adjust that when it
happens.
