### PR TITLE
feat(streams): add WebSocket read protocol contract

### DIFF
--- a/.changeset/ws-stream-read-protocol-v1.md
+++ b/.changeset/ws-stream-read-protocol-v1.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Add the client frame contract for the dedicated `workflow-stream-read-ws/v1` protocol.

--- a/packages/world-vercel/src/__fixtures__/workflow-stream-read-ws-v1.json
+++ b/packages/world-vercel/src/__fixtures__/workflow-stream-read-ws-v1.json
@@ -1,0 +1,87 @@
+{
+  "protocol": "workflow-stream-read-ws/v1",
+  "version": 1,
+  "endpoint": "/api/websockets/v1/runs/:runId/stream-reads/:streamId?startIndex=:startIndex&readerId=:readerId",
+  "readerId": "read_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "envelope": "u32_be(cbor_meta_length) || cbor_meta || u32_be(body_length) || body_bytes",
+  "frames": [
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "opened",
+        "requestedStartIndex": -5,
+        "resolvedStartIndex": 42
+      },
+      "bodyHex": "",
+      "frameHex": "00000039b900036474797065666f70656e6564737265717565737465645374617274496e64657824727265736f6c7665645374617274496e646578182a00000000"
+    },
+    {
+      "direction": "client_to_server",
+      "meta": {
+        "type": "credit",
+        "chunks": 2
+      },
+      "bodyHex": "",
+      "frameHex": "00000017b90002647479706566637265646974666368756e6b730200000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "chunk",
+        "index": 42
+      },
+      "bodyHex": "6869",
+      "frameHex": "00000016b900026474797065656368756e6b65696e646578182a000000026869"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "eof",
+        "finalIndex": 42,
+        "nextIndex": 43
+      },
+      "bodyHex": "",
+      "frameHex": "00000025b90003647479706563656f666a66696e616c496e646578182a696e657874496e646578182b00000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "end",
+        "reason": "drain",
+        "retryAfterMs": 1000
+      },
+      "bodyHex": "",
+      "frameHex": "00000029b90003647479706563656e6466726561736f6e65647261696e6c726574727941667465724d731903e800000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "error",
+        "status": 410,
+        "code": "read_failed",
+        "message": "stream expired"
+      },
+      "bodyHex": "",
+      "frameHex": "00000040b900046474797065656572726f726673746174757319019a64636f64656b726561645f6661696c6564676d6573736167656e73747265616d206578706972656400000000"
+    },
+    {
+      "direction": "client_to_server",
+      "meta": {
+        "type": "cancel",
+        "reqId": 7,
+        "reason": "consumer cancelled"
+      },
+      "bodyHex": "",
+      "frameHex": "00000030b9000364747970656663616e63656c6572657149640766726561736f6e72636f6e73756d65722063616e63656c6c656400000000"
+    },
+    {
+      "direction": "server_to_client",
+      "meta": {
+        "type": "cancel_ack",
+        "reqId": 7
+      },
+      "bodyHex": "",
+      "frameHex": "0000001ab9000264747970656a63616e63656c5f61636b6572657149640700000000"
+    }
+  ]
+}

