### PR TITLE
feat(streams): add resumable WebSocket reads

### DIFF
--- a/.changeset/ws-stream-read-resume.md
+++ b/.changeset/ws-stream-read-resume.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Add the default-off WebSocket stream read transport with single-owner resumable recovery.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -289,6 +289,13 @@ Platform-provided values such as `VERCEL_DEPLOYMENT_ID`, `VERCEL_PROJECT_ID`, an
 - Experimental stream-write transport capability. Set to exactly `ws` to attempt `workflow-stream-ws/v1`. The server authoritatively accepts or declines each upgrade; a decline uses HTTP directly for that writer lifetime. Stream reads remain HTTP and demand-driven.
 - This is not tenant rollout policy or a package-version check. HTTP remains the compatibility path. `/websockets/v1` is independent of REST v2/v4 and persisted workflow `specVersion` values.
 
+### `WORKFLOW_STREAM_READS_TRANSPORT`
+
+- Factory option: none
+- CLI flag: none
+- Default: `http`
+- Experimental. Set to exactly `ws` to attempt the dedicated `workflow-stream-read-ws/v1` transport. The server authoritatively accepts or declines each reader upgrade. Pre-open declines and recoverable interruptions use indexed HTTP pages with server-authoritative start-position resolution, so an interrupted body cannot be mistaken for completion. Reads never share writer or event sockets.
+
 ### `WORKFLOW_DISABLE_ANALYTICS_READS`
 
 - Factory option: none

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -210,6 +210,12 @@ Writes and close requests execute serially. The first operation waits up to 250 
 
 Before routine authentication expiry or server max duration, the server sends a v1 `drain` control. The client stops sending, lets an already-admitted request receive its reply, and reconnects after the server closes with code 1001. Authentication drains re-resolve a fresh bearer. A request that was sent but receives no reply before close still has an unknown outcome and is never replayed.
 
+### `WORKFLOW_STREAM_READS_TRANSPORT`
+
+Experimental WebSocket stream reads. Default: `http`. Set `WORKFLOW_STREAM_READS_TRANSPORT=ws` to attempt the dedicated `workflow-stream-read-ws/v1` endpoint. The server authoritatively accepts or declines each upgrade; pre-open declines and recoverable interruptions use indexed HTTP pages with server-authoritative start-position resolution, so an interrupted body cannot be mistaken for completion.
+
+After the WebSocket resolves an absolute position, the logical reader owns recovery: indexed chunks are delivered contiguously, duplicates are ignored, gaps and recoverable ends reconnect from the next expected index, and only explicit verified EOF completes the stream. After bounded WebSocket retries it uses indexed HTTP pages rather than inferring durable chunk indexes from raw network read boundaries. Reads never share writer or event sockets.
+
 ### `WORKFLOW_EVENTS_TRANSPORT`
 
 Workflow run events ship to the Vercel World over a WebSocket instead of one HTTP request each. Default: `ws`.

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -103,6 +103,26 @@ describe('createReconnectingFramedStream', () => {
     setWorld(undefined as unknown as World);
   });
 
