### PR TITLE
fix(builders): shim __dirname/__filename in fully-bundled ESM output

### DIFF
--- a/.changeset/esm-dirname-filename-shim.md
+++ b/.changeset/esm-dirname-filename-shim.md
@@ -1,0 +1,5 @@
+---
+'@workflow/builders': patch
+---
+
+Shim `__dirname`/`__filename` in fully-bundled ESM output so CJS dependencies that reference them at module scope (e.g. `google-gax`) no longer crash the deployed function at init with `ReferenceError: __dirname is not defined in ES module scope`.

--- a/.changeset/esm-dirname-filename-shim.md
+++ b/.changeset/esm-dirname-filename-shim.md
@@ -3,3 +3,5 @@
 ---
 
 Shim `__dirname`/`__filename` in fully-bundled ESM output so CJS dependencies that reference them at module scope (e.g. `google-gax`) no longer crash the deployed function at init with `ReferenceError: __dirname is not defined in ES module scope`.
+
+CJS dependencies that feature-detect with `typeof __dirname !== 'undefined'` will now take their CJS branch, where `__dirname` resolves to the function root rather than the dependency's original directory.

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -921,10 +921,19 @@ export const __steps_registered = true;
     rewriteTsExtensions?: boolean;
     discoveredEntries?: DiscoveredEntries;
     /**
-     * When true, skip the `createRequire` banner on the steps bundle.
-     * Used by `createCombinedBundle` with `bundleFinalOutput: true` where
-     * the outer esbuild pass provides its own banner, preventing the
+     * When true, skip the ESM interop banner on the steps bundle. Despite the
+     * name, that banner declares `require`, `__filename` *and* `__dirname`, so
+     * skipping it drops all three.
+     *
+     * Used by `createCombinedBundle` with `bundleFinalOutput: true`, where the
+     * outer esbuild pass provides its own banner, preventing the
      * `__createRequire` identifier from being declared twice after inlining.
+     *
+     * Do not reach for this to silence a duplicate `require` declaration
+     * introduced elsewhere (see #3778): it also removes the
+     * `__dirname`/`__filename` shim, reintroducing `ReferenceError: __dirname
+     * is not defined in ES module scope` for CJS dependencies that reference
+     * those at module scope.
      */
     skipEsmRequireBanner?: boolean;
   }): Promise<{

--- a/packages/builders/src/base-builder.ts
+++ b/packages/builders/src/base-builder.ts
@@ -305,10 +305,24 @@ export abstract class BaseBuilder {
    * for Node.js builtins (e.g. debug → require('tty')) break because esbuild's
    * CJS-to-ESM __require shim doesn't have access to a real require function.
    * This banner provides one via createRequire so bundled CJS code works in ESM.
+   *
+   * Likewise, esbuild leaves the CJS globals `__dirname`/`__filename` as free
+   * identifiers when inlining CJS modules into ESM output, so dependencies that
+   * reference them at module scope (e.g. google-gax, Prisma's runtime) crash
+   * with `ReferenceError: __dirname is not defined in ES module scope` before
+   * any workflow code runs. The banner defines them from `import.meta.url`,
+   * pointing at the bundle location (the function root at runtime).
    */
   private getEsmRequireBanner(format: string): string {
     if (format !== 'esm') return '';
-    return 'import { createRequire as __createRequire } from "node:module";\nvar require = __createRequire(import.meta.url);\n';
+    return (
+      'import { createRequire as __createRequire } from "node:module";\n' +
+      'import { fileURLToPath as __fileURLToPath } from "node:url";\n' +
+      'import { dirname as __pathDirname } from "node:path";\n' +
+      'var require = __createRequire(import.meta.url);\n' +
+      'var __filename = __fileURLToPath(import.meta.url);\n' +
+      'var __dirname = __pathDirname(__filename);\n'
+    );
   }
 
   /**

--- a/packages/builders/src/vercel-build-output-api.test.ts
+++ b/packages/builders/src/vercel-build-output-api.test.ts
@@ -152,10 +152,20 @@ export async function gaxWorkflow(): Promise<string> {
       // The shim is declared exactly once: the inner steps bundle skips its
       // banner when the outer combined pass provides one
       // (skipEsmRequireBanner), so the import bindings don't collide.
+      //
+      // Note this only covers createCombinedBundle. The same banner is also
+      // emitted by createWorkflowsBundle's final wrapper and by
+      // createWebhookBundle, which are not exercised here.
       const bundle = await readFile(
         join(getFlowFuncDir(workingDir), 'index.mjs'),
         'utf8'
       );
+      // The import binding is the assertion that matters: a duplicated banner
+      // fails at parse time on the redeclared import, before the `var` ever
+      // runs.
+      expect(
+        bundle.match(/import \{ fileURLToPath as __fileURLToPath \}/g)
+      ).toHaveLength(1);
       expect(
         bundle.match(/var __dirname = __pathDirname\(__filename\);/g)
       ).toHaveLength(1);

--- a/packages/builders/src/vercel-build-output-api.test.ts
+++ b/packages/builders/src/vercel-build-output-api.test.ts
@@ -153,9 +153,9 @@ export async function gaxWorkflow(): Promise<string> {
       // banner when the outer combined pass provides one
       // (skipEsmRequireBanner), so the import bindings don't collide.
       //
-      // Note this only covers createCombinedBundle. The same banner is also
-      // emitted by createWorkflowsBundle's final wrapper and by
-      // createWebhookBundle, which are not exercised here.
+      // Note this covers createCombinedBundle and createWebhookBundle. The
+      // same banner is also emitted by createWorkflowsBundle's final wrapper,
+      // which is not exercised here.
       const bundle = await readFile(
         join(getFlowFuncDir(workingDir), 'index.mjs'),
         'utf8'
@@ -168,6 +168,24 @@ export async function gaxWorkflow(): Promise<string> {
       ).toHaveLength(1);
       expect(
         bundle.match(/var __dirname = __pathDirname\(__filename\);/g)
+      ).toHaveLength(1);
+
+      // The webhook route is a separately deployed function built by the same
+      // build() through its own esbuild pass (createWebhookBundle) — a CJS
+      // dependency referencing __dirname reachable from it would have crashed
+      // the same way, so it needs the shim too.
+      const webhookBundle = await readFile(
+        join(
+          workingDir,
+          '.vercel/output/functions/.well-known/workflow/v1/webhook/[token].func/index.mjs'
+        ),
+        'utf8'
+      );
+      expect(
+        webhookBundle.match(/import \{ fileURLToPath as __fileURLToPath \}/g)
+      ).toHaveLength(1);
+      expect(
+        webhookBundle.match(/var __dirname = __pathDirname\(__filename\);/g)
       ).toHaveLength(1);
     }
   );

--- a/packages/builders/src/vercel-build-output-api.test.ts
+++ b/packages/builders/src/vercel-build-output-api.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { VercelBuildOutputConfig } from './types.js';
+import { VercelBuildOutputAPIBuilder } from './vercel-build-output-api.js';
+
+const BUILD_TIMEOUT = 120_000;
+
+async function write(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, 'utf8');
+}
+
+function getFlowFuncDir(workingDir: string): string {
+  return join(
+    workingDir,
+    '.vercel/output/functions/.well-known/workflow/v1/flow.func'
+  );
+}
+
+function createBuilder(workingDir: string): VercelBuildOutputAPIBuilder {
+  const config: VercelBuildOutputConfig = {
+    buildTarget: 'vercel-build-output-api',
+    workingDir,
+    dirs: ['src'],
+    stepsBundlePath: join(workingDir, 'unused-steps.mjs'),
+    workflowsBundlePath: join(workingDir, 'unused-workflows.mjs'),
+    webhookBundlePath: join(workingDir, 'unused-webhook.mjs'),
+    suppressCreateManifestLogs: true,
+  };
+  return new VercelBuildOutputAPIBuilder(config);
+}
+
+function executeStep(workingDir: string, stepName: string): string {
+  const bundleUrl = pathToFileURL(
+    join(getFlowFuncDir(workingDir), 'index.mjs')
+  ).href;
+  const output = execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `await import(${JSON.stringify(bundleUrl)});
+const steps = globalThis[Symbol.for('@workflow/core//registeredSteps')];
+const step = [...steps].find(([id]) => id.endsWith(${JSON.stringify(`//${stepName}`)}))?.[1];
+if (!step) throw new Error(${JSON.stringify(`${stepName} step was not registered`)});
+process.stdout.write(JSON.stringify(await step()));`,
+    ],
+    { encoding: 'utf8' }
+  );
+  return JSON.parse(output);
+}
+
+/**
+ * Minimal stand-in for the `workflow` package so the builder can resolve
+ * its runtime imports inside the temp app.
+ */
+async function writeWorkflowRuntimeStub(workingDir: string): Promise<void> {
+  const packageDir = join(workingDir, 'node_modules/workflow');
+  await write(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: 'workflow',
+      version: '1.0.0',
+      type: 'module',
+      exports: {
+        './api': './api.js',
+        './internal/builtins': './internal/builtins.js',
+        './runtime': './runtime.js',
+      },
+    })
+  );
+  await write(
+    join(packageDir, 'api.js'),
+    'export async function resumeWebhook() { return new Response(null, { status: 204 }); }\n'
+  );
+  await write(
+    join(packageDir, 'internal/builtins.js'),
+    'export const __workflow_builtins = true;\n'
+  );
+  await write(
+    join(packageDir, 'runtime.js'),
+    'export function workflowEntrypoint() { return async function POST() { return new Response(null, { status: 204 }); }; }\n'
+  );
+}
+
+describe('VercelBuildOutputAPIBuilder ESM output', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(realpathSync(tmpdir()), 'workflow-vercel-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it(
+    'executes a bundled CJS dependency that references __dirname at module scope',
+    { timeout: BUILD_TIMEOUT },
+    async () => {
+      await writeWorkflowRuntimeStub(workingDir);
+
+      // google-gax-shaped fixture: a CJS package that computes a path from
+      // __dirname at module scope (google-gax/build/src/grpc.js does exactly
+      // this), which crashed the whole function at init with
+      // `ReferenceError: __dirname is not defined in ES module scope` when
+      // inlined into the ESM bundle without the banner shim.
+      const packageDir = join(workingDir, 'node_modules/fake-gax');
+      await write(
+        join(packageDir, 'package.json'),
+        JSON.stringify({ name: 'fake-gax', version: '1.0.0', main: 'index.js' })
+      );
+      await write(
+        join(packageDir, 'index.js'),
+        `const path = require('path');
+// Module-scope __dirname reference, like google-gax's grpc.js.
+const protoFilesDir = path.join(__dirname, '..', 'protos');
+exports.getProtoFilesDir = () => protoFilesDir;
+exports.getFilename = () => __filename;
+`
+      );
+      await write(
+        join(workingDir, 'src/workflows/gax.ts'),
+        `import { getProtoFilesDir, getFilename } from 'fake-gax';
+
+export async function readDirs(): Promise<string> {
+  'use step';
+  return [getProtoFilesDir(), getFilename()].every((p) => typeof p === 'string' && p.length > 0)
+    ? 'dirs-ok'
+    : 'dirs-missing';
+}
+
+export async function gaxWorkflow(): Promise<string> {
+  'use workflow';
+  return readDirs();
+}
+`
+      );
+
+      await createBuilder(workingDir).build();
+
+      // The bundle must be importable under plain Node (this is where the
+      // unshimmed bundle throws, before any workflow code runs) and the step
+      // must see defined __dirname/__filename values.
+      expect(executeStep(workingDir, 'readDirs')).toBe('dirs-ok');
+
+      // The shim is declared exactly once: the inner steps bundle skips its
+      // banner when the outer combined pass provides one
+      // (skipEsmRequireBanner), so the import bindings don't collide.
+      const bundle = await readFile(
+        join(getFlowFuncDir(workingDir), 'index.mjs'),
+        'utf8'
+      );
+      expect(
+        bundle.match(/var __dirname = __pathDirname\(__filename\);/g)
+      ).toHaveLength(1);
+    }
+  );
+});


