### PR TITLE
[world-vercel] Fix deploymentId "latest" resolving against the wrong team

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Authenticate `deploymentId: "latest"` with the deployment's own OIDC identity instead of an ambient `VERCEL_TOKEN`, and scope the request to the configured team, fixing spurious 404s when resolving the latest deployment

--- a/docs/content/docs/v4/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v4/api-reference/workflow-api/start.mdx
@@ -104,6 +104,18 @@ The `deploymentId` option is currently a Vercel-specific feature. Other Worlds m
 In Worlds without atomic, immutable deployments (such as local development or self-hosted Postgres), there is no notion of multiple deployments to resolve between, so `deploymentId: "latest"` has no effect: the SDK logs a warning and the run targets the current deployment. This means a workflow that opts into `"latest"` on Vercel still runs unchanged in local development.
 </Callout>
 
+<Callout type="info">
+Resolving `"latest"` is the one `start()` path that calls the Vercel API, so it
+needs an identity that can see the calling deployment. Inside a Vercel
+deployment the SDK authenticates with the deployment's own OIDC token, which
+carries the owning team, and this takes precedence over a `VERCEL_TOKEN` set in
+the function's environment. A `VERCEL_TOKEN` belongs to a *user* and carries no
+team, so authenticating with it scopes the lookup to that user's default team
+and fails with a 404 whenever that is not the team that owns the deployment.
+Outside a deployment (CLI, CI, the dashboard) `VERCEL_TOKEN` is still used;
+configure the World's `teamId` so the request is scoped explicitly.
+</Callout>
+
 <Callout type="warn">
 When using `deploymentId: "latest"`, the workflow run will execute on a potentially different deployment than the one calling `start()`. Be mindful of forward and backward compatibility:
 

--- a/docs/content/docs/v5/api-reference/workflow-api/start.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-api/start.mdx
@@ -108,6 +108,18 @@ The `deploymentId` option is currently a Vercel-specific feature. Other Worlds m
 In Worlds without atomic, immutable deployments (such as local development or self-hosted Postgres), there is no notion of multiple deployments to resolve between, so `deploymentId: "latest"` has no effect: the SDK logs a warning and the run targets the current deployment. This means a workflow that opts into `"latest"` on Vercel still runs unchanged in local development.
 </Callout>
 
+<Callout type="info">
+Resolving `"latest"` is the one `start()` path that calls the Vercel API, so it
+needs an identity that can see the calling deployment. Inside a Vercel
+deployment the SDK authenticates with the deployment's own OIDC token, which
+carries the owning team, and this takes precedence over a `VERCEL_TOKEN` set in
+the function's environment. A `VERCEL_TOKEN` belongs to a *user* and carries no
+team, so authenticating with it scopes the lookup to that user's default team
+and fails with a 404 whenever that is not the team that owns the deployment.
+Outside a deployment (CLI, CI, the dashboard) `VERCEL_TOKEN` is still used;
+configure the World's `teamId` so the request is scoped explicitly.
+</Callout>
+
 <Callout type="warn">
 When using `deploymentId: "latest"`, the workflow run will execute on a potentially different deployment than the one calling `start()`. Be mindful of forward and backward compatibility:
 

--- a/packages/world-vercel/src/resolve-latest-deployment.test.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.test.ts
@@ -154,6 +154,129 @@ describe('createResolveLatestDeploymentId', () => {
     expect(headers.get('Authorization')).toBe('Bearer oidc-token-456');
   });
 
