### PR TITLE
Stop logging on healthy workflow execution

### DIFF
--- a/.changeset/quiet-normal-execution-logs.md
+++ b/.changeset/quiet-normal-execution-logs.md
@@ -5,16 +5,4 @@
 '@workflow/world': patch
 ---
 
-Stop logging on healthy workflow execution. A successful run now prints nothing;
-the breadcrumbs that described it are behind `DEBUG=workflow:*`, alongside the
-existing HTTP and retry debug output. Warnings and errors are unchanged, so a
-run that actually goes wrong is no quieter than before.
-
-Most of this was fallout from defaulting the events transport to WebSockets:
-`world-vercel: using ws events transport (…)` ran once per cold start on every
-deployment, the `projectConfig` fallback warned on every CLI command, and the
-routine `max_duration` / `auth_expiry` drain notice printed on healthy
-long-lived runs. Also gated: `world-local`'s queue-concurrency notice,
-`@workflow/world`'s active-run recovery line, and the port-detection diagnostics
-in `@workflow/utils`, which keyed off `NODE_ENV=development` — the one
-environment that always reaches them.
+Stop logging on healthy workflow execution: the breadcrumbs that only described the runtime working correctly now print under `DEBUG=workflow:*`. Warnings and errors are unchanged.

--- a/.changeset/quiet-normal-execution-logs.md
+++ b/.changeset/quiet-normal-execution-logs.md
@@ -1,0 +1,20 @@
+---
+'@workflow/world-vercel': patch
+'@workflow/world-local': patch
+'@workflow/utils': patch
+'@workflow/world': patch
+---
+
+Stop logging on healthy workflow execution. A successful run now prints nothing;
+the breadcrumbs that described it are behind `DEBUG=workflow:*`, alongside the
+existing HTTP and retry debug output. Warnings and errors are unchanged, so a
+run that actually goes wrong is no quieter than before.
+
+Most of this was fallout from defaulting the events transport to WebSockets:
+`world-vercel: using ws events transport (…)` ran once per cold start on every
+deployment, the `projectConfig` fallback warned on every CLI command, and the
+routine `max_duration` / `auth_expiry` drain notice printed on healthy
+long-lived runs. Also gated: `world-local`'s queue-concurrency notice,
+`@workflow/world`'s active-run recovery line, and the port-detection diagnostics
+in `@workflow/utils`, which keyed off `NODE_ENV=development` — the one
+environment that always reaches them.

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -206,7 +206,7 @@ Workflow run events ship to the Vercel World over a WebSocket instead of one HTT
 
 Set `WORKFLOW_EVENTS_TRANSPORT=http` to opt out. Only that exact value disables the WebSocket — any other value, including unset or empty, takes it — so a typo fails toward the default rather than silently pinning a deployment to HTTP.
 
-The setting is ignored when the World is configured with `projectConfig` and therefore routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP and a warning is logged once per process.
+The setting is ignored when the World is configured with `projectConfig` and therefore routes through the `api-workflow` proxy: that endpoint is an HTTP-only REST gateway and does not forward a WebSocket upgrade, so events stay on HTTP. The fallback is silent — now that the WebSocket is the default, nothing asked for it — and is reported once per process under `DEBUG=workflow:*`. `workflow.events.transport` on the per-write span records which transport actually carried a run.
 
 Tracing is unaffected by the choice. Each event write emits an `http POST` client span against the same `url.full`, regardless of which transport carries it. On the WebSocket path, the span is synthesized around the frame because no HTTP request is made. Attributes distinguish the transports:
 

