### PR TITLE
feat(streams): add WebSocket read session

### DIFF
--- a/.changeset/ws-stream-read-session.md
+++ b/.changeset/ws-stream-read-session.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Add the indexed HTTP fallback seam and a credit-driven WebSocket stream reader session.

--- a/packages/world-vercel/src/indexed-stream-fallback.test.ts
+++ b/packages/world-vercel/src/indexed-stream-fallback.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createIndexedStreamFallback } from './indexed-stream-fallback.js';
+
+async function readAll(stream: ReadableStream<Uint8Array>) {
+  const values: Uint8Array[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
+describe('indexed HTTP stream fallback', () => {
+  it('starts at an absolute index then follows opaque cursors', async () => {
+    const getChunks = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ index: 4, data: new Uint8Array([4]) }],
+        cursor: 'opaque',
+        hasMore: true,
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        data: [{ index: 5, data: new Uint8Array([5]) }],
+        cursor: null,
+        hasMore: false,
+        done: true,
+      })
+      .mockResolvedValueOnce({
+        data: [],
+        cursor: null,
+        hasMore: false,
+        done: true,
+      });
+    const getInfo = vi.fn().mockResolvedValue({ tailIndex: 5, done: true });
+
+    await expect(
+      readAll(createIndexedStreamFallback(4, { getChunks, getInfo }))
+    ).resolves.toEqual([new Uint8Array([4]), new Uint8Array([5])]);
+    expect(getChunks).toHaveBeenNthCalledWith(1, {
+      limit: 100,
+      startIndex: 4,
+    });
+    expect(getChunks).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      cursor: 'opaque',
+    });
+  });
+
+  it('rejects a gap instead of skipping durable data', async () => {
+    const stream = createIndexedStreamFallback(4, {
+      getChunks: vi.fn().mockResolvedValue({
+        data: [{ index: 5, data: new Uint8Array([5]) }],
+        cursor: null,
+        hasMore: false,
+        done: false,
+      }),
+      getInfo: vi.fn(),
+    });
+    await expect(stream.getReader().read()).rejects.toThrow(
+      'expected 4, received 5'
+    );
+  });
+
+  it('polls while caught up and completes only past the terminal tail', async () => {
+    const getChunks = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [],
+        cursor: null,
+        hasMore: false,
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        data: [],
+        cursor: null,
+        hasMore: false,
+        done: true,
+      });
+    const getInfo = vi
+      .fn()
+      .mockResolvedValueOnce({ tailIndex: 3, done: false })
+      .mockResolvedValueOnce({ tailIndex: 3, done: true });
+
+    const result = await createIndexedStreamFallback(4, {
+      getChunks,
+      getInfo,
+    })
+      .getReader()
+      .read();
+    expect(result).toEqual({ done: true, value: undefined });
+    expect(getChunks).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancellation interrupts caught-up polling', async () => {
+    const stream = createIndexedStreamFallback(4, {
+      getChunks: vi.fn().mockResolvedValue({
+        data: [],
+        cursor: null,
+        hasMore: false,
+        done: false,
+      }),
+      getInfo: vi.fn().mockResolvedValue({ tailIndex: 3, done: false }),
+    });
+    const reader = stream.getReader();
+    const reading = reader.read();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await reader.cancel();
+    await expect(reading).resolves.toEqual({ done: true, value: undefined });
+  });
+});

