### PR TITLE
Transmit the write's trace context on each WS event frame

### DIFF
--- a/packages/world-vercel/src/events-v4-ws.test.ts
+++ b/packages/world-vercel/src/events-v4-ws.test.ts
@@ -9,8 +9,9 @@
  * what happens when it isn't one this client understands.
  */
 
+import * as otel from '@opentelemetry/api';
 import { EntityConflictError, WorkflowWorldError } from '@workflow/errors';
-import { encode } from 'cbor-x';
+import { decode, encode } from 'cbor-x';
 import { MockAgent } from 'undici';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -523,5 +524,83 @@ describe('withEventPostRetry over ws', () => {
       )
     ).rejects.toThrow(EntityConflictError);
     expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Per-frame trace context. Frames carry no headers, so the write's
+ * `traceparent`/`tracestate` ride the frame envelope — next to `reqId`, not
+ * inside `event`, because `event` is forwarded verbatim into the HTTP wire
+ * format and must not grow WS-only fields. Without this the server's
+ * per-message route span parents to the connection's upgrade, and every WS
+ * write shows up in the flamegraph time-aligned with its client span but not
+ * connected to it.
+ */
+describe('per-frame trace context', () => {
+  afterEach(() => {
+    otel.propagation.disable();
+  });
+
+  /** Decode the CBOR meta block of a single encoded frame. */
+  const frameMeta = (frame: Uint8Array): Record<string, unknown> => {
+    const metaLen = new DataView(
+      frame.buffer,
+      frame.byteOffset
+    ).getUint32(0, false);
+    return decode(frame.subarray(4, 4 + metaLen));
+  };
+
+  const captureFrame = () => {
+    let frame: Uint8Array | undefined;
+    requestMock.mockImplementation(
+      async (...args: unknown[]): Promise<WsFrameReply> => {
+        const build = args[0] as (reqId: number) => Uint8Array;
+        frame = build(1);
+        return ack();
+      }
+    );
+    return () => {
+      if (!frame) throw new Error('transport.request never built a frame');
+      return frameMeta(frame);
+    };
+  };
+
+  it('stamps traceparent and tracestate onto the frame envelope', async () => {
+    otel.propagation.setGlobalPropagator({
+      inject: (_context, carrier, setter) => {
+        setter.set(
+          carrier,
+          'traceparent',
+          '00-11111111111111111111111111111111-2222222222222222-01'
+        );
+        setter.set(carrier, 'tracestate', 'vendor=1');
+      },
+      extract: (context) => context,
+      fields: () => ['traceparent', 'tracestate'],
+    });
+    const meta = captureFrame();
+
+    await createWorkflowRunEventV4(input, { token: 'test-token' });
+
+    expect(meta()).toMatchObject({
+      reqId: 1,
+      type: 'event',
+      traceparent: '00-11111111111111111111111111111111-2222222222222222-01',
+      tracestate: 'vendor=1',
+    });
+    // The event meta itself is the HTTP wire format and must stay free of
+    // WS-only fields.
+    expect(
+      (meta().event as Record<string, unknown>).traceparent
+    ).toBeUndefined();
+  });
+
+  it('omits the fields entirely when no propagator injects anything', async () => {
+    const meta = captureFrame();
+
+    await createWorkflowRunEventV4(input, { token: 'test-token' });
+
+    expect(meta()).not.toHaveProperty('traceparent');
+    expect(meta()).not.toHaveProperty('tracestate');
   });
 });

--- a/packages/world-vercel/src/events-v4-ws.test.ts
+++ b/packages/world-vercel/src/events-v4-ws.test.ts
@@ -527,15 +527,9 @@ describe('withEventPostRetry over ws', () => {
   });
 });
 