### PR DESCRIPTION
### Problem

A customer upgrading from workflow v4 to v5 (`5.0.0-beta.46`) hit a hard init crash on every flow-route invocation:

```
ReferenceError: __dirname is not defined in ES module scope

google-gax@5.0.8/build/src/grpc.js
→ @google-cloud/pubsub@5.3.0
→ /var/task/index.mjs
```

The function dies with `Runtime.ExitError` before any workflow code runs, so the flow route returns 500 and runs sit in `pending` forever.

### Root cause

#1562 switched the Vercel Build Output API function from CJS (`index.js`) to a fully-bundled ESM `index.mjs`. esbuild wraps inlined CJS modules in `__commonJS` closures and our banner provides `require` via `createRequire`, but esbuild deliberately leaves the CJS globals `__dirname`/`__filename` as free identifiers in ESM output (evanw/esbuild#1921). `google-gax` is CJS-only (no ESM build exists) and computes a path from `__dirname` at module scope (`build/src/grpc.js:66`), so the whole bundle throws at import. v4 never hit this because the function was real CJS.

### Fix

Extend `getEsmRequireBanner` to also define `__filename`/`__dirname` from `import.meta.url` — the standard interop shim (tsup injects the same one for `format: esm` + `platform: node`). This is the shim already written and verified live (with `@prisma/client`, which fails the same way) in #2770; it's extracted here so the regression fix isn't blocked on that PR's larger runtime-asset-tracing work. The existing `skipEsmRequireBanner` dedup keeps it declared exactly once in the combined bundle.

The shimmed `__dirname` points at the function root, not each dep's original package directory — that's sufficient for pubsub (protos load via `require`d JSON, which esbuild inlines) and per-module-accurate asset paths remain #2770's territory.

### Test

New regression test builds a temp app through `VercelBuildOutputAPIBuilder` with a google-gax-shaped CJS dependency (module-scope `path.join(__dirname, ...)`), then imports the emitted `index.mjs` under plain Node and executes the step. On `main` it fails with exactly the production error; with the fix it passes. It also asserts the shim appears exactly once in the bundle.

Related: #2770, #1956.