--- a/packages/world-vercel/src/indexed-stream-fallback.ts
+++ b/packages/world-vercel/src/indexed-stream-fallback.ts
@@ -1,0 +1,94 @@
+import type {
+  GetChunksOptions,
+  StreamChunksResponse,
+  StreamInfoResponse,
+} from '@workflow/world';
+
+const PAGE_LIMIT = 100;
+const INITIAL_POLL_MS = 50;
+const MAX_POLL_MS = 1_000;
+
+export interface IndexedStreamFallbackSource {
+  getChunks(options: GetChunksOptions): Promise<StreamChunksResponse>;
+  getInfo(): Promise<StreamInfoResponse>;
+}
+
+/** Rare post-WebSocket recovery path that preserves durable chunk indexes. */
+export function createIndexedStreamFallback(
+  startIndex: number,
+  source: IndexedStreamFallbackSource
+): ReadableStream<Uint8Array> {
+  let expected = startIndex;
+  let page: StreamChunksResponse['data'] = [];
+  let cursor: string | undefined;
+  let pageInitialized = false;
+  let pollDelayMs = INITIAL_POLL_MS;
+  let cancelled = false;
+  let pollTimer: ReturnType<typeof setTimeout> | undefined;
+  let pollResolve: (() => void) | undefined;
+
+  const wait = () =>
+    new Promise<void>((resolve) => {
+      pollResolve = resolve;
+      pollTimer = setTimeout(resolve, pollDelayMs);
+      pollTimer.unref?.();
+    }).finally(() => {
+      pollTimer = undefined;
+      pollResolve = undefined;
+    });
+
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        while (!cancelled) {
+          const chunk = page.shift();
+          if (chunk) {
+            if (chunk.index < expected) continue;
+            if (chunk.index > expected) {
+              controller.error(
+                new Error(
+                  `indexed stream fallback gap: expected ${expected}, received ${chunk.index}`
+                )
+              );
+              return;
+            }
+            expected++;
+            controller.enqueue(chunk.data);
+            return;
+          }
+
+          const options: GetChunksOptions = pageInitialized
+            ? {
+                limit: PAGE_LIMIT,
+                ...(cursor ? { cursor } : { startIndex: expected }),
+              }
+            : { limit: PAGE_LIMIT, startIndex: expected };
+          const result = await source.getChunks(options);
+          pageInitialized = true;
+          page = [...result.data];
+          cursor = result.cursor ?? undefined;
+          if (page.length > 0) {
+            pollDelayMs = INITIAL_POLL_MS;
+            continue;
+          }
+
+          const info = await source.getInfo();
+          if (info.done && expected > info.tailIndex) {
+            controller.close();
+            return;
+          }
+          await wait();
+          pollDelayMs = Math.min(pollDelayMs * 2, MAX_POLL_MS);
+          pageInitialized = false;
+          cursor = undefined;
+        }
+      },
+      cancel() {
+        cancelled = true;
+        if (pollTimer) clearTimeout(pollTimer);
+        pollResolve?.();
+      },
+    },
+    { highWaterMark: 1 }
+  );
+}

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -235,6 +235,20 @@ describe('session HTTP fallback', () => {
   });
 });
 