--- a/packages/world-vercel/src/stream-read-ws-protocol-v1.test.ts
+++ b/packages/world-vercel/src/stream-read-ws-protocol-v1.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import fixture from './__fixtures__/workflow-stream-read-ws-v1.json';
+import { decodeFrames } from './frames.js';
+import {
+  encodeStreamReadWsControl,
+  getStreamReadWsProtocolV1Url,
+  parseStreamReadWsServerFrame,
+  STREAM_READ_WS_PROTOCOL_V1,
+  StreamReadWsClientMetaSchema,
+  StreamReadWsReaderIdSchema,
+} from './stream-read-ws-protocol-v1.js';
+
+type FixtureFrame = {
+  direction: 'client_to_server' | 'server_to_client';
+  meta: Record<string, unknown>;
+  bodyHex: string;
+  frameHex: string;
+};
+const bytes = (hex: string) => new Uint8Array(Buffer.from(hex, 'hex'));
+
+async function decodeOne(raw: Uint8Array) {
+  for await (const frame of decodeFrames(
+    (async function* () {
+      yield raw;
+    })()
+  )) {
+    return frame;
+  }
+  throw new Error('no frame');
+}
+
+describe('workflow-stream-read-ws/v1 contract', () => {
+  it('matches the canonical server fixture byte-for-byte', async () => {
+    const rawFixture = await readFile(
+      new URL('./__fixtures__/workflow-stream-read-ws-v1.json', import.meta.url)
+    );
+    expect(createHash('sha256').update(rawFixture).digest('hex')).toBe(
+      '9e4517cee0b36fccefac9344a53e7e63534676313a09059d1246c3bad51fb821'
+    );
+    expect(fixture.protocol).toBe(STREAM_READ_WS_PROTOCOL_V1);
+
+    for (const item of fixture.frames as FixtureFrame[]) {
+      const raw = bytes(item.frameHex);
+      const decoded = await decodeOne(raw);
+      expect(decoded).toEqual({ meta: item.meta, body: bytes(item.bodyHex) });
+      if (item.direction === 'client_to_server') {
+        expect(
+          encodeStreamReadWsControl(
+            StreamReadWsClientMetaSchema.parse(decoded.meta)
+          )
+        ).toEqual(raw);
+      } else {
+        expect(
+          parseStreamReadWsServerFrame(decoded.meta, decoded.body).meta
+        ).toEqual(item.meta);
+      }
+    }
+  });
+
+  it('builds the independent reader endpoint', () => {
+    const readerId = 'read_01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    expect(StreamReadWsReaderIdSchema.parse(readerId)).toBe(readerId);
+    expect(
+      getStreamReadWsProtocolV1Url(
+        'https://example.test/api',
+        'run/1',
+        'stream name',
+        -5,
+        readerId
+      ).toString()
+    ).toBe(
+      'wss://example.test/api/websockets/v1/runs/run%2F1/stream-reads/stream%20name?startIndex=-5&readerId=read_01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    );
+  });
+
+  it('enforces body and terminal invariants', () => {
+    expect(() =>
+      parseStreamReadWsServerFrame(
+        { type: 'eof', finalIndex: 2, nextIndex: 4 },
+        new Uint8Array()
+      )
+    ).toThrow('nextIndex');
+    expect(() =>
+      parseStreamReadWsServerFrame(
+        { type: 'opened', requestedStartIndex: 1, resolvedStartIndex: 2 },
+        new Uint8Array()
+      )
+    ).toThrow('resolves to itself');
+    expect(() =>
+      parseStreamReadWsServerFrame(
+        { type: 'opened', requestedStartIndex: 0, resolvedStartIndex: 0 },
+        new Uint8Array([1])
+      )
+    ).toThrow('body must be empty');
+  });
+});

--- a/packages/world-vercel/src/stream-read-ws-protocol-v1.ts
+++ b/packages/world-vercel/src/stream-read-ws-protocol-v1.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+import { encodeFrame } from './frames.js';
+
+/** Dedicated read protocol; independent of writes, REST, and specVersion. */
+export const STREAM_READ_WS_PROTOCOL_V1 = 'workflow-stream-read-ws/v1';
+
+const NonnegativeIntegerSchema = z.number().int().nonnegative();
+const RequestIdSchema = NonnegativeIntegerSchema;
+
+/** One logical ReadableStream identity, reused across transport attempts. */
+export const StreamReadWsReaderIdSchema = z
+  .string()
+  .regex(/^read_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/);
+export type StreamReadWsReaderId = z.infer<typeof StreamReadWsReaderIdSchema>;
+
+export const StreamReadWsCreditMetaSchema = z.object({
+  type: z.literal('credit'),
+  chunks: z.number().int().positive(),
+});
+export const StreamReadWsCancelMetaSchema = z.object({
+  type: z.literal('cancel'),
+  reqId: RequestIdSchema,
+  reason: z.string().optional(),
+});
+export const StreamReadWsClientMetaSchema = z.discriminatedUnion('type', [
+  StreamReadWsCreditMetaSchema,
+  StreamReadWsCancelMetaSchema,
+]);
+
+export const StreamReadWsOpenedMetaSchema = z
+  .object({
+    type: z.literal('opened'),
+    requestedStartIndex: z.number().int(),
+    resolvedStartIndex: NonnegativeIntegerSchema,
+  })
+  .superRefine((frame, ctx) => {
+    if (
+      frame.requestedStartIndex >= 0 &&
+      frame.resolvedStartIndex !== frame.requestedStartIndex
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'a non-negative requested index resolves to itself',
+      });
+    }
+  });
+export const StreamReadWsChunkMetaSchema = z.object({
+  type: z.literal('chunk'),
+  index: NonnegativeIntegerSchema,
+});
+export const StreamReadWsEofMetaSchema = z
+  .object({
+    type: z.literal('eof'),
+    finalIndex: z.number().int().min(-1),
+    nextIndex: NonnegativeIntegerSchema,
+  })
+  .superRefine((frame, ctx) => {
+    if (frame.nextIndex !== frame.finalIndex + 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'eof nextIndex must equal finalIndex + 1',
+      });
+    }
+  });
+export const StreamReadWsEndReasonSchema = z.enum([
+  'source_interrupted',
+  'max_duration',
+  'drain',
+  'idle',
+  'capacity',
+]);
+export const StreamReadWsEndMetaSchema = z.object({
+  type: z.literal('end'),
+  reason: StreamReadWsEndReasonSchema,
+  retryAfterMs: NonnegativeIntegerSchema.optional(),
+});
+export const StreamReadWsErrorCodeSchema = z.enum([
+  'invalid_start_index',
+  'read_failed',
+  'protocol_error',
+]);
+export const StreamReadWsErrorMetaSchema = z.object({
+  type: z.literal('error'),
+  status: z.number().int(),
+  code: StreamReadWsErrorCodeSchema,
+  message: z.string().optional(),
+});
+export const StreamReadWsCancelAckMetaSchema = z.object({
+  type: z.literal('cancel_ack'),
+  reqId: RequestIdSchema,
+});
+export const StreamReadWsServerMetaSchema = z.discriminatedUnion('type', [
+  StreamReadWsOpenedMetaSchema,
+  StreamReadWsChunkMetaSchema,
+  StreamReadWsEofMetaSchema,
+  StreamReadWsEndMetaSchema,
+  StreamReadWsErrorMetaSchema,
+  StreamReadWsCancelAckMetaSchema,
+]);
+
+export type StreamReadWsClientMeta = z.infer<
+  typeof StreamReadWsClientMetaSchema
+>;
+export type StreamReadWsServerMeta = z.infer<
+  typeof StreamReadWsServerMetaSchema
+>;
+
+export function getStreamReadWsProtocolV1Url(
+  baseUrl: string,
+  runId: string,
+  streamId: string,
+  startIndex: number,
+  readerId: StreamReadWsReaderId
+): URL {
+  if (!Number.isSafeInteger(startIndex)) {
+    throw new Error('stream read startIndex must be a safe integer');
+  }
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/websockets/v1/runs/${encodeURIComponent(runId)}/stream-reads/${encodeURIComponent(streamId)}`;
+  url.search = new URLSearchParams({
+    startIndex: String(startIndex),
+    readerId: StreamReadWsReaderIdSchema.parse(readerId),
+  }).toString();
+  return url;
+}
+
+/** Client control frames always have an empty body. */
+export function encodeStreamReadWsControl(
+  meta: StreamReadWsClientMeta
+): Uint8Array {
+  return encodeFrame(
+    StreamReadWsClientMetaSchema.parse(meta),
+    new Uint8Array()
+  );
+}
+
+/** Parse one server envelope, enforcing that only chunk carries a body. */
+export function parseStreamReadWsServerFrame(
+  meta: Record<string, unknown>,
+  body: Uint8Array
+): { meta: StreamReadWsServerMeta; body: Uint8Array } {
+  const parsed = StreamReadWsServerMetaSchema.parse(meta);
+  if (parsed.type !== 'chunk' && body.byteLength !== 0) {
+    throw new Error(`stream read ${parsed.type} body must be empty`);
+  }
+  return { meta: parsed, body };
+}


### PR DESCRIPTION
## Summary & Motivation

Reads get their own protocol (`workflow-stream-read-ws/v1`) with its own endpoint and reader identity, so a stream read is not tied to the lifetime or versioning of the write or event socket. Client frames, server frames, and the URL builder are validated against a canonical fixture so the wire shape is pinned rather than described.

## Test Plan

Protocol and framing tests added, checked against the canonical server fixture.