--- a/packages/utils/src/debug-log.test.ts
+++ b/packages/utils/src/debug-log.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { debugLog, isWorkflowDebugEnabled } from './debug-log.js';
+
+describe('isWorkflowDebugEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('is off when DEBUG is unset or empty', () => {
+    vi.stubEnv('DEBUG', undefined);
+    expect(isWorkflowDebugEnabled()).toBe(false);
+
+    vi.stubEnv('DEBUG', '');
+    expect(isWorkflowDebugEnabled()).toBe(false);
+  });
+
+  it('accepts the selectors a namespaced logger would match', () => {
+    for (const value of [
+      'workflow:*',
+      '*',
+      'workflow:runtime:debug',
+      'app:*,workflow:world-vercel:*',
+    ]) {
+      vi.stubEnv('DEBUG', value);
+      expect(isWorkflowDebugEnabled(), value).toBe(true);
+    }
+  });
+
+  it("ignores another library's DEBUG selector", () => {
+    // A user debugging their own package must not be handed the SDK's
+    // transport breadcrumbs as well.
+    vi.stubEnv('DEBUG', 'express:*');
+    expect(isWorkflowDebugEnabled()).toBe(false);
+  });
+
+  it('re-reads DEBUG on every call', () => {
+    // Worlds are built long after import, so a value captured at module load
+    // answers for the wrong moment.
+    vi.stubEnv('DEBUG', '');
+    expect(isWorkflowDebugEnabled()).toBe(false);
+
+    vi.stubEnv('DEBUG', 'workflow:*');
+    expect(isWorkflowDebugEnabled()).toBe(true);
+  });
+});
+
+describe('debugLog', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('writes nothing at all when DEBUG is off', () => {
+    vi.stubEnv('DEBUG', '');
+    const spies = (['log', 'debug', 'info', 'warn', 'error'] as const).map(
+      (level) => vi.spyOn(console, level).mockImplementation(() => {})
+    );
+
+    debugLog('a breadcrumb', { runId: 'wrun_1' });
+
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('forwards every argument to console.debug under DEBUG', () => {
+    vi.stubEnv('DEBUG', 'workflow:*');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const detail = { runId: 'wrun_1' };
+
+    debugLog('a breadcrumb', detail);
+
+    expect(debugSpy).toHaveBeenCalledWith('a breadcrumb', detail);
+  });
+});

--- a/packages/utils/src/debug-log.ts
+++ b/packages/utils/src/debug-log.ts
@@ -1,0 +1,36 @@
+/**
+ * The `DEBUG` gate for diagnostic log lines emitted by the layers below
+ * `@workflow/core`.
+ *
+ * `@workflow/core` has a real logger (`packages/core/src/logger.ts`) whose
+ * `debug`/`info` levels are already gated this way. The packages under it —
+ * `@workflow/utils`, `@workflow/world`, `@workflow/world-local`,
+ * `@workflow/world-vercel` — carry no logger dependency, so a breadcrumb there
+ * is a bare `console.*` call: unconditional, and therefore in every user's
+ * function logs on a normal run. This is the gate those call sites use instead.
+ *
+ * Accepts the same selectors a namespaced logger would match for a line that
+ * has no namespace of its own: any `workflow:`-prefixed pattern, or `*`.
+ */
+export function isWorkflowDebugEnabled(): boolean {
+  // Read per call rather than captured at module load. A World is often
+  // constructed long after import (and a test sets `DEBUG` in `beforeEach`),
+  // so a module-scope constant answers for the wrong moment.
+  const debug = typeof process !== 'undefined' ? process.env.DEBUG : undefined;
+  if (typeof debug !== 'string') return false;
+  return debug.includes('workflow:') || debug === '*';
+}
+
+/**
+ * Emit a diagnostic line only under `DEBUG`.
+ *
+ * `console.debug` to match the rest of the SDK's debug output — core's logger,
+ * world-vercel's `httpLog` and `logRetry` — so one `DEBUG=workflow:*` collects
+ * all of it. Use this for anything a *successful* run would print; a genuine
+ * anomaly still belongs on `console.warn`/`console.error`, which stay
+ * unconditional so a broken run is never silent.
+ */
+export function debugLog(...args: unknown[]): void {
+  if (!isWorkflowDebugEnabled()) return;
+  console.debug(...args);
+}

--- a/packages/utils/src/get-port.ts
+++ b/packages/utils/src/get-port.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { readdir, readFile, readlink } from 'node:fs/promises';
 import { promisify } from 'node:util';
+import { debugLog } from './debug-log.js';
 import { parseWindowsNetstatPortsForPid } from './get-port-internals.js';
 import { WORKFLOW_ROUTE_BASE } from './workflow-routes.js';
 
@@ -198,9 +199,12 @@ export async function getAllPorts(): Promise<number[]> {
         return [];
     }
   } catch (error) {
-    if (process.env.NODE_ENV === 'development') {
-      console.debug('[getAllPorts] Detection failed:', error);
-    }
+    // `DEBUG`, not `NODE_ENV`: development is exactly when port detection runs
+    // (the local world resolves the dev server's port on every start), so
+    // gating on it made the diagnostic unconditional for the only audience
+    // that reaches this code. Detection failing is recoverable — the caller
+    // falls through to its own resolution — so it is a debug line, not a warn.
+    debugLog('[getAllPorts] Detection failed:', error);
     return [];
   }
 }