+  it('delegates interruption recovery to a resumable World reader', async () => {
+    const get = vi.fn();
+    const getResumable = vi.fn(async () =>
+      scriptedStream([
+        { kind: 'value', value: payloadFrame(1) },
+        { kind: 'error', err: new Error('resumable reader exhausted') },
+      ])
+    );
+    setWorld({
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: { get, getResumable },
+    } as unknown as World);
+
+    await expect(
+      readAll(createReconnectingFramedStream(RUN_ID, 's', 0))
+    ).rejects.toThrow('resumable reader exhausted');
+    expect(getResumable).toHaveBeenCalledTimes(1);
+    expect(get).not.toHaveBeenCalled();
+  });
+
   it('passes through complete frames and closes cleanly on EOF', async () => {
     const { world, calls } = makeWorldWithScriptedStreams({
       0: () =>

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -787,7 +787,10 @@ export class WorkflowServerReadableStream extends ReadableStream<Uint8Array> {
           if (readStart === undefined) readStart = Date.now();
           const world = await getWorldLazy();
           const connectStart = Date.now();
-          const stream = await world.streams.get(runId, name, startIndex);
+          const getStream =
+            world.streams.getResumable?.bind(world.streams) ??
+            world.streams.get.bind(world.streams);
+          const stream = await getStream(runId, name, startIndex);
           connectMs = Date.now() - connectStart;
           reader = this.#reader = stream.getReader();
         }
@@ -928,6 +931,7 @@ export function createReconnectingFramedStream(
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let canceled = false;
   let cancelReason: unknown;
+  let worldOwnsRecovery = false;
   let buffer = new Uint8Array(0);
   // Read telemetry (same semantics as WorkflowServerReadableStream):
   // dispatch time, first-connect duration, first-frame latch, and totals.
@@ -965,7 +969,11 @@ export function createReconnectingFramedStream(
       ? currentStartIndex + consumedFrames
       : startIndex;
     const connectStart = Date.now();
-    const stream = await world.streams.get(runId, name, effectiveStartIndex);
+    const getStream =
+      world.streams.getResumable?.bind(world.streams) ??
+      world.streams.get.bind(world.streams);
+    worldOwnsRecovery = world.streams.getResumable !== undefined;
+    const stream = await getStream(runId, name, effectiveStartIndex);
     if (canceled) {
       await stream.cancel(cancelReason).catch(() => {});
       return false;
@@ -1072,7 +1080,7 @@ export function createReconnectingFramedStream(
           result = await reader!.read();
         } catch (err) {
           if (canceled) return;
-          if (!reconnectSupported) {
+          if (worldOwnsRecovery || !reconnectSupported) {
             controller.error(err);
             return;
           }
@@ -1096,7 +1104,9 @@ export function createReconnectingFramedStream(
           // EOF), and a completed stream can still be cut mid-body; both
           // would otherwise be silently read as a shorter, complete stream.
           const verifiedComplete =
-            !reconnectSupported || (await isVerifiedComplete());
+            worldOwnsRecovery ||
+            !reconnectSupported ||
+            (await isVerifiedComplete());
           if (canceled) return;
           if (!verifiedComplete) {
             try {

--- a/packages/world-vercel/src/streamer.test.ts
+++ b/packages/world-vercel/src/streamer.test.ts
@@ -212,6 +212,15 @@ describe('stream writer session capability', () => {
   });
 });
 
+describe('stream reader capability', () => {
+  it('exposes the resumable reader only for the exact read opt-in', async () => {
+    const { createStreamer } = await import('./streamer.js');
+    expect(createStreamer().streams.getResumable).toBeUndefined();
+    vi.stubEnv('WORKFLOW_STREAM_READS_TRANSPORT', 'ws');
+    expect(createStreamer().streams.getResumable).toBeTypeOf('function');
+  });
+});
+
 describe('session HTTP fallback', () => {
   it('paginates with the configured request-work cap', async () => {
     vi.stubEnv('WORKFLOW_MAX_CHUNKS_PER_REQUEST', '2');
@@ -232,6 +241,27 @@ describe('session HTTP fallback', () => {
         (call) => (call[1]?.body as Uint8Array).byteLength
       )
     ).toEqual([10, 5]);
+  });
+});
+
+describe('streams.getInfo', () => {
+  it('requests and parses authoritative start-index resolution', async () => {
+    const { makeRequest } = await import('./utils.js');
+    vi.mocked(makeRequest).mockResolvedValueOnce({
+      tailIndex: 5,
+      done: false,
+      resolvedStartIndex: 4,
+    });
+    const { createStreamer } = await import('./streamer.js');
+
+    await expect(
+      createStreamer().streams.getInfo('run-123', 'stream', { startIndex: -2 })
+    ).resolves.toMatchObject({ resolvedStartIndex: 4 });
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: expect.stringContaining('startIndex=-2'),
+      })
+    );
   });
 });
 

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -42,8 +42,12 @@ import {
   type HttpConfig,
   makeRequest,
 } from './utils.js';
+import { createStreamReadWsSession } from './ws-stream-read-session.js';
 import { createStreamWriteSession } from './ws-stream-session.js';
-import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
+import {
+  isWsStreamReadsTransportEnabled,
+  isWsStreamsTransportEnabled,
+} from './ws-transport-enabled.js';
 
 /**
  * Maximum number of chunks per request, matching the server-side
@@ -263,6 +267,106 @@ export async function closeStreamSessionOverHttp(
   await response.text();
 }
 
+async function getStreamOverHttp(
+  runId: string,
+  name: string,
+  startIndex: number | undefined,
+  config: APIConfig | undefined
+): Promise<ReadableStream<Uint8Array>> {
+  const httpConfig = await getHttpConfig(config);
+  httpConfig.headers.set('Accept', 'application/json');
+  const url = getStreamReadUrl(name, runId, httpConfig);
+  if (typeof startIndex === 'number') {
+    url.searchParams.set('startIndex', String(startIndex));
+  }
+  const response = await instrumentedFetch({
+    method: 'GET',
+    url: url.toString(),
+    headers: httpConfig.headers,
+    dispatcher: undefined,
+    timeoutMs: null,
+    transportErrorCode: 'STREAM_ERROR',
+    logLabel: url.pathname,
+    spanName: 'workflow.stream.read.connect',
+    attributes: streamSpanAttributes({
+      runId,
+      name,
+      operation: 'read',
+      startIndex,
+    }),
+    buildError: createStreamReadError,
+  });
+  if (!response.body) {
+    throw new StreamError('No response body for stream', {
+      url: url.toString(),
+    });
+  }
+  return response.body as ReadableStream<Uint8Array>;
+}
+
+async function getStreamChunksOverHttp(
+  runId: string,
+  name: string,
+  options: GetChunksOptions | undefined,
+  config: APIConfig | undefined
+): Promise<StreamChunksResponse> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.cursor && options.startIndex !== undefined) {
+    throw new Error(
+      'stream chunks cursor and startIndex are mutually exclusive'
+    );
+  }
+  if (options?.cursor) params.set('cursor', options.cursor);
+  if (options?.startIndex !== undefined) {
+    if (!Number.isSafeInteger(options.startIndex) || options.startIndex < 0) {
+      throw new Error(
+        'stream chunks startIndex must be a nonnegative safe integer'
+      );
+    }
+    params.set('startIndex', String(options.startIndex));
+  }
+  const qs = params.toString();
+  const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/chunks${qs ? `?${qs}` : ''}`;
+  try {
+    return await makeRequest({
+      endpoint,
+      config,
+      schema: StreamChunksResponseSchema,
+    });
+  } catch (cause) {
+    throw toStreamError(`Failed to read stream chunks for ${name}`, cause);
+  }
+}
+
+async function getStreamInfoOverHttp(
+  runId: string,
+  name: string,
+  options: GetStreamInfoOptions | undefined,
+  config: APIConfig | undefined
+): Promise<StreamInfoResponse> {
+  if (
+    options?.startIndex !== undefined &&
+    !Number.isSafeInteger(options.startIndex)
+  ) {
+    throw new Error('stream info startIndex must be a safe integer');
+  }
+  const query =
+    options?.startIndex === undefined
+      ? ''
+      : `?startIndex=${encodeURIComponent(String(options.startIndex))}`;
+  const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/info${query}`;
+  try {
+    return await makeRequest({
+      endpoint,
+      config,
+      schema: StreamInfoResponseSchema,
+    });
+  } catch (cause) {
+    throw toStreamError(`Failed to read stream info for ${name}`, cause);
+  }
+}
+
 /** Creates the HTTP-backed streamer that talks to workflow-server. */
 export function createStreamer(config?: APIConfig): Streamer {
   return {
@@ -402,90 +506,48 @@ export function createStreamer(config?: APIConfig): Streamer {
       },
 
       async get(runId: string, name: string, startIndex?: number) {
-        const httpConfig = await getHttpConfig(config);
-        // Stream bytes themselves are untyped binary, but any pre-header error
-        // is a JSON envelope. Asking explicitly avoids a CBOR 410 that this
-        // binary response path cannot decode while leaving successful stream
-        // bodies unchanged.
-        httpConfig.headers.set('Accept', 'application/json');
-        const url = getStreamReadUrl(name, runId, httpConfig);
-        if (typeof startIndex === 'number') {
-          url.searchParams.set('startIndex', String(startIndex));
-        }
-        // The `.connect` span covers dispatch → response headers (the
-        // network-connect portion). The end-to-end time-to-first-chunk span
-        // (`workflow.stream.read`) is emitted from the core reader
-        // (`WorkflowServerReadableStream`) when the first chunk reaches the
-        // consumer, so it includes deframing and doesn't need a wrapper here.
-        // Live read: keep the global dispatcher and no request timeout so the
-        // long-lived, reconnecting read isn't truncated.
-        const response = await instrumentedFetch({
-          method: 'GET',
-          url: url.toString(),
-          headers: httpConfig.headers,
-          dispatcher: undefined,
-          timeoutMs: null,
-          transportErrorCode: 'STREAM_ERROR',
-          logLabel: url.pathname,
-          spanName: 'workflow.stream.read.connect',
-          attributes: streamSpanAttributes({
-            runId,
-            name,
-            operation: 'read',
-            startIndex,
-          }),
-          buildError: createStreamReadError,
-        });
-        if (!response.body) {
-          throw new StreamError('No response body for stream', {
-            url: url.toString(),
-          });
-        }
-        return response.body as ReadableStream<Uint8Array>;
+        return getStreamOverHttp(runId, name, startIndex, config);
       },
+
+      ...(isWsStreamReadsTransportEnabled()
+        ? {
+            async getResumable(runId: string, name: string, startIndex = 0) {
+              return createStreamReadWsSession(
+                runId,
+                name,
+                startIndex,
+                config,
+                {
+                  resolveStartIndex: async (index) => {
+                    const info = await getStreamInfoOverHttp(
+                      runId,
+                      name,
+                      { startIndex: index },
+                      config
+                    );
+                    if (info.resolvedStartIndex === undefined) {
+                      throw new Error(
+                        'stream info omitted resolvedStartIndex for indexed fallback'
+                      );
+                    }
+                    return info.resolvedStartIndex;
+                  },
+                  getChunks: (options) =>
+                    getStreamChunksOverHttp(runId, name, options, config),
+                  getInfo: () =>
+                    getStreamInfoOverHttp(runId, name, undefined, config),
+                }
+              );
+            },
+          }
+        : {}),
 
       async getChunks(
         runId: string,
         name: string,
         options?: GetChunksOptions
       ): Promise<StreamChunksResponse> {
-        const params = new URLSearchParams();
-        if (options?.limit != null) {
-          params.set('limit', String(options.limit));
-        }
-        if (options?.cursor && options.startIndex !== undefined) {
-          throw new Error(
-            'stream chunks cursor and startIndex are mutually exclusive'
-          );
-        }
-        if (options?.cursor) {
-          params.set('cursor', options.cursor);
-        }
-        if (options?.startIndex !== undefined) {
-          if (
-            !Number.isSafeInteger(options.startIndex) ||
-            options.startIndex < 0
-          ) {
-            throw new Error(
-              'stream chunks startIndex must be a nonnegative safe integer'
-            );
-          }
-          params.set('startIndex', String(options.startIndex));
-        }
-        const qs = params.toString();
-        const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/chunks${qs ? `?${qs}` : ''}`;
-        try {
-          return await makeRequest({
-            endpoint,
-            config,
-            schema: StreamChunksResponseSchema,
-          });
-        } catch (cause) {
-          throw toStreamError(
-            `Failed to read stream chunks for ${name}`,
-            cause
-          );
-        }
+        return getStreamChunksOverHttp(runId, name, options, config);
       },
 
       async getInfo(
@@ -493,20 +555,7 @@ export function createStreamer(config?: APIConfig): Streamer {
         name: string,
         options?: GetStreamInfoOptions
       ): Promise<StreamInfoResponse> {
-        const query =
-          options?.startIndex === undefined
-            ? ''
-            : `?startIndex=${encodeURIComponent(String(options.startIndex))}`;
-        const endpoint = `/v2/runs/${encodeURIComponent(runId)}/streams/${encodeURIComponent(name)}/info${query}`;
-        try {
-          return await makeRequest({
-            endpoint,
-            config,
-            schema: StreamInfoResponseSchema,
-          });
-        } catch (cause) {
-          throw toStreamError(`Failed to read stream info for ${name}`, cause);
-        }
+        return getStreamInfoOverHttp(runId, name, options, config);
       },
 
       async list(runId: string) {

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -364,6 +364,43 @@ describe('ws stream transport upgrade trace propagation', () => {
   });
 });
 
+describe('ws stream read upgrade trace propagation', () => {
+  afterEach(() => {
+    wsUpgrades.length = 0;
+  });
+
+  it('injects traceparent from its dedicated read connect span', async () => {
+    const { createStreamReadWsSession } = await import(
+      './ws-stream-read-session.js'
+    );
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'user',
+      0,
+      { token: 'test-token' },
+      {
+        resolveStartIndex: async (startIndex) => startIndex,
+        getChunks: async () => ({
+          data: [],
+          cursor: null,
+          hasMore: false,
+          done: true,
+        }),
+        getInfo: async () => ({ tailIndex: -1, done: true }),
+      }
+    );
+    const reader = stream.getReader();
+    void reader.read();
+    await vi.waitFor(() => expect(wsUpgrades).toHaveLength(1));
+
+    expect(wsUpgrades[0]?.headers.traceparent).toMatch(
+      /^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/
+    );
+    expect(wsUpgrades[0]?.headers.authorization).toBe('Bearer test-token');
+    await reader.cancel();
+  });
+});
+
 describe('ws events transport upgrade trace propagation', () => {
   // `openWsChannel` is gated, unlike the `resolveWsTransport` lookup it
   // replaced: nothing opens a channel on the HTTP default.

--- a/packages/world-vercel/src/ws-stream-read-session.test.ts
+++ b/packages/world-vercel/src/ws-stream-read-session.test.ts
@@ -44,9 +44,14 @@ const { FakeWebSocket, sockets } = vi.hoisted(() => {
     close(code = 1000, reason = ''): void {
       this.readyState = 3;
       this.closed.push([code, reason]);
+      queueMicrotask(() => this.emit('close', code));
     }
     reply(meta: Record<string, unknown>, body = new Uint8Array()): void {
       this.emit('message', encodeFrame(meta, body));
+    }
+    peerClose(): void {
+      this.readyState = 3;
+      this.emit('close', 1000);
     }
   }
   return { FakeWebSocket: FakeSocket, sockets };
@@ -304,6 +309,26 @@ describe('stream read WebSocket session', () => {
     const { reading, socket } = await open(stream, 10);
     socket.reply({ type: 'eof', finalIndex: 4, nextIndex: 5 });
     await expect(reading).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it('does not wait the cleanup budget when close follows queued EOF', async () => {
+    const stream = createStreamReadWsSession(
+      'wrun_1',
+      'stream',
+      0,
+      { token: 'token' },
+      makeFallbacks()
+    );
+    const { reading, socket } = await open(stream);
+    socket.reply({ type: 'eof', finalIndex: -1, nextIndex: 0 });
+    socket.peerClose();
+
+    await expect(
+      Promise.race([
+        reading,
+        new Promise((resolve) => setTimeout(() => resolve('timed out'), 100)),
+      ])
+    ).resolves.toEqual({ done: true, value: undefined });
   });
 
   it('treats fatal error as terminal', async () => {

--- a/packages/world-vercel/src/ws-stream-read-session.ts
+++ b/packages/world-vercel/src/ws-stream-read-session.ts
@@ -17,6 +17,7 @@ import {
 import { injectTraceContextIntoHeaders } from './telemetry.js';
 import type { APIConfig } from './utils.js';
 import { getHttpConfig } from './utils.js';
+import { beginNormalWsClose } from './ws-stream-connect.js';
 
 export const STREAM_READ_WS_CONNECT_BUDGET_MS = 250;
 export const STREAM_READ_WS_CANCEL_BUDGET_MS = 250;
@@ -212,7 +213,11 @@ export function createStreamReadWsSession(
     if (meta.type === 'eof') {
       if (expected >= meta.nextIndex) {
         terminal = true;
-        closeSocket('stream complete');
+        const closingSocket = socket;
+        socket = undefined;
+        if (closingSocket) {
+          beginNormalWsClose(closingSocket, 'stream complete');
+        }
         controller.close();
         notifyPull();
       } else {
@@ -315,8 +320,15 @@ export function createStreamReadWsSession(
             if (!settled) {
               if (socket === ws) fallback();
               else finish();
-            } else if (!cancelled && !terminal && socket === ws) {
-              void recover().catch((error) => controller.error(error));
+            } else {
+              // A peer may queue EOF immediately before close. Let every frame
+              // already delivered by this socket decode before deciding that
+              // the logical reader needs recovery.
+              void inbound.then(() => {
+                if (!cancelled && !terminal && socket === ws) {
+                  return recover().catch((error) => controller.error(error));
+                }
+              });
             }
           });
           ws.on('message', (raw) => {
@@ -360,7 +372,11 @@ export function createStreamReadWsSession(
       })
     );
     await Promise.race([acknowledged, wait(STREAM_READ_WS_CANCEL_BUDGET_MS)]);
-    closeSocket('reader cancelled');
+    const closingSocket = socket;
+    socket = undefined;
+    if (closingSocket) {
+      beginNormalWsClose(closingSocket, 'reader cancelled');
+    }
   };
 
   return new ReadableStream<Uint8Array>(

--- a/packages/world-vercel/src/ws-streams-transport-enabled.test.ts
+++ b/packages/world-vercel/src/ws-streams-transport-enabled.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
+import {
+  isWsStreamReadsTransportEnabled,
+  isWsStreamsTransportEnabled,
+} from './ws-transport-enabled.js';
 
 afterEach(() => {
   delete process.env.WORKFLOW_STREAMS_TRANSPORT;
+  delete process.env.WORKFLOW_STREAM_READS_TRANSPORT;
 });
 
 describe('isWsStreamsTransportEnabled', () => {
@@ -22,5 +26,23 @@ describe('isWsStreamsTransportEnabled', () => {
     }
 
     expect(isWsStreamsTransportEnabled()).toBe(expected);
+  });
+});
+
+describe('isWsStreamReadsTransportEnabled', () => {
+  it.each([
+    [undefined, false],
+    ['', false],
+    ['http', false],
+    ['WS', false],
+    ['ws', true],
+  ])('advertises read v1 only for the exact ws value: %j', (value, expected) => {
+    if (value === undefined) {
+      delete process.env.WORKFLOW_STREAM_READS_TRANSPORT;
+    } else {
+      process.env.WORKFLOW_STREAM_READS_TRANSPORT = value;
+    }
+
+    expect(isWsStreamReadsTransportEnabled()).toBe(expected);
   });
 });

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -70,3 +70,8 @@ export function isWsEventsTransportStrict(): boolean {
 export function isWsStreamsTransportEnabled(): boolean {
   return process.env.WORKFLOW_STREAMS_TRANSPORT === 'ws';
 }
+
+/** Read transport capability is independently default-off. */
+export function isWsStreamReadsTransportEnabled(): boolean {
+  return process.env.WORKFLOW_STREAM_READS_TRANSPORT === 'ws';
+}

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -125,6 +125,17 @@ export interface Streamer {
       startIndex?: number
     ): Promise<ReadableStream<Uint8Array>>;
 
+    /**
+     * Optional logical reader that owns transport interruption recovery and
+     * closes only at verified stream completion. Core must not wrap it in a
+     * second reconnect owner.
+     */
+    getResumable?(
+      runId: string,
+      name: string,
+      startIndex?: number
+    ): Promise<ReadableStream<Uint8Array>>;
+
     list(runId: string): Promise<string[]>;
 
     /**


### PR DESCRIPTION
## Summary & Motivation

- `Streamer.streams.getResumable` — an optional World reader that owns interruption recovery itself, so core's reconnecting readers hand off to it instead of stacking a second recovery owner on top.
- `WORKFLOW_STREAM_READS_TRANSPORT=ws` opts world-vercel into the dedicated `workflow-stream-read-ws/v1` reader, gated separately from stream writes so reads never share the writer socket.

## Test Plan

Covered by new unit tests: the core handoff, the read gate, and traceparent injection on the read upgrade. Manual runs of the focused world-vercel and core suites passed; the root build is blocked locally by a missing Rust toolchain for the unrelated SWC plugin.
