### PR TITLE
Classify Workflow stream failures

### DIFF
--- a/.changeset/stream-error-classification.md
+++ b/.changeset/stream-error-classification.md
@@ -1,0 +1,10 @@
+---
+'@workflow/errors': minor
+'@workflow/core': patch
+'@workflow/cli': patch
+'@workflow/web-shared': patch
+'@workflow/world-vercel': patch
+'workflow': minor
+---
+
+Add a catchable `StreamError` and classify Workflow stream infrastructure failures as `STREAM_ERROR` instead of `USER_ERROR`.

--- a/packages/cli/src/lib/inspect/hydration.ts
+++ b/packages/cli/src/lib/inspect/hydration.ts
@@ -157,6 +157,7 @@ const ERROR_REVIVER_KEYS = [
   'ReferenceError',
   'RetryableError',
   'RuntimeDecryptionError',
+  'StreamError',
   'SyntaxError',
   'TypeError',
   'URIError',

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -5,6 +5,7 @@ import {
   ReplayDivergenceError,
   RUN_ERROR_CODES,
   RuntimeDecryptionError,
+  StreamError,
   ThrottleError,
   TooEarlyError,
   WorkflowDeploymentMismatchError,
@@ -153,6 +154,12 @@ describe('classifyRunError', () => {
     ).toBe(RUN_ERROR_CODES.WORLD_CONTRACT_ERROR);
   });
 
+  it('classifies StreamError as STREAM_ERROR', () => {
+    expect(classifyRunError(new StreamError('stream write failed'))).toBe(
+      RUN_ERROR_CODES.STREAM_ERROR
+    );
+  });
+
   it('classifies a TRANSPORT error as WORLD_CONTRACT_ERROR (backend fault, not USER_ERROR)', () => {
     // Transport blips are normally redelivered via the queue (see
     // isRetryableWorldError); if one ever reaches terminal classification it is
@@ -192,6 +199,22 @@ describe('isRetryableWorldError', () => {
         new WorkflowWorldError('Service Unavailable', { status: 503 })
       )
     ).toBe(true);
+  });
+
+  it('retries transport and server-side StreamErrors, but not terminal 4xx responses', () => {
+    expect(isRetryableWorldError(new StreamError('stream read failed'))).toBe(
+      true
+    );
+    expect(
+      isRetryableWorldError(
+        new StreamError('stream service failed', { status: 503 })
+      )
+    ).toBe(true);
+    expect(
+      isRetryableWorldError(
+        new StreamError('stream request was invalid', { status: 400 })
+      )
+    ).toBe(false);
   });
 
   it('treats TRANSPORT and TIMEOUT codes as retryable', () => {

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -6,6 +6,7 @@ import {
   type RunErrorCode,
   RuntimeDecryptionError,
   StepNotRegisteredError,
+  StreamError,
   ThrottleError,
   WorkflowDeploymentMismatchError,
   WorkflowNotRegisteredError,
@@ -29,7 +30,11 @@ const WORLD_CONTRACT_ERROR_CODES = new Set([
  * from. Kept distinct from `WORLD_CONTRACT_ERROR_CODES` so a transport blip is
  * never misclassified as the server returning a malformed response.
  */
-const RETRYABLE_WORLD_ERROR_CODES = new Set(['TRANSPORT', 'TIMEOUT']);
+const RETRYABLE_WORLD_ERROR_CODES = new Set([
+  'TRANSPORT',
+  'TIMEOUT',
+  RUN_ERROR_CODES.STREAM_ERROR,
+]);
 
 /**
  * Set of error names that should classify as generic `RUNTIME_ERROR`. Each
@@ -100,6 +105,9 @@ export function isRetryableWorldError(err: unknown): boolean {
   if (ThrottleError.is(err)) {
     return true;
   }
+  if (StreamError.is(err)) {
+    return err.status === undefined || err.status >= 500;
+  }
   if (!WorkflowWorldError.is(err)) {
     return false;
   }
@@ -133,6 +141,10 @@ export function classifyRunError(err: unknown): RunErrorCode {
   // attribute an outage correctly. Note the retryable variants are normally
   // redelivered via the queue (see `isRetryableWorldError`) and only reach this
   // terminal classification if the run ultimately gives up.
+  if (StreamError.is(err)) {
+    return RUN_ERROR_CODES.STREAM_ERROR;
+  }
+
   if (isWorldContractError(err) || isRetryableWorldError(err)) {
     return RUN_ERROR_CODES.WORLD_CONTRACT_ERROR;
   }

--- a/packages/core/src/describe-error.ts
+++ b/packages/core/src/describe-error.ts
@@ -85,6 +85,8 @@ const MAX_DELIVERIES_HINT =
   'The workflow queue exceeded its max-delivery budget. This usually indicates a persistent runtime failure — check the most recent stack traces for the underlying cause.';
 const MAX_EVENTS_HINT =
   'The workflow exceeded the maximum number of events per run. This usually means unbounded work in the workflow function — e.g. a loop that keeps creating steps without terminating. Break long-running workflows into child workflows to stay under the limit.';
+const STREAM_ERROR_HINT =
+  'Workflow stream infrastructure failed while reading or writing data. This is an SDK or backend failure, not an error in your workflow code; please retry the run and report persistent failures with the runId.';
 const WORLD_CONTRACT_HINT =
   'The workflow backend returned data that violated the SDK contract. This is not retryable; please report it with the stack trace and runId.';
 const DEPLOYMENT_MISMATCH_HINT =
@@ -142,6 +144,13 @@ export function describeRunError(
       attribution: 'sdk',
       errorCode,
       hint: CORRUPTED_EVENT_LOG_HINT,
+    };
+  }
+  if (errorCode === RUN_ERROR_CODES.STREAM_ERROR) {
+    return {
+      attribution: 'sdk',
+      errorCode,
+      hint: STREAM_ERROR_HINT,
     };
   }
   if (errorCode === RUN_ERROR_CODES.WORLD_CONTRACT_ERROR) {
@@ -261,6 +270,14 @@ export function describeError(
       attribution: 'sdk',
       errorCode: effectiveCode,
       hint: CORRUPTED_EVENT_LOG_HINT,
+    };
+  }
+
+  if (effectiveCode === RUN_ERROR_CODES.STREAM_ERROR) {
+    return {
+      attribution: 'sdk',
+      errorCode: effectiveCode,
+      hint: STREAM_ERROR_HINT,
     };
   }
 

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -1,4 +1,4 @@
-import { StreamExpiredError } from '@workflow/errors';
+import { StreamError, StreamExpiredError } from '@workflow/errors';
 import { SPEC_VERSION_CURRENT, type World } from '@workflow/world';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -502,8 +502,11 @@ describe('createReconnectingFramedStream', () => {
     setWorld(world);
 
     const stream = createReconnectingFramedStream(RUN_ID, 's', 0);
-    await expect(readAll(stream)).rejects.toThrow(
-      /exceeded maximum reconnection attempts/
+    const error = await readAll(stream).catch((cause: unknown) => cause);
+    expect(StreamError.is(error)).toBe(true);
+    expect(error).toHaveProperty(
+      'message',
+      expect.stringMatching(/exceeded maximum reconnection attempts/)
     );
     // Initial connect + one connect per allowed reconnect; the following
     // reconnect throws before opening another stream.

--- a/packages/core/src/runtime/quickjs-serde.test.ts
+++ b/packages/core/src/runtime/quickjs-serde.test.ts
@@ -19,6 +19,7 @@
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import { StreamError } from '@workflow/errors';
 import { QuickJS } from 'quickjs-wasi';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
@@ -160,6 +161,21 @@ describe('wire parity: guest serialize matches the reference codec', () => {
         const e = new TypeError('bad type');
         e.stack = 'ts';
         return e;
+      },
+    ],
+    [
+      'StreamError',
+      '(() => { const cause = new Error("socket closed"); cause.stack = "cause-stack"; const e = new Error("stream failed", { cause }); e.name = "StreamError"; e.stack = "stream-stack"; e.status = 503; e.url = "https://workflow.example/stream"; return e; })()',
+      () => {
+        const cause = new Error('socket closed');
+        cause.stack = 'cause-stack';
+        const error = new StreamError('stream failed', {
+          cause,
+          status: 503,
+          url: 'https://workflow.example/stream',
+        });
+        error.stack = 'stream-stack';
+        return error;
       },
     ],
     [

--- a/packages/core/src/runtime/quickjs-serde.ts
+++ b/packages/core/src/runtime/quickjs-serde.ts
@@ -256,6 +256,7 @@ const SYMBOL_NAMES = [
   '@workflow/errors//HookConflictError',
   '@workflow/errors//RetryableError',
   '@workflow/errors//RuntimeDecryptionError',
+  '@workflow/errors//StreamError',
 ] as const;
 type SymbolName = (typeof SYMBOL_NAMES)[number];
 
@@ -1167,6 +1168,23 @@ export function createQuickJSSerde(
       if (Object.hasOwn(shape, 'cause')) reduced.cause = shape.cause;
       return reduced;
     },
+    StreamError: (value) => {
+      if (!isHandle(value) || !value.isError) return false;
+      if (chainedString(value, 'name') !== 'StreamError') return false;
+      const shape = reduceErrorShape(value) as Record<string, unknown>;
+      const reduced: Record<string, unknown> = {
+        message: shape.message,
+        stack: shape.stack,
+      };
+      if (Object.hasOwn(shape, 'cause')) reduced.cause = shape.cause;
+      const status = own(value, 'status');
+      if (status && !status.isUndefined) reduced.status = status;
+      else status?.dispose();
+      const url = own(value, 'url');
+      if (url && !url.isUndefined) reduced.url = url;
+      else url?.dispose();
+      return reduced;
+    },
     SyntaxError: namedErrorSubclassReducer('SyntaxError'),
     TypeError: namedErrorSubclassReducer('TypeError'),
     URIError: namedErrorSubclassReducer('URIError'),
@@ -1846,6 +1864,37 @@ export function createQuickJSSerde(
           define(error, 'context', context);
         }
         context?.dispose();
+      }
+      return error;
+    },
+    StreamError: (value: JSValueHandle) => {
+      const cls = registeredErrorClass('@workflow/errors//StreamError');
+      let error: JSValueHandle;
+      if (cls) {
+        const options = vm.newObject();
+        for (const property of ['cause', 'status', 'url'] as const) {
+          if (!guestHasOwn(value, property)) continue;
+          const propertyValue = own(value, property) ?? vm.undefined;
+          options.setProp(property, propertyValue);
+          if (propertyValue !== vm.undefined) propertyValue.dispose();
+        }
+        const message = own(value, 'message') ?? vm.undefined;
+        error = vm.construct(cls, message, options);
+        if (message !== vm.undefined) message.dispose();
+        options.dispose();
+        const stack = own(value, 'stack');
+        if (stack && !stack.isUndefined) define(error, 'stack', stack);
+        stack?.dispose();
+        cls.dispose();
+      } else {
+        error = buildError(i.Error, value, { name: 'StreamError' });
+        for (const property of ['status', 'url'] as const) {
+          const propertyValue = own(value, property);
+          if (propertyValue && !propertyValue.isUndefined) {
+            define(error, property, propertyValue);
+          }
+          propertyValue?.dispose();
+        }
       }
       return error;
     },

--- a/packages/core/src/runtime/runs.ts
+++ b/packages/core/src/runtime/runs.ts
@@ -1,4 +1,4 @@
-import { EntityConflictError } from '@workflow/errors';
+import { EntityConflictError, StreamError } from '@workflow/errors';
 import {
   BULK_CANCEL_MAX_RUN_IDS,
   type BulkCancelWorkflowRunResult,
@@ -409,7 +409,8 @@ export async function readStream(
   try {
     return await world.streams.get(runId, streamId, options?.startIndex);
   } catch (err) {
-    throw new Error(
+    if (StreamError.is(err)) throw err;
+    throw new StreamError(
       `Failed to read stream ${streamId}: ${err instanceof Error ? err.message : String(err)}`,
       { cause: err }
     );
@@ -426,7 +427,8 @@ export async function listStreams(
   try {
     return await world.streams.list(runId);
   } catch (err) {
-    throw new Error(
+    if (StreamError.is(err)) throw err;
+    throw new StreamError(
       `Failed to list streams for run ${runId}: ${err instanceof Error ? err.message : String(err)}`,
       { cause: err }
     );

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -4,7 +4,9 @@ import {
   FatalError,
   HookConflictError,
   RetryableError,
+  RUN_ERROR_CODES,
   RuntimeDecryptionError,
+  StreamError,
 } from '@workflow/errors';
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from '@workflow/serde';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
@@ -4712,6 +4714,34 @@ describe('dehydrate/hydrateRunError', () => {
     // The underlying DOMException cause is preserved too.
     const cause = (hydrated as Error).cause as Error;
     expect(cause?.name).toBe('OperationError');
+  });
+
+  it('should round-trip StreamError as a catchable error type', async () => {
+    const original = new StreamError('stream write failed', {
+      cause: new Error('HTTP 500'),
+      status: 503,
+      url: 'https://workflow.example/stream',
+    });
+    const serialized = await dehydrateRunError(
+      original,
+      mockRunId,
+      noEncryptionKey
+    );
+    const hydrated = (await hydrateRunError(
+      serialized,
+      mockRunId,
+      noEncryptionKey
+    )) as StreamError;
+
+    expect(StreamError.is(hydrated)).toBe(true);
+    expect(hydrated).toBeInstanceOf(StreamError);
+    expect(hydrated).toMatchObject({
+      message: 'stream write failed',
+      status: 503,
+      url: 'https://workflow.example/stream',
+      code: RUN_ERROR_CODES.STREAM_ERROR,
+    });
+    expect((hydrated.cause as Error).message).toBe('HTTP 500');
   });
 
   it('should produce DEVALUE_V1-prefixed binary output', async () => {

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1,6 +1,7 @@
 import {
   RuntimeDecryptionError,
   SerializationError,
+  StreamError,
   StreamExpiredError,
   WorkflowRuntimeError,
 } from '@workflow/errors';
@@ -972,12 +973,12 @@ export function createReconnectingFramedStream(
       reconnectCount++;
       totalReconnectCount++;
       if (reconnectCount > maxReconnects) {
-        throw new Error(
+        throw new StreamError(
           `Stream "${name}" exceeded maximum reconnection attempts (${maxReconnects})`
         );
       }
       if (totalReconnectCount > maxTotalReconnects) {
-        throw new Error(
+        throw new StreamError(
           `Stream "${name}" exceeded maximum total reconnection attempts (${maxTotalReconnects})`
         );
       }

--- a/packages/core/src/serialization/reducers/common-vm.ts
+++ b/packages/core/src/serialization/reducers/common-vm.ts
@@ -198,6 +198,16 @@ export function getCommonReducers(): Partial<Reducers> {
       if ('cause' in value) reduced.cause = (value as any).cause;
       return reduced;
     },
+    StreamError: (value) => {
+      const base = makeNamedErrorSubclassReducer('StreamError')(value);
+      if (!base) return false;
+      const reduced: SerializableSpecial['StreamError'] = { ...base };
+      const status = (value as any).status;
+      const url = (value as any).url;
+      if (typeof status === 'number') reduced.status = status;
+      if (typeof url === 'string') reduced.url = url;
+      return reduced;
+    },
     SyntaxError: makeNamedErrorSubclassReducer('SyntaxError'),
     TypeError: makeNamedErrorSubclassReducer('TypeError'),
     URIError: makeNamedErrorSubclassReducer('URIError'),
@@ -459,6 +469,27 @@ export function getCommonRevivers(): Partial<Revivers> {
           (error as any).context = value.context;
         }
         if ('cause' in value) (error as any).cause = (value as any).cause;
+      }
+      if (value.stack !== undefined) error.stack = value.stack;
+      return error;
+    },
+    StreamError: (value) => {
+      const Cls = (globalThis as any)[
+        Symbol.for('@workflow/errors//StreamError')
+      ];
+      let error: Error;
+      if (typeof Cls === 'function') {
+        error = new Cls(value.message, {
+          ...('cause' in value ? { cause: value.cause } : {}),
+          status: value.status,
+          url: value.url,
+        });
+      } else {
+        error = new Error(value.message);
+        error.name = 'StreamError';
+        if ('cause' in value) (error as any).cause = value.cause;
+        if (value.status !== undefined) (error as any).status = value.status;
+        if (value.url !== undefined) (error as any).url = value.url;
       }
       if (value.stack !== undefined) error.stack = value.stack;
       return error;

--- a/packages/core/src/serialization/reducers/common.ts
+++ b/packages/core/src/serialization/reducers/common.ts
@@ -15,6 +15,7 @@ import {
   HookConflictError,
   RetryableError,
   RuntimeDecryptionError,
+  StreamError,
 } from '@workflow/errors';
 import {
   arrayBufferByteLength,
@@ -347,6 +348,16 @@ export function getCommonReducers(
       }
       return reduced;
     },
+    StreamError: (value) => {
+      const base = reduceNamedErrorSubclassBase('StreamError', value);
+      if (!base) return false;
+      const reduced: SerializableSpecial['StreamError'] = { ...base };
+      const status = readProperty(value, 'status');
+      const url = readProperty(value, 'url');
+      if (typeof status === 'number') reduced.status = status;
+      if (typeof url === 'string') reduced.url = url;
+      return reduced;
+    },
     SyntaxError: makeErrorSubclassReducer('SyntaxError'),
     TypeError: makeErrorSubclassReducer('TypeError'),
     URIError: makeErrorSubclassReducer('URIError'),
@@ -514,6 +525,19 @@ export function getCommonRevivers(
       if ('cause' in value) opts.cause = value.cause;
       if (value.context !== undefined) opts.context = value.context;
       const error = new Ctor(value.message, opts);
+      if (value.stack !== undefined) error.stack = value.stack;
+      return error;
+    },
+    StreamError: (value) => {
+      const Ctor =
+        ((global as Record<symbol, unknown>)[
+          Symbol.for('@workflow/errors//StreamError')
+        ] as typeof StreamError | undefined) ?? StreamError;
+      const error = new Ctor(value.message, {
+        ...('cause' in value ? { cause: value.cause } : {}),
+        status: value.status,
+        url: value.url,
+      });
       if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },

--- a/packages/core/src/serialization/types.ts
+++ b/packages/core/src/serialization/types.ts
@@ -134,6 +134,13 @@ export interface SerializableSpecial {
     cause?: unknown;
     context?: RuntimeDecryptionErrorContext;
   };
+  StreamError: {
+    message: string;
+    stack?: string;
+    cause?: unknown;
+    status?: number;
+    url?: string;
+  };
   Request: {
     method: string;
     url: string;

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -18,6 +18,8 @@ export const RUN_ERROR_CODES = {
   MAX_EVENTS_EXCEEDED: 'MAX_EVENTS_EXCEEDED',
   /** Workflow replay exceeded the maximum allowed duration */
   REPLAY_TIMEOUT: 'REPLAY_TIMEOUT',
+  /** Workflow stream infrastructure failed while reading or writing data */
+  STREAM_ERROR: 'STREAM_ERROR',
   /** World response violated the SDK contract and cannot be retried safely */
   WORLD_CONTRACT_ERROR: 'WORLD_CONTRACT_ERROR',
   /** Run was delivered to a deployment other than the one it is pinned to */

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,6 +1,7 @@
 import { parseDurationToDate, pluralize } from '@workflow/utils';
 
 import type { StringValue } from 'ms';
+import { RUN_ERROR_CODES } from './error-codes.js';
 
 // Note: `Ansi` helpers live under the `@workflow/errors/ansi` subpath so the
 // main entry point doesn't pull `chalk` (and its ESM machinery) into every
@@ -790,6 +791,29 @@ export class RunExpiredError extends WorkflowWorldError {
 }
 
 /**
+ * Thrown when Workflow's stream infrastructure fails to read or write data.
+ * The failure is attributable to the Workflow service rather than user code.
+ */
+export class StreamError extends WorkflowWorldError {
+  constructor(
+    message: string,
+    options?: { cause?: unknown; url?: string; status?: number }
+  ) {
+    super(message, {
+      code: RUN_ERROR_CODES.STREAM_ERROR,
+      cause: options?.cause,
+      url: options?.url,
+      status: options?.status,
+    });
+    this.name = 'StreamError';
+  }
+
+  static is(value: unknown): value is StreamError {
+    return isError(value) && value.name === 'StreamError';
+  }
+}
+
+/**
  * Thrown when a stream is no longer readable because its owning run passed its
  * storage-retention boundary. This is terminal: retrying cannot restore data.
  *
@@ -1070,6 +1094,7 @@ const HOOK_CONFLICT_ERROR_KEY = Symbol.for(
 const RUNTIME_DECRYPTION_ERROR_KEY = Symbol.for(
   '@workflow/errors//RuntimeDecryptionError'
 );
+const STREAM_ERROR_KEY = Symbol.for('@workflow/errors//StreamError');
 
 if (typeof globalThis !== 'undefined') {
   if (!Object.hasOwn(globalThis, FATAL_ERROR_KEY)) {
@@ -1099,6 +1124,14 @@ if (typeof globalThis !== 'undefined') {
   if (!Object.hasOwn(globalThis, RUNTIME_DECRYPTION_ERROR_KEY)) {
     Object.defineProperty(globalThis, RUNTIME_DECRYPTION_ERROR_KEY, {
       value: RuntimeDecryptionError,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  if (!Object.hasOwn(globalThis, STREAM_ERROR_KEY)) {
+    Object.defineProperty(globalThis, STREAM_ERROR_KEY, {
+      value: StreamError,
       writable: false,
       enumerable: false,
       configurable: false,

--- a/packages/web-shared/src/lib/hydration.ts
+++ b/packages/web-shared/src/lib/hydration.ts
@@ -228,6 +228,18 @@ export function getWebRevivers(): Revivers {
       if (value.stack !== undefined) error.stack = value.stack;
       return error;
     },
+    StreamError: (value) => {
+      const opts = 'cause' in value ? { cause: value.cause } : undefined;
+      const error = new Error(value.message, opts) as Error & {
+        status?: number;
+        url?: string;
+      };
+      error.name = 'StreamError';
+      if (value.status !== undefined) error.status = value.status;
+      if (value.url !== undefined) error.url = value.url;
+      if (value.stack !== undefined) error.stack = value.stack;
+      return error;
+    },
     DOMException: (value) => {
       // Modern browsers and Node 18+ expose `DOMException` on globalThis.
       // `AbortController.abort()` with no argument synthesizes one as the

--- a/packages/web-shared/test/serializable-revivers.test.ts
+++ b/packages/web-shared/test/serializable-revivers.test.ts
@@ -163,6 +163,13 @@ const SERIALIZABLE_PAYLOADS: Record<string, unknown[]> = {
   ],
   Set: [['Set', 1], [2], 'value'],
   StepFunction: [['StepFunction', 1], { stepId: 2 }, 'step//example'],
+  StreamError: [
+    ['StreamError', 1],
+    { message: 2, status: 3, url: 4 },
+    'stream failed',
+    503,
+    'https://workflow.example/stream',
+  ],
   SyntaxError: [['SyntaxError', 1], { message: 2 }, 'boom'],
   TypeError: [['TypeError', 1], { message: 2 }, 'boom'],
   URIError: [['URIError', 1], { message: 2 }, 'boom'],

--- a/packages/workflow/src/internal/errors.ts
+++ b/packages/workflow/src/internal/errors.ts
@@ -6,6 +6,7 @@ export {
   RunExpiredError,
   RunNotSupportedError,
   StepNotRegisteredError,
+  StreamError,
   ThrottleError,
   TooEarlyError,
   WorkflowError,

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -595,6 +595,7 @@ describe('getWorkflowRunEventsV4 over HTTP', () => {
       {},
       {
         token: 'test-token',
+        dispatcher: {},
       }
     );
 
@@ -895,7 +896,10 @@ describe('getEventV4 over HTTP', () => {
     );
 
     await expect(
-      getEventV4('wrun_1', 'evnt_1', 'resolve', { token: 'test-token' })
+      getEventV4('wrun_1', 'evnt_1', 'resolve', {
+        token: 'test-token',
+        dispatcher: {},
+      })
     ).rejects.toSatisfy(StreamError.is);
   });
 
@@ -1043,6 +1047,35 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+
+  it('preserves a post-header StreamError while reading a materialized response', async () => {
+    const transportFailure = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('HTTP/2: "stream timeout after 300"'), {
+        code: 'UND_ERR_INFO',
+      }),
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.error(transportFailure);
+          },
+        })
+      )
+    );
+
+    await expect(
+      createWorkflowRunEventV4(
+        {
+          runId: 'wrun_1',
+          eventType: 'step_completed',
+          specVersion: 2,
+          correlationId: 'step_1',
+        },
+        { token: 'test-token', dispatcher: {} }
+      )
+    ).rejects.toSatisfy(StreamError.is);
   });
 
   it('POSTs to the /events/:eventType alias and decodes the response', async () => {

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -265,6 +265,10 @@ describe('throwForErrorResponse', () => {
  * `config.dispatcher` is honored (it was silently ignored before).
  */
 describe('getWorkflowRunEventsV4 over HTTP', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('parses a frame stream fetched via a custom dispatcher', async () => {
     const origin =
       WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
@@ -546,6 +550,61 @@ describe('getWorkflowRunEventsV4 over HTTP', () => {
     });
   });
 
+  it('resumes a transport-failed full stream after its last complete event', async () => {
+    let pull = 0;
+    const firstFrame = encodeFrame(
+      {
+        eventId: 'evnt_1',
+        runId: 'wrun_1',
+        eventType: 'run_created',
+        createdAt: CREATED_AT,
+        eventData: {
+          deploymentId: 'dpl_1',
+          workflowName: 'workflow',
+          input: null,
+        },
+      },
+      new Uint8Array()
+    );
+    const streamFailure = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('HTTP/2: "stream timeout after 300"'), {
+        code: 'UND_ERR_INFO',
+      }),
+    });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (pull++ === 0) controller.enqueue(firstFrame);
+              else controller.error(streamFailure);
+            },
+          }),
+          { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          encodeFrame({ _end: 1, hasMore: false }, new Uint8Array()),
+          { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+        )
+      );
+
+    const result = await getWorkflowRunEventsV4(
+      'wrun_1',
+      {},
+      {
+        token: 'test-token',
+      }
+    );
+
+    expect(result.events.map((event) => event.eventId)).toEqual(['evnt_1']);
+    expect(result.cursor).toBe('eid:evnt_1');
+    expect(result.hasMore).toBe(false);
+    const secondUrl = String(vi.mocked(globalThis.fetch).mock.calls[1]?.[0]);
+    expect(secondUrl).toContain('cursor=eid%3Aevnt_1');
+  });
+
   it('resumes a truncated full stream after its last complete event', async () => {
     const origin =
       WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
@@ -780,6 +839,10 @@ describe('getEventsByCorrelationIdV4 over HTTP', () => {
  * value or hanging — the trailing frame below is never read.
  */
 describe('getEventV4 over HTTP', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('reports a terminal payload-missing frame as a corrupted event log', async () => {
     const origin =
       WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
@@ -812,6 +875,28 @@ describe('getEventV4 over HTTP', () => {
       })
     ).rejects.toSatisfy(CorruptedEventLogError.is);
     agent.assertNoPendingInterceptors();
+  });
+
+  it('unwraps a post-header transport failure from an incomplete single-event frame', async () => {
+    const transportFailure = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('HTTP/2: "stream timeout after 300"'), {
+        code: 'UND_ERR_INFO',
+      }),
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.error(transportFailure);
+          },
+        }),
+        { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+      )
+    );
+
+    await expect(
+      getEventV4('wrun_1', 'evnt_1', 'resolve', { token: 'test-token' })
+    ).rejects.toSatisfy(StreamError.is);
   });
 
   it('returns the first frame and stops reading the rest', async () => {
@@ -1963,9 +2048,59 @@ describe('v4 transport reports failures to the events recycler', () => {
     expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);
   });
 
+  it('resets the failure streak when a complete HTTP error response arrives', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockRejectedValueOnce(wedgedSessionError());
+    fetchSpy.mockRejectedValueOnce(wedgedSessionError());
+    fetchSpy.mockResolvedValueOnce(new Response('', { status: 404 }));
+    fetchSpy.mockRejectedValueOnce(wedgedSessionError());
+
+    const before = getEventsDispatcher({ token: 'test-token' });
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1; i++) {
+      await expect(
+        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+      ).rejects.toSatisfy(StreamError.is);
+    }
+    await expect(
+      getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+    ).rejects.toSatisfy(StreamError.is);
+
+    expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
+  });
+
+  it('counts a non-2xx response body timeout as a transport failure', async () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now + 20_000);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockRejectedValueOnce(wedgedSessionError());
+    fetchSpy.mockRejectedValueOnce(wedgedSessionError());
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.error(wedgedSessionError());
+          },
+        }),
+        { status: 500 }
+      )
+    );
+
+    const before = getEventsDispatcher({ token: 'test-token' });
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      await expect(
+        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+      ).rejects.toSatisfy(StreamError.is);
+    }
+
+    expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);
+  });
+
   it('classifies post-header stream timeouts and rebuilds the shared pool', async () => {
     const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now + 10_000);
+    vi.spyOn(Date, 'now').mockReturnValue(now + 40_000);
     vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
       const body = new ReadableStream<Uint8Array>({
         pull(controller) {

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -4,6 +4,7 @@ import {
   EntityConflictError,
   PreconditionFailedError,
   RunExpiredError,
+  StreamError,
   ThrottleError,
   TooEarlyError,
   WorkflowWorldError,
@@ -1942,7 +1943,7 @@ describe('v4 transport reports failures to the events recycler', () => {
       }),
     });
 
-  it('rebuilds the shared pool after repeated stream timeouts', async () => {
+  it('rebuilds the shared pool after repeated pre-header stream timeouts', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(wedgedSessionError());
 
     // No `dispatcher` in the config: the request must resolve the shared one,
@@ -1952,11 +1953,36 @@ describe('v4 transport reports failures to the events recycler', () => {
     for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
       await expect(
         getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
-      ).rejects.toThrow();
+      ).rejects.toSatisfy(StreamError.is);
       // Still the same pool until the threshold is reached.
       if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
         expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
       }
+    }
+
+    expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);
+  });
+
+  it('classifies post-header stream timeouts and rebuilds the shared pool', async () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now + 10_000);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.error(wedgedSessionError());
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-type': V4_FRAME_CONTENT_TYPE },
+      });
+    });
+
+    const before = getEventsDispatcher({ token: 'test-token' });
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      await expect(
+        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+      ).rejects.toSatisfy(StreamError.is);
     }
 
     expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -1610,6 +1610,9 @@ async function consumeEventFrameStream(
     ) {
       throw cause;
     }