@@ -294,11 +298,14 @@ export async function getWorkflowPort(
   // This handles cases where:
   // - Server hasn't started workflow routes yet
   // - Network issues during probing
-  if (process.env.NODE_ENV === 'development') {
-    console.debug(
-      '[getWorkflowPort] Probing failed, falling back to first port:',
-      ports[0]
-    );
-  }
+  //
+  // Debug-gated for the same reason as `getAllPorts` above: the first of those
+  // cases is an ordinary dev-server startup race that the fallback then
+  // resolves correctly, and `NODE_ENV=development` is the normal case here
+  // rather than the diagnostic one.
+  debugLog(
+    '[getWorkflowPort] Probing failed, falling back to first port:',
+    ports[0]
+  );
   return ports[0];
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+export { debugLog, isWorkflowDebugEnabled } from './debug-log.js';
 export {
   globalSingleton,
   resetGlobalSingletonForTest,

--- a/packages/world-local/src/queue.ts
+++ b/packages/world-local/src/queue.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises';
 import type { Transport } from '@vercel/queue';
-import { createWorkflowUrl } from '@workflow/utils';
+import { createWorkflowUrl, debugLog } from '@workflow/utils';
 import {
   isNodeHttpEnabled,
   MessageId,
@@ -212,7 +212,10 @@ export function createQueue(config: Partial<Config>): LocalQueue {
 
       const token = semaphore.tryAcquire();
       if (!token) {
-        console.warn(
+        // Debug-gated: this is the semaphore doing its job. A fan-out wider
+        // than the limit queues behind it and every message still runs, so a
+        // per-message warning turns a healthy wide run into a wall of output.
+        debugLog(
           `[world-local]: concurrency limit (${WORKFLOW_LOCAL_QUEUE_CONCURRENCY}) reached, waiting for queue to free up`
         );
         await semaphore.acquire();

--- a/packages/world-vercel/src/ws-transport.test.ts
+++ b/packages/world-vercel/src/ws-transport.test.ts
@@ -191,6 +191,8 @@ async function connectAndSend(
 
 let errorSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
+let debugSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(async () => {
   // The upgrade injects trace context, whose first call imports the optional
@@ -206,18 +208,31 @@ beforeEach(() => {
   resetWsEventsTransportsForTest();
   errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
   delete process.env.WORKFLOW_REQUEST_TIMEOUT_MS;
+  delete process.env.DEBUG;
 });
 
 const headers = async () => ({ authorization: 'Bearer token-1' });
 
-const loggedErrors = () =>
-  errorSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+const joined = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((args) => args.join(' ')).join('\n');
+
+const loggedErrors = () => joined(errorSpy);
+
+/**
+ * Everything the transport says about a *healthy* connection is debug-gated, so
+ * the assertions below have to distinguish "printed the line" from "printed it
+ * unconditionally". This is what a user without `DEBUG` set sees.
+ */
+const loggedWithoutDebug = () =>
+  `${joined(logSpy)}\n${joined(warnSpy)}\n${joined(debugSpy)}`;
 
 describe('toEventsWsUrl', () => {
   it('upgrades the scheme and scopes the path to one run', () => {
@@ -490,7 +505,8 @@ describe('failures are never silent', () => {
     expect(loggedErrors()).not.toContain('timed out');
   });
 
-  it('logs a drain notice without settling in-flight work', async () => {
+  it('logs a drain notice under DEBUG without settling in-flight work', async () => {
+    process.env.DEBUG = 'workflow:*';
     const transport = getWsEventsTransport(WS_URL, headers);
     const { promise, socket } = await connectAndSend(transport);
     let settled = false;
@@ -506,10 +522,22 @@ describe('failures are never silent', () => {
     socket.deliver(encodeFrame({ type: 'drain', graceMs: 10_000 }, EMPTY));
     await tick();
 
-    expect(logSpy.mock.calls.map((a) => a.join(' ')).join('\n')).toContain(
-      'drain notice'
-    );
+    expect(joined(debugSpy)).toContain('drain notice');
     expect(settled).toBe(false);
+  });
+
+  it('stays silent on a drain notice without DEBUG', async () => {
+    // Both drain reasons — the socket outliving the server's max duration, and
+    // its bearer nearing expiry — are routine on the WS default, and the
+    // transport reconnects from the close that follows. A healthy long-lived
+    // run must not narrate that.
+    const transport = getWsEventsTransport(WS_URL, headers);
+    const { socket } = await connectAndSend(transport);
+
+    socket.deliver(encodeFrame({ type: 'drain', graceMs: 10_000 }, EMPTY));
+    await tick();
+
+    expect(loggedWithoutDebug()).not.toContain('drain notice');
   });
 });
 
@@ -1037,15 +1065,14 @@ describe('transport selection', () => {
       // That gateway does not forward a raw upgrade, so the caller has to fall
       // back to HTTP rather than attempt a connection it can't serve.
       process.env.WORKFLOW_EVENTS_TRANSPORT = 'ws';
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
       openWsChannel('wrun_1', proxyConfig);
 
       expect(resolveWsTransport('wrun_1', proxyConfig)).toBeNull();
       expect(sockets).toHaveLength(0);
     });
 
-    it('logs the proxy fallback and the ws-in-use notice once per process', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs the proxy fallback and the ws-in-use notice once per process, under DEBUG', () => {
+      process.env.DEBUG = 'workflow:*';
       process.env.WORKFLOW_EVENTS_TRANSPORT = 'ws';
 
       openWsChannel('wrun_1', proxyConfig);
@@ -1054,10 +1081,27 @@ describe('transport selection', () => {
       openWsChannel('wrun_2', directConfig);
 
       // Every event takes the resolve path, so a per-request line would be noise.
-      expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(
-        logSpy.mock.calls.filter(([m]) => String(m).includes('using ws'))
+        debugSpy.mock.calls.filter(([m]) => String(m).includes('falling back'))
       ).toHaveLength(1);
+      expect(
+        debugSpy.mock.calls.filter(([m]) => String(m).includes('using ws'))
+      ).toHaveLength(1);
+    });
+
+    it('says nothing about the transport it selected without DEBUG', () => {
+      // The regression this pins: both lines were written while WS was opt-in,
+      // where "using ws" and "you asked for ws but this World can't" reported a
+      // choice the caller had made. On the WS default nobody asked, so every
+      // deployment printed the first after each cold start and every CLI
+      // command — all `projectConfig` Worlds — printed the second.
+      process.env.WORKFLOW_EVENTS_TRANSPORT = 'ws';
+
+      openWsChannel('wrun_1', proxyConfig);
+      openWsChannel('wrun_2', directConfig);
+
+      expect(loggedWithoutDebug()).not.toContain('using ws');
+      expect(loggedWithoutDebug()).not.toContain('falling back');
     });
   });
 

--- a/packages/world-vercel/src/ws-transport.ts
+++ b/packages/world-vercel/src/ws-transport.ts
@@ -23,7 +23,7 @@
  */
 
 import { getVercelOidcToken } from '@vercel/oidc';
-import { globalSingleton } from '@workflow/utils';
+import { debugLog, globalSingleton } from '@workflow/utils';
 import { WebSocket } from 'ws';
 import { type DecodedFrame, decodeFrames } from './frames.js';
 import {
@@ -580,10 +580,16 @@ class WsEventsTransport {
       // Unsolicited server push, no reqId. Informational on its own: the
       // `close` that follows is what triggers the reconnect and consumes the
       // reason recorded here.
+      //
+      // Debug-gated, because both reasons are routine rather than faults: a
+      // socket outliving the server's max duration, or its bearer approaching
+      // expiry. Neither loses a write — the drain is a heads-up ahead of a
+      // close the transport reconnects from — so on the WS default every
+      // long-lived run would otherwise print this on a healthy path.
       const reason: DrainReason =
         decoded.meta.reason === 'auth_expiry' ? 'auth_expiry' : 'max_duration';
       this.lastDrainReason = reason;
-      console.log(
+      debugLog(
         `world-vercel: ws events transport received a drain notice ` +
           `(reason: ${reason}, graceMs: ${decoded.meta.graceMs ?? 'unspecified'}); ` +
           `connection will close soon.`
@@ -812,7 +818,12 @@ export function openWsChannel(
   if (!resolved) return undefined;
   if (!wsState.loggedWsInUse) {
     wsState.loggedWsInUse = true;
-    console.log(`world-vercel: using ws events transport (${resolved}).`);
+    // Debug-gated: this said something when WS was opt-in, and says nothing now
+    // that it is the default — every deployment would print it on its first
+    // invocation after each cold start, describing the transport it was always
+    // going to use. `workflow.events.transport` on the per-write span is the
+    // durable answer to "which transport carried this run".
+    debugLog(`world-vercel: using ws events transport (${resolved}).`);
   }
   // Cheap: a URL plus a map lookup, no token mint and no I/O. The socket work
   // happens inside `open`, unawaited.
@@ -888,11 +899,19 @@ function resolveChannelUrl(
     // platform-level upgrade path, which is what surfaces as
     // "experimental_upgradeWebSocket is not available in the current runtime
     // environment". Fall back rather than fail a connection it can't serve.
+    //
+    // Debug-gated rather than a warning, and the flip to the WS default is why:
+    // "requested but unavailable" was a real mismatch to report while the
+    // transport was opt-in, because someone had asked for it. Nobody asks now,
+    // so a `projectConfig` World — every CLI command and the observability app —
+    // would warn about a fallback its caller neither chose nor can act on. The
+    // HTTP path it falls back to is the same one it used before the default
+    // flipped.
     if (!wsState.loggedWsProxyFallback) {
       wsState.loggedWsProxyFallback = true;
-      console.warn(
-        `world-vercel: ws events transport requested but a World with projectConfig ` +
-          `(api-workflow proxy, resolved baseUrl: ${baseUrl}) is active — falling back.`
+      debugLog(
+        `world-vercel: ws events transport unavailable for a World with projectConfig ` +
+          `(api-workflow proxy, resolved baseUrl: ${baseUrl}) — falling back to HTTP.`
       );
     }
     return null;

--- a/packages/world/src/recovery.test.ts
+++ b/packages/world/src/recovery.test.ts
@@ -48,4 +48,50 @@ describe('reenqueueActiveRuns', () => {
       runId: 'wrun_AAA',
     });
   });
+
+  it('recovers runs without logging', async () => {
+    // Resuming active runs is what a restart is for, so a successful recovery
+    // is not news: this printed on every dev-server restart with work in
+    // flight.
+    vi.stubEnv('DEBUG', '');
+    const spies = (['log', 'debug', 'info', 'warn', 'error'] as const).map(
+      (level) => vi.spyOn(console, level).mockImplementation(() => {})
+    );
+
+    await reenqueueActiveRuns(createRuns(), vi.fn<Queue['queue']>(), 'test');
+
+    for (const spy of spies) {
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    }
+  });
+
+  it('reports the recovery under DEBUG', async () => {
+    vi.stubEnv('DEBUG', 'workflow:*');
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    await reenqueueActiveRuns(createRuns(), vi.fn<Queue['queue']>(), 'test');
+
+    expect(debugSpy.mock.calls.map((args) => args.join(' ')).join('\n')).toBe(
+      '[test] Re-enqueued 1 active run(s) on startup'
+    );
+    debugSpy.mockRestore();
+  });
+
+  it('always reports a run it could not re-enqueue', async () => {
+    // The other side of the gate: this one leaves a run unresumed, so it must
+    // not need DEBUG to be seen.
+    vi.stubEnv('DEBUG', '');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const enqueue = vi
+      .fn<Queue['queue']>()
+      .mockRejectedValue(new Error('nope'));
+
+    await reenqueueActiveRuns(createRuns(), enqueue, 'test');
+
+    expect(
+      warnSpy.mock.calls.map((args) => args.join(' ')).join('\n')
+    ).toContain('Failed to re-enqueue run wrun_AAA');
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/world/src/recovery.ts
+++ b/packages/world/src/recovery.ts
@@ -51,9 +51,25 @@ export async function reenqueueActiveRuns(
       cursor = page.cursor ?? undefined;
     }
   }
-  if (reenqueued > 0) {
-    console.log(
+  if (reenqueued > 0 && isDebugEnabled()) {
+    // Debug-gated: recovering active runs is what a restart is supposed to do,
+    // so on every `next dev` restart with work in flight this printed a line
+    // about the world working correctly. The re-enqueue failures above stay
+    // unconditional — those lose a run's resumption.
+    console.debug(
       `[${label}] Re-enqueued ${reenqueued} active run(s) on startup`
     );
   }
+}
+
+/**
+ * The `DEBUG` gate, inlined. This is `isWorkflowDebugEnabled()` from
+ * `@workflow/utils`, hand-rolled for the same reason `env-config.ts` hand-rolls
+ * `globalSingleton()`: this package deliberately carries no workspace
+ * dependencies, and the two are equivalent.
+ */
+function isDebugEnabled(): boolean {
+  const debug = typeof process !== 'undefined' ? process.env.DEBUG : undefined;
+  if (typeof debug !== 'string') return false;
+  return debug.includes('workflow:') || debug === '*';
 }


### PR DESCRIPTION
## What

Normal workflow execution should print nothing. Today a healthy run emits several lines that only describe the runtime working correctly.

Most of it is fallout from #3702, which defaulted the events transport to WebSockets. Three log sites written while the transport was **opt-in** became default-path output, because each one reports a choice the caller no longer makes:

| Line | Why it was fine when WS was opt-in | Why it is noise now |
| --- | --- | --- |
| `world-vercel: using ws events transport (…)` | Confirmed the flag took effect | Runs once per cold start on **every** deployment, naming the transport it was always going to use |
| `…requested but a World with projectConfig … falling back` | A real mismatch: someone asked for WS and didn't get it | Nobody asks now, so every CLI command and the observability app — all `projectConfig` Worlds — warn about a fallback they neither chose nor can act on |
| `…received a drain notice (reason: max_duration…)` | Rare while few sockets existed | `max_duration` and `auth_expiry` are routine; the transport reconnects from the close that follows and no write is lost |

Swept for the same shape elsewhere and found three more:

- **`world-local` queue concurrency** — warned per message once a fan-out exceeded the limit. That is the semaphore doing its job; every message still runs.
- **`@workflow/world` active-run recovery** — printed on every dev-server restart with work in flight. Resuming active runs is what a restart is *for*.
- **`@workflow/utils` port detection** — two diagnostics gated on `NODE_ENV=development`, which is the only environment that reaches this code, so the gate made them unconditional for their entire audience. The `getWorkflowPort` one fires on an ordinary startup race (dev server still compiling its workflow routes) that the fallback then resolves correctly.

## How

A new `debugLog` in `@workflow/utils` gates on `DEBUG=workflow:*` (or `*`), the same selector `@workflow/core`'s logger already uses, so these join world-vercel's existing `httpLog` and `logRetry` output under one switch. It reads `DEBUG` per call rather than at module load, since Worlds are built long after import. `@workflow/world` hand-rolls the same check — that package deliberately carries no workspace dependencies, matching how `env-config.ts` hand-rolls `globalSingleton()`.

**Nothing about error logging changed.** Every `console.error` / `console.warn` on a genuine fault is untouched, including the ws-transport's "failures are never silent" set and the re-enqueue failure sitting directly above the recovery line that did get gated — that one leaves a run unresumed. `logger.warn` / `logger.error` in `@workflow/core` still print unconditionally.

## Testing

- `packages/{utils,world,world-local,world-vercel}/src` — 1449 passed, 4 skipped.
- `packages/core/src` — 2268 passed (unchanged; core consumes `@workflow/utils`).
- New coverage: `debug-log.test.ts` (off by default, accepts `workflow:*` / `*`, ignores another library's selector, re-reads per call); ws-transport tests split into DEBUG / no-DEBUG pairs; recovery tests assert a successful recovery logs at *no* level while a failed re-enqueue still warns without `DEBUG`.
- Verified the new ws-transport assertions bite: reverting `ws-transport.ts` alone fails exactly 4 of them.
- `biome check` on the changed files reports the same 7 pre-existing warnings as base (exit 0); `turbo typecheck` clean for all four packages.

Two `packages/utils/src/check-data-dir.test.ts` cases fail on this machine on **unmodified main** as well — a leftover gitignored `.workflow-data` at the repo root that the test walks up and finds. Unrelated to this change.

## Docs

`worlds/v5/vercel.mdx` claimed the `projectConfig` fallback logs a warning once per process. Updated to say it is silent and reported under `DEBUG`, and to point at `workflow.events.transport` on the per-write span as the durable answer to which transport carried a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)