+  it('prefers the OIDC token over VERCEL_TOKEN inside the Vercel runtime', async () => {
+    // The shape that broke production: a deployed function whose environment
+    // also carries a VERCEL_TOKEN for unrelated tooling. The token is a user
+    // credential and carries no team, so authenticating with it scopes the
+    // lookup to that user's default team and 404s.
+    process.env.VERCEL = '1';
+    process.env.VERCEL_TOKEN = 'user-token-wrong-team';
+
+    const { getVercelOidcToken } = await import('@vercel/oidc');
+    vi.mocked(getVercelOidcToken).mockResolvedValueOnce('oidc-token-789');
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_latest_from_oidc' }), {
+        status: 200,
+      })
+    );
+
+    const result = await createResolveLatestDeploymentId({})();
+
+    expect(result).toBe('dpl_latest_from_oidc');
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer oidc-token-789');
+  });
+
+  it('keeps using VERCEL_TOKEN outside the Vercel runtime', async () => {
+    // CLI and CI callers export VERCEL_TOKEN deliberately and have no
+    // deployment identity to prefer, so the original order stands there.
+    delete process.env.VERCEL;
+    process.env.VERCEL_TOKEN = 'env-token-123';
+
+    const { getVercelOidcToken } = await import('@vercel/oidc');
+    vi.mocked(getVercelOidcToken).mockResolvedValueOnce('oidc-token-789');
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_from_env' }), { status: 200 })
+    );
+
+    await createResolveLatestDeploymentId({})();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer env-token-123');
+  });
+
+  it('still prefers an explicit config token inside the Vercel runtime', async () => {
+    process.env.VERCEL = '1';
+    process.env.VERCEL_TOKEN = 'env-token-123';
+
+    // Queueing an OIDC value here would leak into the next test, since an
+    // explicit config token short-circuits before OIDC is ever consulted.
+    // Assert that directly instead.
+    const { getVercelOidcToken } = await import('@vercel/oidc');
+    vi.mocked(getVercelOidcToken).mockClear();
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_from_config' }), { status: 200 })
+    );
+
+    await createResolveLatestDeploymentId({ token: 'config-token' })();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer config-token');
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+  });
+
+  it('falls back to VERCEL_TOKEN inside the runtime when OIDC is unavailable', async () => {
+    process.env.VERCEL = '1';
+    process.env.VERCEL_TOKEN = 'env-token-123';
+
+    const { getVercelOidcToken } = await import('@vercel/oidc');
+    // mockReset clears any queue a prior test left behind; the rejection is
+    // scoped to this call so it does not leak into later tests.
+    vi.mocked(getVercelOidcToken).mockReset();
+    vi.mocked(getVercelOidcToken).mockRejectedValueOnce(new Error('no OIDC'));
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_from_env' }), { status: 200 })
+    );
+
+    await createResolveLatestDeploymentId({})();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer env-token-123');
+  });
+
+  it('scopes the request to the configured team', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_latest' }), { status: 200 })
+    );
+
+    await createResolveLatestDeploymentId({
+      token: 'test-token',
+      projectConfig: { projectId: 'prj_123', teamId: 'team_abc' },
+    })();
+
+    const url = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(url.pathname).toBe(
+      '/v1/workflow/resolve-latest-deployment/dpl_current_abc123'
+    );
+    expect(url.searchParams.get('teamId')).toBe('team_abc');
+  });
+
+  it('omits the team parameter when no team is configured', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'dpl_latest' }), { status: 200 })
+    );
+
+    await createResolveLatestDeploymentId({ token: 'test-token' })();
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v1/workflow/resolve-latest-deployment/dpl_current_abc123'
+    );
+  });
+
+  it('explains the identity cause on a 404', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Deployment not found.', { status: 404 })
+    );
+
+    await expect(
+      createResolveLatestDeploymentId({ token: 'test-token' })()
+    ).rejects.toThrow(/not visible to the identity/);
+  });
+
   it('should throw on non-ok HTTP response', async () => {
     mockFetch.mockResolvedValueOnce(new Response('Not found', { status: 404 }));
 

--- a/packages/world-vercel/src/resolve-latest-deployment.ts
+++ b/packages/world-vercel/src/resolve-latest-deployment.ts
@@ -6,6 +6,7 @@
  * deployments) as the provided current deployment.
  */
 
+import { getVercelOidcToken } from '@vercel/oidc';
 import * as z from 'zod';
 import { missingDeploymentIdMessage } from './deployment-id.js';
 import { getDispatcher } from './http-client.js';
@@ -15,6 +16,41 @@ import type { APIConfig } from './utils.js';
 const ResolveLatestDeploymentResponseSchema = z.object({
   id: z.string(),
 });
+
+/**
+ * Resolve the credential this call should authenticate with.
+ *
+ * This endpoint is scoped to a *team* on the API side: it reads the source
+ * deployment out of a team-partitioned store, so the identity we present
+ * decides which team's deployments are visible. That makes the credential
+ * choice a correctness concern here, not just an auth detail, and it is why
+ * this path does not simply use `resolveVercelApiToken`.
+ *
+ * Inside the Vercel runtime the OIDC token is preferred over `VERCEL_TOKEN`,
+ * reversing that helper's order. The OIDC token carries the deployment's own
+ * `owner_id`/`project_id` claims, so the API resolves exactly the team that
+ * owns the deployment we are asking about. A `VERCEL_TOKEN` in the function's
+ * environment is a *user's* credential: it carries no team, so the API falls
+ * back to that user's default team, and the lookup then misses on every team
+ * but that one and returns 404. An ambient token set for unrelated tooling
+ * must not displace the deployment's own identity.
+ *
+ * Outside the runtime (CLI, CI, the dashboard) the original order is kept.
+ * There is no deployment identity to prefer, `VERCEL_TOKEN` is usually set
+ * deliberately, and those callers pass an explicit `teamId` instead.
+ */
+async function resolveDeploymentIdentityToken(
+  config?: APIConfig
+): Promise<string | null> {
+  if (config?.token) return config.token;
+
+  if (process.env.VERCEL === '1') {
+    const oidcToken = await getVercelOidcToken().catch(() => null);
+    if (oidcToken) return oidcToken;
+  }
+
+  return resolveVercelApiToken(config);
+}
 
 /**
  * Create the `resolveLatestDeploymentId` implementation for a Vercel World.
@@ -38,14 +74,21 @@ export function createResolveLatestDeploymentId(
       );
     }
 
-    const token = await resolveVercelApiToken(config);
+    const token = await resolveDeploymentIdentityToken(config);
     if (!token) {
       throw new Error(
         'Cannot resolve latest deployment: no OIDC token or VERCEL_TOKEN available'
       );
     }
 
-    const url = `https://api.vercel.com/v1/workflow/resolve-latest-deployment/${encodeURIComponent(currentDeploymentId)}`;
+    // Scope the request to the owning team when the caller knows it, the same
+    // way the sibling run-key request does. Without either this parameter or
+    // an OIDC token's `owner_id` claim, the API scopes the lookup to the
+    // token owner's *default* team and 404s when that is not the team that
+    // owns the deployment.
+    const teamId = config?.projectConfig?.teamId;
+    const query = teamId ? `?${new URLSearchParams({ teamId })}` : '';
+    const url = `https://api.vercel.com/v1/workflow/resolve-latest-deployment/${encodeURIComponent(currentDeploymentId)}${query}`;
 
     // 429/5xx retries are handled by the shared RetryAgent from getDispatcher().
     // instrumentedFetch adds the OTEL client span + DEBUG logging the v3/v4
@@ -66,8 +109,19 @@ export function createResolveLatestDeploymentId(
         } catch {
           body = '<unable to read response body>';
         }
+        // A 404 here reads as "the deployment does not exist", but the far
+        // more common cause is that the request resolved to a team that does
+        // not own it, so the team-partitioned lookup missed. Name that, or
+        // the next reader debugs deployment state instead of identity.
+        const hint =
+          res.status === 404
+            ? '. The deployment exists but was not visible to the identity this' +
+              ' request authenticated as, which means the request resolved to a' +
+              " different team. Set the World's `projectConfig.teamId` to scope" +
+              ' it explicitly.'
+            : '';
         return new Error(
-          `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`
+          `Failed to resolve latest deployment for ${currentDeploymentId}: HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}${hint}`
         );
       },
     });


### PR DESCRIPTION
## Problem

Resolving `deploymentId: "latest"` is the only `start()` path that calls `api.vercel.com`, and that endpoint reads the source deployment out of a **team-partitioned** store. The identity the request presents therefore decides which team's deployments are visible, which makes the credential choice a correctness concern rather than an auth detail.

Two things combined to send the request to the wrong team:

1. `resolveVercelApiToken` prefers `process.env.VERCEL_TOKEN` over the OIDC token. A `VERCEL_TOKEN` set in a deployed function's environment for unrelated tooling silently displaced the deployment's own identity.
2. The request carried no team scoping at all: no `teamId` query parameter, and no `x-vercel-team-id` (that header is only read by the proxy endpoint, never by the API's team auth).

A `VERCEL_TOKEN` is a *user* credential and carries no team, so with no team specified the API scopes the lookup to the token owner's **default team**. When that is not the team owning the deployment, the partitioned lookup misses and returns `404 Deployment not found` for a deployment that is READY and plainly visible in the dashboard.

This is why only `"latest"` broke while every other workflow operation kept working: everything else talks to the workflow backend with the OIDC token, and pinning a deployment ID skips this call entirely.

## Evidence

Traces for the affected project, over 22 requests, were unanimous:

- `workflow.auth.token_type: "token"` (never `vercel-oidc`)
- `workflow.team_id` set to a team that owns none of the project's deployments
- `workflow.failure.reason: source_deployment_not_found`

The split by auth type over 7 days shows the resolver itself is healthy and the failures track the credential:

| token type | calls | `source_deployment_not_found` |
|---|---|---|
| `vercel-oidc` | 519,330 | **0** |
| `token` | 31,796 | 23 |
| `app-token` | 19 | 1 |

## Fix

- **Prefer the OIDC token inside the Vercel runtime.** Its `owner_id` claim names exactly the team that owns the deployment. An explicit `config.token` still wins, and outside the runtime (CLI, CI, dashboard) the original order is kept, where `VERCEL_TOKEN` is usually set deliberately and there is no deployment identity to prefer. If OIDC is unavailable in the runtime, it still falls back to `VERCEL_TOKEN`.
- **Send `?teamId=`** from `projectConfig.teamId`, the same way the sibling run-key request already does. This fixes the CLI/dashboard path for anyone whose default team differs from the project's.
- **Name identity as the cause in the 404 message.** It previously read as a missing deployment, which sends readers to inspect deployment state instead of the credential.

## Testing

Six tests added to `resolve-latest-deployment.test.ts` covering OIDC-over-`VERCEL_TOKEN` in the runtime, the unchanged order outside it, explicit config token precedence, the OIDC-unavailable fallback, the `teamId` parameter and its absence, and the 404 message.

The existing suite could not have caught this: its OIDC test explicitly deletes `VERCEL_TOKEN`, so the both-present case (which is what production looks like) was untested, and the neighbouring test called `VERCEL_TOKEN` a "fall back" when it was in fact the winner.

Separately verified against a stub of the API handler's team-resolution logic that the reported scenario now resolves both in-deployment and from the CLI with `teamId` configured, and still reports a clear error when neither identity nor team is available. That simulation was validation-only and is not included here.

## Notes for reviewers

- The docs note is added to both v4 and v5 `start.mdx`, since both describe `deploymentId: "latest"`.
- Worth considering as a follow-up on the API side: for a deployment-scoped lookup, falling back to the caller's `defaultTeamId` yields a confusing 404 rather than a clear "no team specified". Out of scope here.

## Docs Preview

| Page | v5 | v4 |
|---|---|---|
| `start()` — `deploymentId: "latest"` | [/docs/api-reference/workflow-api/start](https://workflow-docs-git-peter-resolve-latest-deployment-team-scope.vercel.sh/docs/api-reference/workflow-api/start#using-deploymentid-latest) | [/v4/docs/api-reference/workflow-api/start](https://workflow-docs-git-peter-resolve-latest-deployment-team-scope.vercel.sh/v4/docs/api-reference/workflow-api/start#using-deploymentid-latest) |

These require Vercel team access (deployment protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