+    if (cause instanceof IncompleteFrameError && StreamError.is(cause.cause)) {
+      throw cause.cause;
+    }
     if (!(cause instanceof IncompleteFrameError)) {
       throw new WorkflowWorldError(`v4 ${opName}: invalid event frame stream`, {
         code: 'SCHEMA_VALIDATION',

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -876,6 +876,7 @@ async function decodeCreateEventResponse<T extends EventType>(
   try {
     bodyBytes = new Uint8Array(await response.arrayBuffer());
   } catch (cause) {
+    if (StreamError.is(cause)) throw cause;
     throw new WorkflowWorldError(
       'v4 createEvent: failed to read response body',
       { code: 'TRANSPORT', cause }

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -22,7 +22,11 @@
  */
 
 import assert from 'node:assert/strict';
-import { CorruptedEventLogError, WorkflowWorldError } from '@workflow/errors';
+import {
+  CorruptedEventLogError,
+  StreamError,
+  WorkflowWorldError,
+} from '@workflow/errors';
 import {
   type Event,
   type EventResult,
@@ -52,6 +56,7 @@ import {
 } from './http-client.js';
 import {
   errorForResponse,
+  getTransientTransportCode,
   headersToRecord,
   httpLog,
   instrumentedFetch,
@@ -111,7 +116,7 @@ async function fetchV4(
   attributes?: Record<string, string | number | string[]>
 ): Promise<Response> {
   const dispatcher = getEventsDispatcher(config);
-  return instrumentedFetch({
+  const response = await instrumentedFetch({
     method: init.method,
     url,
     headers: init.headers,
@@ -122,9 +127,13 @@ async function fetchV4(
     // request builds a fresh one. undici keeps a black-holed HTTP/2 session in
     // service indefinitely, so without this every request routed onto it fails
     // until the compute instance is recycled. See noteEventsTransportOutcome.
-    onTransportOutcome: (error) =>
-      noteEventsTransportOutcome(dispatcher, error),
+    onTransportOutcome: (error) => {
+      // A response header is not a successful streamed request yet. Only report
+      // failures here; the wrapped body below reports success after clean EOF.
+      if (error !== undefined) noteEventsTransportOutcome(dispatcher, error);
+    },
     timeoutMs: null,
+    transportErrorCode: 'STREAM_ERROR',
     logLabel: opName,
     // Read the body as bytes, not text: a CBOR error body (the fence 412
     // carries event payloads back) does not survive a UTF-8 decode.
@@ -136,6 +145,45 @@ async function fetchV4(
         opName,
         url
       ),
+  });
+
+  if (!response.body) {
+    noteEventsTransportOutcome(dispatcher);
+    return response;
+  }
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          noteEventsTransportOutcome(dispatcher);
+          controller.close();
+        } else {
+          controller.enqueue(chunk.value);
+        }
+      } catch (cause) {
+        noteEventsTransportOutcome(dispatcher, cause);
+        const transportCode = getTransientTransportCode(cause);
+        controller.error(
+          transportCode
+            ? new StreamError(
+                `v4 ${opName}: response stream transport failure (${transportCode})`,
+                { cause, url }
+              )
+            : cause
+        );
+      }
+    },
+    cancel(reason) {
+      noteEventsTransportOutcome(dispatcher);
+      return reader.cancel(reason);
+    },
+  });
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
   });
 }
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -127,11 +127,9 @@ async function fetchV4(
     // request builds a fresh one. undici keeps a black-holed HTTP/2 session in
     // service indefinitely, so without this every request routed onto it fails
     // until the compute instance is recycled. See noteEventsTransportOutcome.
-    onTransportOutcome: (error) => {
-      // A response header is not a successful streamed request yet. Only report
-      // failures here; the wrapped body below reports success after clean EOF.
-      if (error !== undefined) noteEventsTransportOutcome(dispatcher, error);
-    },
+    onTransportOutcome: (error) =>
+      noteEventsTransportOutcome(dispatcher, error),
+    deferTransportSuccessUntilBody: true,
     timeoutMs: null,
     transportErrorCode: 'STREAM_ERROR',
     logLabel: opName,
@@ -1458,14 +1456,21 @@ export async function getEventV4(
 
   // GET emits a single frame (no sentinel); decodeFrames returns at EOF
   // after yielding it.
-  for await (const frame of decodeFrames(chunks)) {
-    if (frame.meta._error === 1) {
-      throw streamErrorFrameToError(frame.meta, 'getEvent');
+  try {
+    for await (const frame of decodeFrames(chunks)) {
+      if (frame.meta._error === 1) {
+        throw streamErrorFrameToError(frame.meta, 'getEvent');
+      }
+      if (Object.keys(frame.meta).some((key) => key.startsWith('_'))) {
+        throw new Error('v4 getEvent: unexpected control frame');
+      }
+      return decodeEventFrame(frame);
     }
-    if (Object.keys(frame.meta).some((key) => key.startsWith('_'))) {
-      throw new Error('v4 getEvent: unexpected control frame');
+  } catch (cause) {
+    if (cause instanceof IncompleteFrameError && StreamError.is(cause.cause)) {
+      throw cause.cause;
     }
-    return decodeEventFrame(frame);
+    throw cause;
   }
   throw new Error(`v4 getEvent: empty frame stream for ${eventId}`);
 }
@@ -1611,7 +1616,7 @@ async function consumeEventFrameStream(
       throw cause;
     }
     if (cause instanceof IncompleteFrameError && StreamError.is(cause.cause)) {
-      throw cause.cause;
+      return partialEventFrameStream(events, cause.cause);
     }
     if (!(cause instanceof IncompleteFrameError)) {
       throw new WorkflowWorldError(`v4 ${opName}: invalid event frame stream`, {

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -23,6 +23,7 @@ import {
   EntityConflictError,
   PreconditionFailedError,
   RunExpiredError,
+  StreamError,
   StreamExpiredError,
   ThrottleError,
   TooEarlyError,
@@ -59,6 +60,40 @@ import {
  * upstream timeout handlers (e.g. the replay timeout).
  */
 export const REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Transport codes that can surface after `fetch()` fails before returning a
+ * response. The outer error is usually `TypeError: fetch failed`; undici hangs
+ * the actionable code off its `cause`, so callers must inspect the chain.
+ */
+const TRANSIENT_TRANSPORT_ERROR_CODES = new Set([
+  'UND_ERR_INFO',
+  'UND_ERR_REQ_RETRY',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CLOSED',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'ETIMEDOUT',
+]);
+
+export function getTransientTransportCode(error: unknown): string | undefined {
+  let current = error;
+  for (let depth = 0; current && depth < 8; depth++) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && TRANSIENT_TRANSPORT_ERROR_CODES.has(code)) {
+      return code;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
 
 /**
  * Effective per-request timeout. Override via `WORKFLOW_REQUEST_TIMEOUT_MS`
@@ -509,6 +544,8 @@ export interface InstrumentedFetchOptions extends HttpClientSpanOptions {
    * connections stop delivering (see noteEventsTransportOutcome).
    */
   onTransportOutcome?: (error?: unknown) => void;
+  /** Error code used when the request itself fails before a response arrives. */
+  transportErrorCode?: 'TRANSPORT' | 'STREAM_ERROR';
 }
 
 /**
@@ -542,6 +579,7 @@ export async function instrumentedFetch(
     attributes,
     durationAttribute,
     onTransportOutcome,
+    transportErrorCode = 'TRANSPORT',
   } = opts;
   const label = logLabel ?? url;
 
@@ -613,13 +651,39 @@ export async function instrumentedFetch(
           error instanceof Error &&
           (error.name === 'TimeoutError' || error.name === 'AbortError')
         ) {
-          const timeoutError = new WorkflowWorldError(
-            `${method} ${label} timed out after ${elapsed}ms`,
-            { url, cause: error }
-          );
-          span?.setAttributes({ ...ErrorType('TIMEOUT') });
+          const message = `${method} ${label} timed out after ${elapsed}ms`;
+          const errorCode =
+            transportErrorCode === 'STREAM_ERROR' ? 'STREAM_ERROR' : 'TIMEOUT';
+          const timeoutError =
+            errorCode === 'STREAM_ERROR'
+              ? new StreamError(message, { url, cause: error })
+              : new WorkflowWorldError(message, {
+                  url,
+                  code: errorCode,
+                  cause: error,
+                });
+          span?.setAttributes({ ...ErrorType(errorCode) });
           span?.recordException?.(timeoutError);
           throw timeoutError;
+        }
+        const transportCode = getTransientTransportCode(error);
+        if (transportCode) {
+          const message = `${method} ${label} transport failure after ${elapsed}ms (${transportCode})`;
+          const errorCode =
+            transportErrorCode === 'STREAM_ERROR'
+              ? 'STREAM_ERROR'
+              : 'TRANSPORT';
+          const transportError =
+            errorCode === 'STREAM_ERROR'
+              ? new StreamError(message, { url, cause: error })
+              : new WorkflowWorldError(message, {
+                  url,
+                  code: errorCode,
+                  cause: error,
+                });
+          span?.setAttributes({ ...ErrorType(errorCode) });
+          span?.recordException?.(transportError);
+          throw transportError;
         }
         throw error;
       }

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -543,7 +543,12 @@ export interface InstrumentedFetchOptions extends HttpClientSpanOptions {
    * worked. Lets a caller that owns a shared dispatcher retire it when its
    * connections stop delivering (see noteEventsTransportOutcome).
    */
-  onTransportOutcome?: (error?: unknown) => void;
+  onTransportOutcome?: (error?: unknown, response?: Response) => void;
+  /**
+   * Delay the successful transport outcome until the caller consumes the body.
+   * Non-2xx bodies consumed by `buildError` are still reported here.
+   */
+  deferTransportSuccessUntilBody?: boolean;
   /** Error code used when the request itself fails before a response arrives. */
   transportErrorCode?: 'TRANSPORT' | 'STREAM_ERROR';
 }
@@ -579,6 +584,7 @@ export async function instrumentedFetch(
     attributes,
     durationAttribute,
     onTransportOutcome,
+    deferTransportSuccessUntilBody = false,
     transportErrorCode = 'TRANSPORT',
   } = opts;
   const label = logLabel ?? url;
@@ -688,7 +694,9 @@ export async function instrumentedFetch(
         throw error;
       }
       const ms = Date.now() - start;
-      onTransportOutcome?.();
+      if (response.ok && !deferTransportSuccessUntilBody) {
+        onTransportOutcome?.(undefined, response);
+      }
 
       httpLog(method, label, response, ms);
       recordClientSpanStatus(span, response.status);
@@ -697,11 +705,40 @@ export async function instrumentedFetch(
       if (!response.ok) {
         logCurlRepro(method, url, headers);
         if (buildError) {
-          const error = await buildError(response);
+          let error: Error;
+          try {
+            error = await buildError(response);
+          } catch (cause) {
+            const transportCode = getTransientTransportCode(cause);
+            if (transportCode) {
+              onTransportOutcome?.(cause, response);
+              const message = `${method} ${label} response body transport failure (${transportCode})`;
+              const mappedError =
+                transportErrorCode === 'STREAM_ERROR'
+                  ? new StreamError(message, { url, cause })
+                  : new WorkflowWorldError(message, {
+                      url,
+                      code: 'TRANSPORT',
+                      cause,
+                    });
+              span?.setAttributes({ ...ErrorType(transportErrorCode) });
+              span?.recordException?.(mappedError);
+              throw mappedError;
+            }
+            onTransportOutcome?.(undefined, response);
+            throw cause;
+          }
+          onTransportOutcome?.(undefined, response);
           span?.recordException?.(error);
           throw error;
         }
-        const text = await response.text().catch(() => '');
+        let text = '';
+        try {
+          text = await response.text();
+          onTransportOutcome?.(undefined, response);
+        } catch (cause) {
+          onTransportOutcome?.(cause, response);
+        }
         const error = errorForResponse(
           response.status,
           `${method} ${label} -> HTTP ${response.status}: ${response.statusText}${

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -1,4 +1,4 @@
-import { StreamExpiredError } from '@workflow/errors';
+import { StreamError, StreamExpiredError } from '@workflow/errors';
 import { NODE_HTTP_ENV_VAR } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { encodeMultiChunks, MAX_CHUNKS_PER_REQUEST } from './streamer.js';
@@ -314,9 +314,14 @@ describe('streams.write error diagnostics', () => {
 
     const streamer = await getStreamer();
 
-    await expect(
-      streamer.streams.write('wrun_test', 'user', 'chunk')
-    ).rejects.toThrow(
+    const error = await streamer.streams
+      .write('wrun_test', 'user', 'chunk')
+      .catch((cause: unknown) => cause);
+
+    expect(StreamError.is(error)).toBe(true);
+    expect(error).toMatchObject({ status: 500, code: 'STREAM_ERROR' });
+    expect(error).toHaveProperty(
+      'message',
       'Stream write failed: HTTP 500 (PUT https://test.example.com/v2/runs/wrun_test/stream/user; x-vercel-id=sfo1::abc; x-vercel-error=FUNCTION_INVOCATION_FAILED): Internal Server Error\nrequest-token'
     );
   });

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -1,4 +1,8 @@
-import { StreamError, StreamExpiredError } from '@workflow/errors';
+import {
+  StreamError,
+  StreamExpiredError,
+  ThrottleError,
+} from '@workflow/errors';
 import { NODE_HTTP_ENV_VAR } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { encodeMultiChunks, MAX_CHUNKS_PER_REQUEST } from './streamer.js';
@@ -187,6 +191,7 @@ describe('encodeMultiChunks', () => {
 // makes the intent clear. The encodeMultiChunks tests above are pure
 // functions and are unaffected.
 vi.mock('./utils.js', () => ({
+  makeRequest: vi.fn(),
   getHttpConfig: vi.fn().mockResolvedValue({
     baseUrl: 'https://test.example.com',
     headers: new Headers(),
@@ -287,6 +292,22 @@ describe('streams.get', () => {
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toBe('/v3/runs/run-123/stream/my-stream');
     expect(url.searchParams.get('startIndex')).toBe('5');
+  });
+});
+
+describe('stream snapshot errors', () => {
+  it('preserves typed World errors from snapshot requests', async () => {
+    const { makeRequest } = await import('./utils.js');
+    const throttled = new ThrottleError('rate limited', { retryAfter: 5 });
+    vi.mocked(makeRequest).mockRejectedValueOnce(throttled);
+    const { createStreamer } = await import('./streamer.js');
+
+    const error = await createStreamer()
+      .streams.getInfo('wrun_test', 'stream-test')
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBe(throttled);
+    expect(error).toMatchObject({ name: 'ThrottleError', retryAfter: 5 });
   });
 });
 

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -1,6 +1,11 @@
 import {
+  EntityConflictError,
+  PreconditionFailedError,
+  RunExpiredError,
   StreamError,
   StreamExpiredError,
+  ThrottleError,
+  TooEarlyError,
   WorkflowWorldError,
 } from '@workflow/errors';
 import {
@@ -134,12 +139,19 @@ async function createStreamReadError(response: Response): Promise<Error> {
 }
 
 function toStreamError(message: string, cause: unknown): Error {
-  if (StreamError.is(cause) || StreamExpiredError.is(cause)) return cause;
-  return new StreamError(message, {
-    cause,
-    status: WorkflowWorldError.is(cause) ? cause.status : undefined,
-    url: WorkflowWorldError.is(cause) ? cause.url : undefined,
-  });
+  if (
+    WorkflowWorldError.is(cause) ||
+    EntityConflictError.is(cause) ||
+    RunExpiredError.is(cause) ||
+    StreamError.is(cause) ||
+    StreamExpiredError.is(cause) ||
+    TooEarlyError.is(cause) ||
+    ThrottleError.is(cause) ||
+    PreconditionFailedError.is(cause)
+  ) {
+    return cause;
+  }
+  return new StreamError(message, { cause });
 }
 
 function createStreamRequestError(

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -1,4 +1,9 @@
 import {
+  StreamError,
+  StreamExpiredError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import {
   envNumber,
   type GetChunksOptions,
   type StreamChunksResponse,
@@ -108,7 +113,9 @@ function streamSpanAttributes(args: {
 
 async function createStreamReadError(response: Response): Promise<Error> {
   const fallback = `Failed to fetch stream: ${response.status}`;
-  if (response.status !== 410) return new Error(fallback);
+  if (response.status !== 410) {
+    return new StreamError(fallback, { status: response.status });
+  }
 
   try {
     const body = (await response.json()) as {
@@ -122,8 +129,17 @@ async function createStreamReadError(response: Response): Promise<Error> {
       { code: body.error, details: body.details }
     );
   } catch {
-    return new Error(fallback);
+    return new StreamError(fallback, { status: response.status });
   }
+}
+
+function toStreamError(message: string, cause: unknown): Error {
+  if (StreamError.is(cause) || StreamExpiredError.is(cause)) return cause;
+  return new StreamError(message, {
+    cause,
+    status: WorkflowWorldError.is(cause) ? cause.status : undefined,
+    url: WorkflowWorldError.is(cause) ? cause.url : undefined,
+  });
 }
 
 function createStreamRequestError(
@@ -137,8 +153,9 @@ function createStreamRequestError(
     ...getVercelDiagnostics(response.headers),
   ];
 
-  return new Error(
-    `Stream ${operation} failed: HTTP ${response.status} (${context.join('; ')}): ${text}`
+  return new StreamError(
+    `Stream ${operation} failed: HTTP ${response.status} (${context.join('; ')}): ${text}`,
+    { url: url.toString(), status: response.status }
   );
 }
 
@@ -222,6 +239,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           headers: httpConfig.headers,
           dispatcher: getStreamDispatcher(config),
           timeoutMs: null,
+          transportErrorCode: 'STREAM_ERROR',
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
           durationAttribute: 'workflow.stream.write.chunk_rtt',
@@ -272,6 +290,7 @@ export function createStreamer(config?: APIConfig): Streamer {
             headers: httpConfig.headers,
             dispatcher: getStreamDispatcher(config),
             timeoutMs: null,
+            transportErrorCode: 'STREAM_ERROR',
             logLabel: url.pathname,
             spanName: 'workflow.stream.write',
             durationAttribute: 'workflow.stream.write.chunk_rtt',
@@ -305,6 +324,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           // 503s with the stream left durably closing.
           dispatcher: getStreamCloseDispatcher(config),
           timeoutMs: null,
+          transportErrorCode: 'STREAM_ERROR',
           logLabel: url.pathname,
           spanName: 'workflow.stream.write',
           durationAttribute: 'workflow.stream.write.chunk_rtt',
@@ -344,6 +364,7 @@ export function createStreamer(config?: APIConfig): Streamer {
           headers: httpConfig.headers,
           dispatcher: undefined,
           timeoutMs: null,
+          transportErrorCode: 'STREAM_ERROR',
           logLabel: url.pathname,
           spanName: 'workflow.stream.read.connect',
           attributes: streamSpanAttributes({
@@ -355,7 +376,9 @@ export function createStreamer(config?: APIConfig): Streamer {
           buildError: createStreamReadError,
         });
         if (!response.body) {
-          throw new Error('No response body for stream');
+          throw new StreamError('No response body for stream', {
+            url: url.toString(),
+          });
         }
         return response.body as ReadableStream<Uint8Array>;
       },
@@ -374,20 +397,31 @@ export function createStreamer(config?: APIConfig): Streamer {
         }
         const qs = params.toString();
         const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/chunks${qs ? `?${qs}` : ''}`;
-        return makeRequest({
-          endpoint,
-          config,
-          schema: StreamChunksResponseSchema,
-        });
+        try {
+          return await makeRequest({
+            endpoint,
+            config,
+            schema: StreamChunksResponseSchema,
+          });
+        } catch (cause) {
+          throw toStreamError(
+            `Failed to read stream chunks for ${name}`,
+            cause
+          );
+        }
       },
 
       async getInfo(runId: string, name: string): Promise<StreamInfoResponse> {
         const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/info`;
-        return makeRequest({
-          endpoint,
-          config,
-          schema: StreamInfoResponseSchema,
-        });
+        try {
+          return await makeRequest({
+            endpoint,
+            config,
+            schema: StreamInfoResponseSchema,
+          });
+        } catch (cause) {
+          throw toStreamError(`Failed to read stream info for ${name}`, cause);
+        }
       },
 
       async list(runId: string) {
@@ -401,11 +435,19 @@ export function createStreamer(config?: APIConfig): Streamer {
           headers: httpConfig.headers,
           dispatcher: undefined,
           timeoutMs: null,
+          transportErrorCode: 'STREAM_ERROR',
           logLabel: url.pathname,
           buildError: (res) =>
-            new Error(`Failed to list streams: ${res.status}`),
+            new StreamError(`Failed to list streams: ${res.status}`, {
+              url: url.toString(),
+              status: res.status,
+            }),
         });
-        return (await response.json()) as string[];
+        try {
+          return (await response.json()) as string[];
+        } catch (cause) {
+          throw toStreamError('Failed to parse stream list response', cause);
+        }
       },
     },
   };

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -16,6 +16,7 @@ import {
   errorForResponse,
   formatVercelDiagnostics,
   getRequestTimeoutMs,
+  getTransientTransportCode,
   HTTP_DEBUG_ENABLED,
   httpClientSpanAttributes,
   httpLog,
@@ -63,76 +64,6 @@ export const MAX_BODY_PARSE_RETRIES = 2;
 
 /** Base delay for the exponential backoff between body-parse retries. */
 const BODY_PARSE_RETRY_BASE_MS = 100;
-
-/**
- * Transient transport failure codes. When a request to workflow-server cannot
- * complete, the request throws rather than returning a response, and the code
- * it carries depends on which transport issued it.
- *
- * Over undici (`fetch` plus the shared dispatcher): the `RetryAgent` exhausted
- * its retries (`UND_ERR_REQ_RETRY`, e.g. the firewall in front of
- * workflow-server shedding load with sustained 429/503, which the RetryAgent
- * retries internally and never surfaces to us), the socket dropped, or
- * connect/DNS failed.
- *
- * Over `node:http` / `node:https` (`WORKFLOW_NODE_HTTP`): there is no undici in
- * the path, so no `UND_ERR_*` code ever appears. Node's own socket and DNS
- * codes are raised instead, plus `ETIMEDOUT` from the client's own header and
- * body deadlines, which stand in for `UND_ERR_HEADERS_TIMEOUT` /
- * `UND_ERR_BODY_TIMEOUT`.
- *
- * Either way these are retryable infrastructure failures, not contract or user
- * errors, so we map them to a typed `WorkflowWorldError` (`code: 'TRANSPORT'`)
- * that the runtime recognizes as retryable and bubbles to the queue for a fast
- * redrive, instead of crashing the invocation or failing the run.
- *
- * The set is consulted on both paths, so adding `ETIMEDOUT` for the node:http
- * deadlines also classifies it on the undici path, where it is near
- * unreachable, since undici's 10s `connectTimeout` fires long before the OS
- * raises `ETIMEDOUT` on a connect, and its own stalls surface as `UND_ERR_*`.
- * Deliberate either way: a socket that timed out is transient under any client.
- */
-const TRANSIENT_TRANSPORT_ERROR_CODES = new Set([
-  'UND_ERR_REQ_RETRY',
-  'UND_ERR_SOCKET',
-  'UND_ERR_CONNECT',
-  'UND_ERR_CONNECT_TIMEOUT',
-  'UND_ERR_HEADERS_TIMEOUT',
-  'UND_ERR_BODY_TIMEOUT',
-  'UND_ERR_CLOSED',
-  'ECONNRESET',
-  'ECONNREFUSED',
-  'ENOTFOUND',
-  'EAI_AGAIN',
-  'EPIPE',
-  'ETIMEDOUT',
-]);
-
-/**
- * Walks the `cause` chain of a thrown value looking for a transient transport
- * error code. `fetch()` wraps the underlying undici error in a
- * `TypeError: fetch failed` whose `cause` carries the real `.code`, so the
- * code we care about is usually one level down (sometimes two). The
- * `node:http` client throws the socket error itself, so there the code is on
- * the top-level value. Bounded depth guards against pathological or cyclic
- * `cause` chains.
- */
-function getTransientTransportCode(error: unknown): string | undefined {
-  let current: unknown = error;
-  for (let depth = 0; current != null && depth < 5; depth++) {
-    if (typeof current === 'object' && 'code' in current) {
-      const code = (current as { code?: unknown }).code;
-      if (
-        typeof code === 'string' &&
-        TRANSIENT_TRANSPORT_ERROR_CODES.has(code)
-      ) {
-        return code;
-      }
-    }
-    current = (current as { cause?: unknown })?.cause;
-  }
-  return undefined;
-}
 
 /**
  * Effective workflow-server URL override. The inline constant wins when


### PR DESCRIPTION
## Summary & Motivation

Stream infrastructure failures (HTTP/2 session wedges, transport timeouts, non-2xx stream responses) surfaced as plain `Error`, so terminal classification attributed them to customer code as `USER_ERROR`. They now carry a catchable `StreamError` with a `STREAM_ERROR` run error code, attributed to the SDK and retried when transport-level or 5xx.

The v4 events response body is wrapped so a post-header stream failure is classified and reported to the dispatcher recycler — a response header arriving is not yet a successful streamed request.

## Test Plan

Unit tests added across classification, serialization round-trip, the streamer, and the v4 transport; 331 `@workflow/core` and 123 `@workflow/world-vercel` focused tests pass.