+describe('streams.getChunks', () => {
+  it('rejects cursor/startIndex conflicts before issuing a request', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const { createStreamer } = await import('./streamer.js');
+    await expect(
+      createStreamer().streams.getChunks?.('run-123', 'stream', {
+        cursor: 'opaque',
+        startIndex: 42,
+      })
+    ).rejects.toThrow('mutually exclusive');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('streams.get', () => {
   async function getStreamer() {
     const { createStreamer } = await import('./streamer.js');

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -11,6 +11,7 @@ import {
 import {
   envNumber,
   type GetChunksOptions,
+  type GetStreamInfoOptions,
   type StreamChunksResponse,
   type Streamer,
   type StreamInfoResponse,
@@ -182,6 +183,7 @@ export { encodeMultiChunks } from './stream-chunks.js';
 const StreamInfoResponseSchema = z.object({
   tailIndex: z.number(),
   done: z.boolean(),
+  resolvedStartIndex: z.number().int().nonnegative().optional(),
 });
 
 /**
@@ -451,8 +453,24 @@ export function createStreamer(config?: APIConfig): Streamer {
         if (options?.limit != null) {
           params.set('limit', String(options.limit));
         }
+        if (options?.cursor && options.startIndex !== undefined) {
+          throw new Error(
+            'stream chunks cursor and startIndex are mutually exclusive'
+          );
+        }
         if (options?.cursor) {
           params.set('cursor', options.cursor);
+        }
+        if (options?.startIndex !== undefined) {
+          if (
+            !Number.isSafeInteger(options.startIndex) ||
+            options.startIndex < 0
+          ) {
+            throw new Error(
+              'stream chunks startIndex must be a nonnegative safe integer'
+            );
+          }
+          params.set('startIndex', String(options.startIndex));
         }
         const qs = params.toString();
         const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/chunks${qs ? `?${qs}` : ''}`;
@@ -470,8 +488,16 @@ export function createStreamer(config?: APIConfig): Streamer {
         }
       },
 
-      async getInfo(runId: string, name: string): Promise<StreamInfoResponse> {
-        const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/info`;
+      async getInfo(
+        runId: string,
+        name: string,
+        options?: GetStreamInfoOptions
+      ): Promise<StreamInfoResponse> {
+        const query =
+          options?.startIndex === undefined
+            ? ''
+            : `?startIndex=${encodeURIComponent(String(options.startIndex))}`;
+        const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/info${query}`;
         try {
           return await makeRequest({
             endpoint,

--- a/packages/world-vercel/src/ws-stream-read-session.test.ts
+++ b/packages/world-vercel/src/ws-stream-read-session.test.ts
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { decodeFrames, encodeFrame } from './frames.js';
+
+const { FakeWebSocket, sockets } = vi.hoisted(() => {
+  const sockets: FakeSocket[] = [];
+  class FakeSocket {
+    static readonly OPEN = 1;
+    readyState = 0;
+    sent: Uint8Array[] = [];
+    closed: Array<[number, string]> = [];
+    binaryType = '';
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    constructor(readonly url: string) {
+      sockets.push(this);
+    }
+    on(event: string, callback: (...args: unknown[]) => void): this {
+      const list = this.listeners.get(event) ?? [];
+      list.push(callback);
+      this.listeners.set(event, list);
+      return this;
+    }
+    once(event: string, callback: (...args: unknown[]) => void): this {
+      const wrapper = (...args: unknown[]) => {
+        this.listeners.set(
+          event,
+          (this.listeners.get(event) ?? []).filter((item) => item !== wrapper)
+        );
+        callback(...args);
+      };
+      return this.on(event, wrapper);
+    }
+    emit(event: string, ...args: unknown[]): void {
+      for (const callback of [...(this.listeners.get(event) ?? [])]) {
+        callback(...args);
+      }
+    }
+    open(): void {
+      this.readyState = 1;
+      this.emit('open');
+    }
+    send(frame: Uint8Array): void {
+      this.sent.push(frame);
+    }
+    close(code = 1000, reason = ''): void {
+      this.readyState = 3;
+      this.closed.push([code, reason]);
+    }
+    reply(meta: Record<string, unknown>, body = new Uint8Array()): void {
+      this.emit('message', encodeFrame(meta, body));
+    }
+  }
+  return { FakeWebSocket: FakeSocket, sockets };
+});
+
+vi.mock('ws', () => ({ WebSocket: FakeWebSocket }));
+vi.mock('./telemetry.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./telemetry.js')>()),
+  injectTraceContextIntoHeaders: vi.fn(),
+}));
+
+const { createStreamReadWsSession } = await import(
+  './ws-stream-read-session.js'
+);
+
+beforeEach(() => {
+  sockets.length = 0;
+});
+
+function makeFallbacks() {
+  return {
+    resolveStartIndex: vi.fn(async (startIndex: number) => startIndex),
+    getChunks: vi.fn(),
+    getInfo: vi.fn(),
+  };
+}
+
+async function decodeSentMeta(raw: Uint8Array) {
+  for await (const frame of decodeFrames(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(raw);
+        controller.close();
+      },
+    })
+  )) {
+    return frame.meta;
+  }
+  throw new Error('missing frame');
+}
+
+async function open(stream: ReadableStream<Uint8Array>, startIndex = 0) {
+  const reader = stream.getReader();
+  const reading = reader.read();
+  await vi.waitFor(() => expect(sockets).toHaveLength(1));
+  sockets[0].open();
+  sockets[0].reply({
+    type: 'opened',
+    requestedStartIndex: startIndex,
+    resolvedStartIndex: startIndex < 0 ? 42 : startIndex,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return { reader, reading, socket: sockets[0] };
+}
+
+describe('stream read WebSocket session', () => {
+  it('keeps a bounded four-chunk credit window', async () => {
+    const fallbacks = makeFallbacks();
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      fallbacks
+    );
+    const { reader, reading, socket } = await open(stream);
+    // `opened` grants one implicit connection-local credit, then the client
+    // fills only the remaining downstream capacity.
+    expect(socket.sent).toHaveLength(1);
+    await expect(decodeSentMeta(socket.sent[0])).resolves.toMatchObject({
+      type: 'credit',
+      chunks: 3,
+    });
+    socket.reply({ type: 'chunk', index: 0 }, new Uint8Array([1]));
+    await expect(reading).resolves.toEqual({
+      done: false,
+      value: new Uint8Array([1]),
+    });
+
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
+    await expect(decodeSentMeta(socket.sent[1])).resolves.toMatchObject({
+      type: 'credit',
+      chunks: 1,
+    });
+    const second = reader.read();
+    socket.reply({ type: 'chunk', index: 1 }, new Uint8Array([2]));
+    await expect(second).resolves.toEqual({
+      done: false,
+      value: new Uint8Array([2]),
+    });
+    await reader.cancel();
+  });
+
+  it('does not grant credit without downstream queue capacity', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reader, reading, socket } = await open(stream);
+    for (let index = 0; index < 5; index++) {
+      socket.reply({ type: 'chunk', index }, new Uint8Array([index]));
+    }
+    await reading;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Initial +3 plus one replacement for the directly-consumed first chunk.
+    // Four queued chunks leave desiredSize=0, so no further credit is sent.
+    expect(socket.sent).toHaveLength(2);
+    await expect(decodeSentMeta(socket.sent[1])).resolves.toMatchObject({
+      type: 'credit',
+      chunks: 1,
+    });
+
+    // Draining one queued chunk creates exactly one slot and one replacement
+    // credit. Filling that slot consumes the credit without granting another.
+    await expect(reader.read()).resolves.toMatchObject({
+      value: new Uint8Array([1]),
+    });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    await expect(decodeSentMeta(socket.sent[2])).resolves.toMatchObject({
+      type: 'credit',
+      chunks: 1,
+    });
+    socket.reply({ type: 'chunk', index: 5 }, new Uint8Array([5]));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(socket.sent).toHaveLength(3);
+    await reader.cancel();
+  });
+
+  it('discards duplicate chunks and restores demanded credit', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reader, reading, socket } = await open(stream);
+    socket.reply({ type: 'chunk', index: 0 }, new Uint8Array([1]));
+    await reading;
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
+    const second = reader.read();
+    socket.reply({ type: 'chunk', index: 0 }, new Uint8Array([9]));
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    await expect(decodeSentMeta(socket.sent[2])).resolves.toMatchObject({
+      type: 'credit',
+      chunks: 1,
+    });
+    socket.reply({ type: 'chunk', index: 1 }, new Uint8Array([2]));
+    await expect(second).resolves.toMatchObject({ value: new Uint8Array([2]) });
+    await reader.cancel();
+  });
+
+  it('resets the reconnect budget after forward progress', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const reader = stream.getReader();
+    let reading = reader.read();
+
+    for (let index = 0; index < 5; index++) {
+      await vi.waitFor(() => expect(sockets).toHaveLength(index + 1));
+      const socket = sockets[index];
+      socket.open();
+      socket.reply({
+        type: 'opened',
+        requestedStartIndex: index,
+        resolvedStartIndex: index,
+      });
+      socket.reply({ type: 'chunk', index }, new Uint8Array([index]));
+      await expect(reading).resolves.toMatchObject({
+        value: new Uint8Array([index]),
+      });
+      if (index < 4) {
+        reading = reader.read();
+        socket.reply({ type: 'end', reason: 'drain' });
+      }
+    }
+
+    expect(sockets).toHaveLength(5);
+    await reader.cancel();
+  });
+
+  it('ignores queued frames from a superseded socket attempt', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reader, reading, socket: first } = await open(stream);
+    first.reply({ type: 'end', reason: 'capacity' });
+    first.reply({ type: 'chunk', index: 0 }, new Uint8Array([99]));
+
+    await vi.waitFor(() => expect(sockets).toHaveLength(2));
+    const second = sockets[1];
+    second.open();
+    second.reply({
+      type: 'opened',
+      requestedStartIndex: 0,
+      resolvedStartIndex: 0,
+    });
+    second.reply({ type: 'chunk', index: 0 }, new Uint8Array([1]));
+
+    await expect(reading).resolves.toMatchObject({
+      value: new Uint8Array([1]),
+    });
+    await reader.cancel();
+  });
+
+  it('ignores stale lifecycle callbacks while a replacement connects', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reader, reading, socket: first } = await open(stream);
+    first.reply({ type: 'end', reason: 'capacity' });
+    await vi.waitFor(() => expect(sockets).toHaveLength(2));
+    const second = sockets[1];
+
+    first.emit('error', new Error('late old-socket error'));
+    second.open();
+    second.reply({
+      type: 'opened',
+      requestedStartIndex: 0,
+      resolvedStartIndex: 0,
+    });
+    second.reply({ type: 'chunk', index: 0 }, new Uint8Array([1]));
+
+    await expect(reading).resolves.toMatchObject({
+      value: new Uint8Array([1]),
+    });
+    await reader.cancel();
+  });
+
+  it('accepts explicit EOF when starting beyond the terminal tail', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      10,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reading, socket } = await open(stream, 10);
+    socket.reply({ type: 'eof', finalIndex: 4, nextIndex: 5 });
+    await expect(reading).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it('treats fatal error as terminal', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reading, socket } = await open(stream);
+    socket.reply({
+      type: 'error',
+      status: 410,
+      code: 'read_failed',
+      message: 'expired',
+    });
+    await expect(reading).rejects.toThrow('expired');
+  });
+
+  it('cancels with a bounded acknowledgement', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reader, socket } = await open(stream);
+    const cancelling = reader.cancel('stop');
+    await vi.waitFor(() =>
+      expect(socket.sent.length).toBeGreaterThanOrEqual(2)
+    );
+    const cancelFrame = socket.sent.at(-1);
+    expect(cancelFrame).toBeDefined();
+    await expect(
+      decodeSentMeta(cancelFrame as Uint8Array)
+    ).resolves.toMatchObject({
+      type: 'cancel',
+      reqId: 1,
+    });
+    socket.reply({ type: 'cancel_ack', reqId: 1 });
+    await expect(
+      Promise.race([
+        cancelling.then(() => 'acknowledged'),
+        new Promise((resolve) => setTimeout(() => resolve('timed out'), 100)),
+      ])
+    ).resolves.toBe('acknowledged');
+    expect(socket.closed).toContainEqual([1000, 'reader cancelled']);
+  });
+
+  it('claims one pre-open HTTP fallback across competing terminal signals', async () => {
+    const fallbacks = makeFallbacks();
+    fallbacks.getChunks
+      .mockResolvedValueOnce({
+        data: [{ index: 0, data: new Uint8Array([1]) }],
+        cursor: null,
+        hasMore: false,
+        done: false,
+      })
+      .mockResolvedValue({
+        data: [],
+        cursor: null,
+        hasMore: false,
+        done: true,
+      });
+    fallbacks.getInfo.mockResolvedValue({ tailIndex: 0, done: true });
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      fallbacks
+    );
+    const reader = stream.getReader();
+    const reading = reader.read();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const response = { resume: vi.fn(), destroy: vi.fn() };
+    sockets[0].emit('unexpected-response', {}, response);
+    sockets[0].emit('error', new Error('declined'));
+    sockets[0].emit('close');
+
+    await expect(reading).resolves.toMatchObject({
+      value: new Uint8Array([1]),
+    });
+    expect(fallbacks.resolveStartIndex).toHaveBeenCalledTimes(1);
+    expect(fallbacks.getChunks).toHaveBeenCalled();
+    await reader.cancel();
+  });
+
+  it('cancels while authoritative position resolution is pending', async () => {
+    let resolveStart: ((index: number) => void) | undefined;
+    const fallbacks = makeFallbacks();
+    fallbacks.resolveStartIndex.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      })
+    );
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      fallbacks
+    );
+    const reader = stream.getReader();
+    void reader.read();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].emit('unexpected-response', {}, {});
+    await vi.waitFor(() =>
+      expect(fallbacks.resolveStartIndex).toHaveBeenCalledTimes(1)
+    );
+    const cancelling = reader.cancel();
+    resolveStart?.(0);
+    await cancelling;
+    expect(fallbacks.getChunks).not.toHaveBeenCalled();
+  });
+
+  it('uses indexed pages after opened recovery and validates gaps', async () => {
+    const fallbacks = makeFallbacks();
+    fallbacks.getChunks.mockResolvedValue({
+      data: [{ index: 2, data: new Uint8Array([2]) }],
+      cursor: null,
+      hasMore: false,
+      done: false,
+    });
+    fallbacks.getInfo.mockResolvedValue({ tailIndex: 2, done: false });
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      fallbacks
+    );
+    const { reading, socket } = await open(stream);
+    socket.reply({ type: 'end', reason: 'capacity' });
+    // Exhaust WS reconnects with accepted/opened attempts ending immediately.
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await vi.waitFor(() => expect(sockets).toHaveLength(attempt + 1));
+      sockets[attempt].open();
+      sockets[attempt].reply({
+        type: 'opened',
+        requestedStartIndex: 0,
+        resolvedStartIndex: 0,
+      });
+      sockets[attempt].reply({ type: 'end', reason: 'capacity' });
+    }
+    await expect(reading).rejects.toThrow('expected 0, received 2');
+    expect(fallbacks.resolveStartIndex).not.toHaveBeenCalled();
+  });
+});

--- a/packages/world-vercel/src/ws-stream-read-session.ts
+++ b/packages/world-vercel/src/ws-stream-read-session.ts
@@ -1,0 +1,388 @@
+import type {
+  GetChunksOptions,
+  StreamChunksResponse,
+  StreamInfoResponse,
+} from '@workflow/world';
+import { ulid } from 'ulid';
+import type { WebSocket } from 'ws';
+import { type DecodedFrame, decodeFrames } from './frames.js';
+import { headersToRecord, withHttpClientSpan } from './http-core.js';
+import { createIndexedStreamFallback } from './indexed-stream-fallback.js';
+import {
+  encodeStreamReadWsControl,
+  getStreamReadWsProtocolV1Url,
+  parseStreamReadWsServerFrame,
+  type StreamReadWsReaderId,
+} from './stream-read-ws-protocol-v1.js';
+import { injectTraceContextIntoHeaders } from './telemetry.js';
+import type { APIConfig } from './utils.js';
+import { getHttpConfig } from './utils.js';
+
+export const STREAM_READ_WS_CONNECT_BUDGET_MS = 250;
+export const STREAM_READ_WS_CANCEL_BUDGET_MS = 250;
+const MAX_WS_RECONNECTS = 3;
+const MAX_RETRY_AFTER_MS = 5_000;
+const MAX_OUTSTANDING_CREDIT = 4;
+
+export interface StreamReadFallbacks {
+  resolveStartIndex(startIndex: number): Promise<number>;
+  getChunks(options: GetChunksOptions): Promise<StreamChunksResponse>;
+  getInfo(): Promise<StreamInfoResponse>;
+}
+
+async function decodeOne(raw: Uint8Array): Promise<DecodedFrame> {
+  let result: DecodedFrame | undefined;
+  for await (const frame of decodeFrames(
+    (async function* () {
+      yield raw;
+    })()
+  )) {
+    if (result) throw new Error('stream read message contains multiple frames');
+    result = frame;
+  }
+  if (!result) throw new Error('stream read message contains no frame');
+  return result;
+}
+
+function asBytes(raw: unknown): Uint8Array {
+  if (raw instanceof Uint8Array) return raw;
+  if (typeof raw === 'string') return new TextEncoder().encode(raw);
+  return new Uint8Array(raw as ArrayBufferLike);
+}
+
+export function createStreamReadWsSession(
+  runId: string,
+  name: string,
+  startIndex: number,
+  config: APIConfig | undefined,
+  fallbacks: StreamReadFallbacks
+): ReadableStream<Uint8Array> {
+  const readerId = `read_${ulid()}` as StreamReadWsReaderId;
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  let socket: WebSocket | undefined;
+  let started = false;
+  let activated = false;
+  let opened = false;
+  let cancelled = false;
+  let terminal = false;
+  let expected = startIndex;
+  let outstandingCredit = 0;
+  let reconnects = 0;
+  let inbound = Promise.resolve();
+  let httpReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let httpFallback: Promise<void> | undefined;
+  let cancelReqId = 1;
+  let cancelAck: (() => void) | undefined;
+  let pullResolve: (() => void) | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryResolve: (() => void) | undefined;
+
+  const notifyPull = () => {
+    const resolve = pullResolve;
+    pullResolve = undefined;
+    resolve?.();
+  };
+  const waitForDelivery = () =>
+    new Promise<void>((resolve) => {
+      pullResolve = resolve;
+    });
+
+  const restoreCreditWindow = () => {
+    if (!opened || terminal || cancelled || !socket || socket.readyState !== 1)
+      return;
+    const capacity = Math.max(
+      0,
+      Math.min(MAX_OUTSTANDING_CREDIT, Math.floor(controller.desiredSize ?? 0))
+    );
+    const chunks = capacity - outstandingCredit;
+    if (chunks <= 0) return;
+    socket.send(encodeStreamReadWsControl({ type: 'credit', chunks }));
+    outstandingCredit += chunks;
+  };
+
+  const closeSocket = (reason: string) => {
+    const active = socket;
+    socket = undefined;
+    active?.close(1000, reason);
+  };
+
+  const wait = (ms: number) =>
+    new Promise<void>((resolve) => {
+      retryResolve = resolve;
+      retryTimer = setTimeout(resolve, ms);
+      retryTimer.unref?.();
+    }).finally(() => {
+      retryTimer = undefined;
+      retryResolve = undefined;
+    });
+
+  const pumpRawHttpReader = async () => {
+    if (!httpReader || cancelled) return;
+    const result = await httpReader.read();
+    if (result.done) {
+      terminal = true;
+      controller.close();
+      notifyPull();
+      return;
+    }
+    controller.enqueue(result.value);
+    notifyPull();
+  };
+
+  const switchToHttp = (): Promise<void> => {
+    if (cancelled || terminal) return Promise.resolve();
+    // Claim fallback synchronously. Timeout/error/close/decline callbacks all
+    // join this one transition and can never open competing HTTP readers.
+    httpFallback ??= (async () => {
+      closeSocket('HTTP fallback');
+      if (!activated) {
+        expected = await fallbacks.resolveStartIndex(startIndex);
+        activated = true;
+      }
+      if (cancelled || terminal) return;
+      httpReader = createIndexedStreamFallback(expected, fallbacks).getReader();
+      await pumpRawHttpReader();
+    })();
+    return httpFallback;
+  };
+
+  const recover = async (retryAfterMs = 0) => {
+    closeSocket('recovering stream read');
+    opened = false;
+    outstandingCredit = 0;
+    if (retryAfterMs > 0) {
+      await wait(Math.min(retryAfterMs, MAX_RETRY_AFTER_MS));
+    }
+    if (cancelled || terminal) return;
+    if (reconnects++ >= MAX_WS_RECONNECTS) {
+      await switchToHttp();
+      return;
+    }
+    await safeConnect(expected);
+  };
+
+  const handleFrame = async (raw: Uint8Array) => {
+    const frame = await decodeOne(raw);
+    const { meta, body } = parseStreamReadWsServerFrame(frame.meta, frame.body);
+    if (cancelled && meta.type !== 'cancel_ack') return;
+    if (meta.type === 'opened') {
+      if (opened || meta.requestedStartIndex !== expected) {
+        throw new Error('unexpected stream read opened frame');
+      }
+      activated = true;
+      opened = true;
+      expected = meta.resolvedStartIndex;
+      outstandingCredit = 1;
+      restoreCreditWindow();
+      return;
+    }
+    // Initialization may fail before a position can be opened.
+    if (meta.type === 'error') {
+      terminal = true;
+      closeSocket('fatal stream read error');
+      controller.error(
+        new Error(
+          `stream read failed (${meta.status}/${meta.code}): ${meta.message ?? ''}`
+        )
+      );
+      notifyPull();
+      return;
+    }
+    if (!opened)
+      throw new Error(`stream read ${meta.type} arrived before opened`);
+    if (meta.type === 'chunk') {
+      outstandingCredit = Math.max(0, outstandingCredit - 1);
+      if (meta.index < expected) {
+        restoreCreditWindow();
+        return;
+      }
+      if (meta.index > expected) {
+        await recover();
+        return;
+      }
+      expected++;
+      // The retry budget counts consecutive reconnects without forward
+      // progress, not normal rotations over a long-lived reader.
+      reconnects = 0;
+      controller.enqueue(body);
+      restoreCreditWindow();
+      notifyPull();
+      return;
+    }
+    if (meta.type === 'eof') {
+      if (expected >= meta.nextIndex) {
+        terminal = true;
+        closeSocket('stream complete');
+        controller.close();
+        notifyPull();
+      } else {
+        await recover();
+      }
+      return;
+    }
+    if (meta.type === 'end') {
+      await recover(meta.retryAfterMs);
+      return;
+    }
+    if (meta.type === 'cancel_ack') {
+      if (meta.reqId === cancelReqId - 1) cancelAck?.();
+    }
+  };
+
+  async function safeConnect(index: number): Promise<void> {
+    try {
+      await connect(index);
+    } catch {
+      // Dynamic ws loading, header construction, or any other pre-OPEN failure
+      // is safe to decline to the mandatory compatibility transport.
+      if (!cancelled && !terminal) await switchToHttp();
+    }
+  }
+
+  async function connect(index: number): Promise<void> {
+    const [{ WebSocket: WebSocketImpl }, http] = await Promise.all([
+      import('ws'),
+      getHttpConfig(config),
+    ]);
+    if (cancelled || terminal) return;
+    if (http.usingProxy) {
+      await switchToHttp();
+      return;
+    }
+    const url = getStreamReadWsProtocolV1Url(
+      http.baseUrl,
+      runId,
+      name,
+      index,
+      readerId
+    );
+    await withHttpClientSpan(
+      {
+        method: 'GET',
+        url: url.toString(),
+        spanName: 'workflow.stream.read.ws.connect',
+      },
+      async () => {
+        await injectTraceContextIntoHeaders(http.headers);
+        if (cancelled || terminal) return;
+        const ws = new WebSocketImpl(url, {
+          headers: headersToRecord(http.headers),
+        });
+        socket = ws;
+        ws.binaryType = 'nodebuffer';
+        let settled = false;
+        await new Promise<void>((resolve) => {
+          const finish = () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve();
+          };
+          const fallback = () => {
+            void switchToHttp().then(finish, (error) => {
+              terminal = true;
+              finish();
+              controller.error(error);
+            });
+          };
+          const timer = setTimeout(() => {
+            closeSocket('connect budget expired');
+            fallback();
+          }, STREAM_READ_WS_CONNECT_BUDGET_MS);
+          timer.unref?.();
+          ws.once('open', () => {
+            if (socket !== ws || cancelled || terminal) {
+              ws.close(1000, 'superseded stream reader');
+              finish();
+              return;
+            }
+            finish();
+          });
+          ws.once('unexpected-response', (_request, response) => {
+            const res = response as {
+              resume?: () => void;
+              destroy?: () => void;
+            };
+            res.resume?.();
+            res.destroy?.();
+            if (socket === ws) fallback();
+            else finish();
+          });
+          ws.once('error', () => {
+            if (socket === ws && !opened) fallback();
+          });
+          ws.once('close', () => {
+            if (!settled) {
+              if (socket === ws) fallback();
+              else finish();
+            } else if (!cancelled && !terminal && socket === ws) {
+              void recover().catch((error) => controller.error(error));
+            }
+          });
+          ws.on('message', (raw) => {
+            inbound = inbound
+              .then(() => {
+                // Frames queued before recovery may arrive after a replacement
+                // socket owns the logical reader. Only the current attempt may
+                // mutate expected or terminate the stream.
+                if (socket !== ws || terminal) return;
+                return handleFrame(asBytes(raw));
+              })
+              .catch((error) => {
+                terminal = true;
+                closeSocket('stream read protocol error');
+                controller.error(error);
+              });
+          });
+        });
+      }
+    );
+  }
+
+  const cancel = async (reason?: unknown) => {
+    cancelled = true;
+    if (retryTimer) clearTimeout(retryTimer);
+    retryResolve?.();
+    await httpReader?.cancel(reason).catch(() => undefined);
+    if (!socket || socket.readyState !== 1 || !opened) {
+      closeSocket('reader cancelled');
+      return;
+    }
+    const reqId = cancelReqId++;
+    const acknowledged = new Promise<void>((resolve) => {
+      cancelAck = resolve;
+    });
+    socket.send(
+      encodeStreamReadWsControl({
+        type: 'cancel',
+        reqId,
+        ...(typeof reason === 'string' ? { reason } : {}),
+      })
+    );
+    await Promise.race([acknowledged, wait(STREAM_READ_WS_CANCEL_BUDGET_MS)]);
+    closeSocket('reader cancelled');
+  };
+
+  return new ReadableStream<Uint8Array>(
+    {
+      start(value) {
+        controller = value;
+      },
+      async pull() {
+        if (terminal || cancelled) return;
+        const delivered = waitForDelivery();
+        if (!started) {
+          started = true;
+          await safeConnect(startIndex);
+        } else if (httpReader) {
+          await pumpRawHttpReader();
+        } else if (opened) {
+          restoreCreditWindow();
+        }
+        if (!terminal && !cancelled) await delivered;
+      },
+      cancel,
+    },
+    { highWaterMark: MAX_OUTSTANDING_CREDIT }
+  );
+}

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -126,6 +126,7 @@ export {
 export type * from './shared.js';
 export type {
   GetChunksOptions,
+  GetStreamInfoOptions,
   StreamChunk,
   StreamChunksResponse,
   StreamInfoResponse,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -29,6 +29,7 @@ import type {
 } from './runs.js';
 import type {
   GetChunksOptions,
+  GetStreamInfoOptions,
   PaginatedResponse,
   StreamChunksResponse,
   StreamInfoResponse,
@@ -154,7 +155,11 @@ export interface Streamer {
      * @param runId - The workflow run ID that owns the stream
      * @param name - The stream name/ID
      */
-    getInfo(runId: string, name: string): Promise<StreamInfoResponse>;
+    getInfo(
+      runId: string,
+      name: string,
+      options?: GetStreamInfoOptions
+    ): Promise<StreamInfoResponse>;
   };
 }
 

--- a/packages/world/src/shared.ts
+++ b/packages/world/src/shared.ts
@@ -85,13 +85,20 @@ export interface StreamChunk {
 export interface GetChunksOptions {
   /** Maximum number of chunks to return per page (default: 100, max: 1000) */
   limit?: number;
-  /** Opaque cursor from a previous response to fetch the next page */
+  /** Opaque cursor from a previous response; mutually exclusive with startIndex. */
   cursor?: string;
+  /** Absolute first chunk index for an initial page; mutually exclusive with cursor. */
+  startIndex?: number;
 }
 
 /**
  * Metadata about a stream, returned by {@link Streamer.getStreamInfo}.
  */
+export interface GetStreamInfoOptions {
+  /** Resolve this requested position using the server's authoritative state. */
+  startIndex?: number;
+}
+
 export interface StreamInfoResponse {
   /**
    * The index of the last known chunk (0-based).
@@ -100,6 +107,8 @@ export interface StreamInfoResponse {
   tailIndex: number;
   /** Whether the stream is fully complete (closed). */
   done: boolean;
+  /** Authoritative absolute position when a startIndex was requested. */
+  resolvedStartIndex?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation

One credit-driven logical reader that survives WebSocket attempts: absolute durable indexes are carried across reconnects, so a replacement socket resumes at the exact chunk the previous attempt stopped on rather than replaying from zero.

- `GetChunksOptions.startIndex` lets an HTTP page start at an absolute durable index instead of only an opaque cursor; the two are rejected together.
- Once a WebSocket has opened, the fallback reads indexed HTTP pages and errors on an index gap, so recovery can't silently skip durable chunks; before that, it declines to the raw HTTP stream.

## Test Plan

Focused WebSocket read-session and indexed-fallback tests, plus the full `@workflow/world-vercel` suite, typecheck, and build.