-/**
- * Per-frame trace context. Frames carry no headers, so the write's
- * `traceparent`/`tracestate` ride the frame envelope — next to `reqId`, not
- * inside `event`, because `event` is forwarded verbatim into the HTTP wire
- * format and must not grow WS-only fields. Without this the server's
- * per-message route span parents to the connection's upgrade, and every WS
- * write shows up in the flamegraph time-aligned with its client span but not
- * connected to it.
- */
+// The write's traceparent/tracestate ride the frame envelope (not `event`,
+// which is the HTTP wire format) so server spans parent to the write rather
+// than to the connection's upgrade.
 describe('per-frame trace context', () => {
   afterEach(() => {
     otel.propagation.disable();

--- a/packages/world-vercel/src/events-v4-ws.test.ts
+++ b/packages/world-vercel/src/events-v4-ws.test.ts
@@ -543,10 +543,10 @@ describe('per-frame trace context', () => {
 
   /** Decode the CBOR meta block of a single encoded frame. */
   const frameMeta = (frame: Uint8Array): Record<string, unknown> => {
-    const metaLen = new DataView(
-      frame.buffer,
-      frame.byteOffset
-    ).getUint32(0, false);
+    const metaLen = new DataView(frame.buffer, frame.byteOffset).getUint32(
+      0,
+      false
+    );
     return decode(frame.subarray(4, 4 + metaLen));
   };
 

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -1159,17 +1159,11 @@ function wsReplyStatus(reply: WsFrameReply, endpoint: string): number {
  * One thing the HTTP envelope has that this one deliberately does not: the
  * cache-bust header (a frame is memoized by nothing).
  *
- * Trace context, by contrast, IS carried per frame. Frames have no headers,
- * so `traceparent`/`tracestate` ride on the frame envelope (next to `reqId`,
- * not inside the `event` meta — propagation is a property of the message, not
- * of the event, and the `event` object is forwarded verbatim into the HTTP
- * wire format, which must not grow WS-only fields). They are captured inside
- * this write's own CLIENT span, so the server's per-message route span
- * parents to the write that produced the frame rather than to the
- * connection's upgrade — without this, every WS write's server half is
- * time-aligned with its client half in the flamegraph but not connected to
- * it. A server that predates the field strips it at the envelope schema and
- * behaves as before.
+ * Trace context rides the frame envelope (`traceparent`/`tracestate` next to
+ * `reqId` — not inside `event`, which is the HTTP wire format forwarded
+ * verbatim), captured inside this write's own CLIENT span so the server's
+ * per-message span parents to the write rather than to the connection's
+ * upgrade. A server that predates the field strips it and behaves as before.
  *
  * One gap this cannot close: Vercel's observability *outgoing requests* view is
  * built by instrumenting the global `fetch`, not by reading OpenTelemetry spans,
@@ -1223,11 +1217,8 @@ async function postEventFrameOverWs(
     },
     async (span) => {
       const start = Date.now();
-      // Captured here — inside this write's active CLIENT span — so the
-      // carrier names this span, not the caller's. A `Headers` because that
-      // is the injector's contract; read back out immediately since the
-      // frame envelope is a plain CBOR map. No-op (both stay undefined)
-      // when no OTEL SDK is registered.
+      // Captured inside this write's active CLIENT span so the carrier names
+      // this span. No-op (both stay undefined) without an OTEL SDK.
       const traceCarrier = new Headers();
       await injectTraceContextIntoHeaders(traceCarrier);
       const traceparent = traceCarrier.get('traceparent') ?? undefined;

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -63,6 +63,7 @@ import { hasSerializedDataFormatPrefix } from './serialized-data.js';
 import { deserializeStep, StepWireSchema } from './steps.js';
 import {
   ErrorType,
+  injectTraceContextIntoHeaders,
   NetworkProtocolName,
   StepLatencyOptimizations,
   StepStsoMs,
@@ -1155,10 +1156,20 @@ function wsReplyStatus(reply: WsFrameReply, endpoint: string): number {
  * key to the server's log line for the same frame. A synthetic span that hid
  * which transport produced it would be a trap, not a convenience.
  *
- * Two things the HTTP envelope has that this one deliberately does not: the
- * cache-bust header (a frame is memoized by nothing) and a per-frame
- * `traceparent` (frames carry no headers; trace context rides the upgrade
- * instead, so the server parents to the connection's span, not to this one).
+ * One thing the HTTP envelope has that this one deliberately does not: the
+ * cache-bust header (a frame is memoized by nothing).
+ *
+ * Trace context, by contrast, IS carried per frame. Frames have no headers,
+ * so `traceparent`/`tracestate` ride on the frame envelope (next to `reqId`,
+ * not inside the `event` meta — propagation is a property of the message, not
+ * of the event, and the `event` object is forwarded verbatim into the HTTP
+ * wire format, which must not grow WS-only fields). They are captured inside
+ * this write's own CLIENT span, so the server's per-message route span
+ * parents to the write that produced the frame rather than to the
+ * connection's upgrade — without this, every WS write's server half is
+ * time-aligned with its client half in the flamegraph but not connected to
+ * it. A server that predates the field strips it at the envelope schema and
+ * behaves as before.
  *
  * One gap this cannot close: Vercel's observability *outgoing requests* view is
  * built by instrumenting the global `fetch`, not by reading OpenTelemetry spans,
@@ -1212,6 +1223,15 @@ async function postEventFrameOverWs(
     },
     async (span) => {
       const start = Date.now();
+      // Captured here — inside this write's active CLIENT span — so the
+      // carrier names this span, not the caller's. A `Headers` because that
+      // is the injector's contract; read back out immediately since the
+      // frame envelope is a plain CBOR map. No-op (both stay undefined)
+      // when no OTEL SDK is registered.
+      const traceCarrier = new Headers();
+      await injectTraceContextIntoHeaders(traceCarrier);
+      const traceparent = traceCarrier.get('traceparent') ?? undefined;
+      const tracestate = traceCarrier.get('tracestate') ?? undefined;
       let reply: WsFrameReply;
       try {
         // `runId` isn't repeated here, since it's already in `wsUrl`, one
@@ -1226,7 +1246,13 @@ async function postEventFrameOverWs(
           // reconnect legitimately re-uses low numbers.
           span?.setAttributes({ ...WorkflowWsRequestId(reqId) });
           return encodeFrame(
-            { reqId, type: 'event', event: buildPostFrameMeta(input) },
+            {
+              reqId,
+              type: 'event',
+              ...(traceparent !== undefined ? { traceparent } : {}),
+              ...(tracestate !== undefined ? { tracestate } : {}),
+              event: buildPostFrameMeta(input),
+            },
             input.payload ?? new Uint8Array(0)
           );
         });


### PR DESCRIPTION
## What

WS event frames now carry the writing span's W3C `traceparent`/`tracestate` on the **frame envelope** (next to `reqId`), captured inside the write's own CLIENT span.

## Why

So downstream services can connect the request span to its own spans. This happened in HTTP requests because of built in trace propagation.

## Testing

- `events-v4-ws.test.ts`: envelope carries both fields when a propagator injects them; fields are absent entirely when none does; the `event` meta never grows them.
- 573 world-vercel tests green, `tsc --noEmit` clean.