### PR TITLE
fix(core): re-arm late-claimed hook deliveries

### DIFF
--- a/.changeset/late-hooks-rearm.md
+++ b/.changeset/late-hooks-rearm.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Keep late-claimed buffered hook payloads from being preempted by workflow suspension in retained VMs.

--- a/packages/core/src/async-deserialization-ordering.test.ts
+++ b/packages/core/src/async-deserialization-ordering.test.ts
@@ -5,7 +5,7 @@ import { monotonicFactory } from 'ulid';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { registerSerializationClass } from './class-serialization.js';
 import { EventsConsumer } from './events-consumer.js';
-import type { WorkflowOrchestratorContext } from './private.js';
+import { isDeliveryIdle, type WorkflowOrchestratorContext } from './private.js';
 import { ReplayPayloadCache } from './replay-payload-cache.js';
 import {
   dehydrateStepError,
@@ -763,5 +763,49 @@ describe('async deserialization ordering', () => {
     await sleep(resumeAt);
 
     expect(ctx.pendingDeliveryBarriers?.size).toBe(0);
+  });
+
+  it('should restore delivery protection when a buffered hook payload is claimed after its barrier retires', async () => {
+    const payload = await dehydrateStepReturnValue(
+      'buffered',
+      'wrun_test',
+      undefined
+    );
+    const ctx = setupWorkflowContext([
+      {
+        eventId: 'evnt_0',
+        runId: 'wrun_test',
+        eventType: 'hook_received',
+        correlationId: 'hook_01K11TFZ62YS0YYFDQ3E8B9YCV',
+        eventData: { payload },
+        createdAt: new Date(),
+      },
+    ]);
+
+    // Model another payload hydrating in the same replay so the idle safety
+    // net cannot retire this hook's barrier before the test observes it.
+    ctx.pendingDeliveries = 1;
+    const createHook = createCreateHook(ctx);
+    const hook = createHook<string>();
+
+    // The payload arrived before a consumer requested it, so it starts with
+    // an unarmed barrier and remains buffered after the idle safety net retires
+    // that barrier.
+    await vi.waitFor(() => {
+      expect(ctx.pendingDeliveryBarriers?.size).toBe(1);
+    });
+    await ctx.promiseQueue;
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(1);
+    ctx.pendingDeliveries = 0;
+    await vi.waitFor(() => {
+      expect(ctx.pendingDeliveryBarriers?.size).toBe(0);
+    });
+
+    // Claiming the buffered payload commits it to reaching this consumer. Its
+    // delivery must become non-idle again until the claim resolves.
+    const delivery = hook.then((value) => value);
+    expect(isDeliveryIdle(ctx)).toBe(false);
+    await expect(delivery).resolves.toBe('buffered');
+    expect(isDeliveryIdle(ctx)).toBe(true);
   });
 });

--- a/packages/core/src/delivery-barrier-dispenser.test.ts
+++ b/packages/core/src/delivery-barrier-dispenser.test.ts
@@ -128,6 +128,18 @@ const resumeAtA = new Date('2026-07-27T12:00:05.000Z');
 const resumeAtB = new Date('2026-07-27T12:00:06.000Z');
 
 describe('barrier safety-net dispenser', () => {
+  it('rejects a second barrier owner for the same event index', () => {
+    const ctx = setupWorkflowContext([]);
+    const barrier = registerDeliveryBarrier(ctx, 0, 'hook', { armed: false });
+
+    expect(() => registerDeliveryBarrier(ctx, 0, 'step')).toThrowError(
+      'Delivery barrier already registered at event index 0'
+    );
+
+    barrier.markDelivered();
+    expect(isDeliveryIdle(ctx)).toBe(true);
+  });
+
   it('suspends only after deliveries parked behind an unclaimed payload have run', async () => {
     const ops: Promise<any>[] = [];
     const payload = await dehydrateStepReturnValue(

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -2,6 +2,7 @@
  * Utils used by the bundler when transforming code
  */
 
+import { WorkflowRuntimeError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { WorldCapabilities } from '@workflow/world';
 import type { EventsConsumer } from './events-consumer.js';
@@ -233,8 +234,8 @@ export type DeliveryKind = 'hook' | 'wait' | 'step';
 
 interface DeliveryBarrierEntry {
   kind: DeliveryKind;
-  /** Resolves once this delivery has resolved to the workflow. */
-  delivered: Promise<void>;
+  /** Resolves once this delivery is handed to the workflow or retired. */
+  released: Promise<void>;
   /**
    * Whether this delivery is committed to reaching the workflow without any
    * further action by workflow code. True for wait completions and step
@@ -247,11 +248,15 @@ interface DeliveryBarrierEntry {
    * once a consumer takes the payload.
    */
   armed: boolean;
+  /** Whether this entry has been removed and its `released` promise settled. */
+  retired: boolean;
   /**
-   * Retire this entry: resolve `delivered` and remove it from the registry,
-   * exactly as `markDelivered` would. Called only by the context's safety-net
-   * dispenser ({@link ensureBarrierSafetyNet}), and only on the lowest-index
-   * entry at delivery idle. Idempotent.
+   * Retire this entry: resolve `released` and remove it from the registry,
+   * without marking the handle delivered to the workflow. A safety-retired
+   * buffered payload may therefore install a fresh entry if it is claimed by
+   * a retained VM later. Called only by the context's safety-net dispenser
+   * ({@link ensureBarrierSafetyNet}), and only on the lowest-index entry at
+   * delivery idle. Idempotent.
    */
   retire: () => void;
 }
@@ -573,7 +578,7 @@ export async function awaitEarlierDeliveries(
     if (!gatesOn(kind, eventIndex, index, entry)) {
       continue;
     }
-    earlier.push(entry.delivered);
+    earlier.push(entry.released);
   }
   if (earlier.length > 0) {
     await Promise.all(earlier);
@@ -612,7 +617,7 @@ export async function awaitEarlierDeliveries(
 export interface DeliveryBarrier {
   /**
    * Mark this delivery as delivered to the workflow. Resolves its
-   * `delivered` promise so any later-in-log delivery gated on it (via
+   * `released` promise so any later-in-log delivery gated on it (via
    * {@link awaitEarlierDeliveries}) may proceed, and removes it from the
    * registry. Idempotent.
    */
@@ -659,17 +664,22 @@ export function registerDeliveryBarrier(
   }
 
   const install = (armed: boolean): DeliveryBarrierEntry => {
-    let retired = false;
+    if (barriers.has(eventIndex)) {
+      throw new WorkflowRuntimeError(
+        `Delivery barrier already registered at event index ${eventIndex}`
+      );
+    }
     const { promise, resolve } = withResolvers<void>();
     const entry: DeliveryBarrierEntry = {
       kind,
-      delivered: promise,
+      released: promise,
       armed,
+      retired: false,
       retire: () => {
-        if (retired) {
+        if (entry.retired) {
           return;
         }
-        retired = true;
+        entry.retired = true;
         if (barriers.get(eventIndex) === entry) {
           barriers.delete(eventIndex);
         }
@@ -691,27 +701,32 @@ export function registerDeliveryBarrier(
   };
 
   let entry = install(options.armed ?? true);
-  let delivered = false;
+  let deliveredToWorkflow = false;
 
   return {
     markDelivered: () => {
-      if (delivered) {
+      if (deliveredToWorkflow) {
         return;
       }
-      delivered = true;
+      deliveredToWorkflow = true;
       entry.retire();
     },
     arm: () => {
-      if (delivered) {
+      if (deliveredToWorkflow) {
         return;
       }
       // The idle safety net may retire an unclaimed buffered hook payload
       // while a retained VM keeps its `claim()` closure alive. If workflow
       // code later claims that payload, replace the settled entry so delivery
       // remains non-idle until the claim reaches the workflow.
-      if (barriers.get(eventIndex) !== entry) {
+      if (entry.retired) {
         entry = install(true);
         return;
+      }
+      if (barriers.get(eventIndex) !== entry) {
+        throw new WorkflowRuntimeError(
+          `Delivery barrier lost ownership of event index ${eventIndex}`
+        );
       }
       entry.armed = true;
     },

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -658,41 +658,61 @@ export function registerDeliveryBarrier(
     return { markDelivered: () => {}, arm: () => {} };
   }
 
-  let done = false;
-  const { promise, resolve } = withResolvers<void>();
+  const install = (armed: boolean): DeliveryBarrierEntry => {
+    let retired = false;
+    const { promise, resolve } = withResolvers<void>();
+    const entry: DeliveryBarrierEntry = {
+      kind,
+      delivered: promise,
+      armed,
+      retire: () => {
+        if (retired) {
+          return;
+        }
+        retired = true;
+        if (barriers.get(eventIndex) === entry) {
+          barriers.delete(eventIndex);
+        }
+        resolve();
+      },
+    };
+    barriers.set(eventIndex, entry);
 
-  const finish = () => {
-    if (done) {
-      return;
-    }
-    done = true;
-    if (barriers.get(eventIndex) === entry) {
-      barriers.delete(eventIndex);
-    }
-    resolve();
+    // Safety net: if this delivery is never delivered to the workflow (its
+    // branch was not taken / the run is suspending, or a buffered hook payload
+    // is only claimed after a later delivery the workflow is still waiting
+    // on), it is retired at idle so a later delivery gated on it cannot
+    // deadlock and the registry cannot leak an entry per abandoned delivery.
+    // Retirement goes through the context's single ordered dispenser rather
+    // than a per-barrier idle poll. See {@link ensureBarrierSafetyNet} for why
+    // the ORDER of these retirements is load-bearing.
+    ensureBarrierSafetyNet(ctx);
+    return entry;
   };
 
-  const entry: DeliveryBarrierEntry = {
-    kind,
-    delivered: promise,
-    armed: options.armed ?? true,
-    retire: finish,
-  };
-  barriers.set(eventIndex, entry);
-
-  // Safety net: if this delivery is never delivered to the workflow (its
-  // branch was not taken / the run is suspending, or a buffered hook payload
-  // is only claimed after a later delivery the workflow is still waiting on),
-  // it is retired at idle so a later delivery gated on it cannot deadlock and
-  // the registry cannot leak an entry per abandoned delivery. Retirement goes
-  // through the context's single ordered dispenser rather than a per-barrier
-  // idle poll. See {@link ensureBarrierSafetyNet} for why the ORDER of these
-  // retirements is load-bearing.
-  ensureBarrierSafetyNet(ctx);
+  let entry = install(options.armed ?? true);
+  let delivered = false;
 
   return {
-    markDelivered: finish,
+    markDelivered: () => {
+      if (delivered) {
+        return;
+      }
+      delivered = true;
+      entry.retire();
+    },
     arm: () => {
+      if (delivered) {
+        return;
+      }
+      // The idle safety net may retire an unclaimed buffered hook payload
+      // while a retained VM keeps its `claim()` closure alive. If workflow
+      // code later claims that payload, replace the settled entry so delivery
+      // remains non-idle until the claim reaches the workflow.
+      if (barriers.get(eventIndex) !== entry) {
+        entry = install(true);
+        return;
+      }
       entry.armed = true;
     },
   };

--- a/packages/core/src/retained-vm-loop.test.ts
+++ b/packages/core/src/retained-vm-loop.test.ts
@@ -28,6 +28,38 @@ vi.mock('./vm/index.js', async (importActual) => {
   return { ...actual, createContext: vi.fn(actual.createContext) };
 });
 
+const barrierArmObservations = vi.hoisted(
+  (): Array<{ before: number; after: number }> => []
+);
+
+// Preserve the production implementation while recording the registry
+// transition made by each arm(). This lets the retained-session regression
+// assert the short-lived protection window directly instead of depending on a
+// timer winning the same race reliably on every test runner.
+vi.mock('./private.js', async (importActual) => {
+  const actual = await importActual<typeof import('./private.js')>();
+  return {
+    ...actual,
+    registerDeliveryBarrier: (
+      ...args: Parameters<typeof actual.registerDeliveryBarrier>
+    ) => {
+      const [ctx] = args;
+      const barrier = actual.registerDeliveryBarrier(...args);
+      return {
+        markDelivered: barrier.markDelivered,
+        arm: () => {
+          const before = ctx.pendingDeliveryBarriers?.size ?? 0;
+          barrier.arm();
+          barrierArmObservations.push({
+            before,
+            after: ctx.pendingDeliveryBarriers?.size ?? 0,
+          });
+        },
+      };
+    },
+  };
+});
+
 const { createContext } = await import('./vm/index.js');
 const { registerSerializationClass } = await import('./class-serialization.js');
 const { registerStepFunction } = await import('./private.js');
@@ -127,6 +159,29 @@ const openHookRaceWorkflow = `const createHook = globalThis[Symbol.for("WORKFLOW
     const a = await Promise.race([hook.then(() => 999), s1()]);
     const b = await s2();
     return a + b;
+  }
+  globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
+
+// The payload arrives while the workflow is waiting on s1, before any hook
+// consumer exists. The next pass buffers it, advances through s1, and suspends
+// on s2; delivery idle retires the payload's unarmed barrier at that boundary.
+// A retained resume arms an empty hook before it claims the buffered one. The
+// empty read schedules suspension while the buffered read resolves a separate
+// workflow promise from its continuation, matching Eve's multiplexed inbox.
+// The late claim must re-arm delivery until that continuation can wake the body.
+const bufferedHookAcrossStepWorkflow = `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const s1 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("r_s1");
+  const s2 = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("r_s2");
+  async function workflow() {
+    const buffered = createHook({ token: "retained-buffered-hook" });
+    const empty = createHook({ token: "retained-empty-hook" });
+    await s1();
+    const stepValue = await s2();
+    const payload = await new Promise((resolve, reject) => {
+      void empty.then(resolve, reject);
+      void buffered.then(resolve, reject);
+    });
+    return stepValue + (payload.source === "external-hook" ? 1000 : 0);
   }
   globalThis.__private_workflows = new Map([["workflow", workflow]]);`;
 
@@ -677,6 +732,7 @@ async function driveConcurrentHookWakeRace(runId: string) {
 describe('retained VM through the inline replay loop', () => {
   beforeEach(() => {
     createContextSpy.mockClear();
+    barrierArmObservations.length = 0;
   });
   afterEach(() => {
     delete process.env.WORKFLOW_RETAINED_VM;
@@ -754,6 +810,29 @@ describe('retained VM through the inline replay loop', () => {
     // the race on resume while the already-started step still completes.
     expect(on.result).toBe(1019);
     expect(on.vmBuilds).toBe(1);
+    expect(on.durableLog).toEqual(off.durableLog);
+  });
+
+  it('claims a buffered hook after its barrier retires across a retained step boundary', async () => {
+    process.env.WORKFLOW_RETAINED_VM = '0';
+    const off = await drive(
+      'wrun_retained_buffered_hook_after_step',
+      bufferedHookAcrossStepWorkflow,
+      { type: 'inject-hook' }
+    );
+    createContextSpy.mockClear();
+    barrierArmObservations.length = 0;
+    delete process.env.WORKFLOW_RETAINED_VM;
+
+    const on = await drive(
+      'wrun_retained_buffered_hook_after_step',
+      bufferedHookAcrossStepWorkflow,
+      { type: 'inject-hook' }
+    );
+    expect(off.result).toBe(1020);
+    expect(on.result).toBe(1020);
+    expect(on.vmBuilds).toBe(1);
+    expect(barrierArmObservations).toContainEqual({ before: 0, after: 1 });
     expect(on.durableLog).toEqual(off.durableLog);
   });
 


### PR DESCRIPTION
## Summary

- reinstall an armed delivery barrier when a retained reusable-hook claim closure runs after the original unarmed barrier was retired
- keep `arm()` and `markDelivered()` terminal and idempotent after actual delivery
- add a behavior-level regression through the real hook API plus a patch changeset

## Root cause

A buffered hook payload registers an unarmed barrier because no workflow consumer has claimed it yet. The idle safety net may legitimately retire that barrier. In a retained VM, however, the payload and its `claim()` closure can survive into a later execution turn. Calling `arm()` then only mutated the already-retired entry, so the runtime still saw no committed delivery and could suspend before the payload reached workflow code.

The fix reinstalls the barrier as armed when that late claim occurs. The delivery chain then removes it normally after handing the payload to the workflow.

This addresses the retained-VM failure investigated from https://github.com/vercel/eve/pull/2611.

## Verification

- `pnpm vitest run src/async-deserialization-ordering.test.ts -t "should restore delivery protection when a buffered hook payload is claimed after its barrier retires"`
- related delivery-barrier, hook/sleep, and retained-VM suites: 86 passed
- full `@workflow/core` suite: 2,284 passed, 3 expected failures, 1 skipped
- `cd packages/core && pnpm typecheck`
- Biome check: clean except the pre-existing cognitive-complexity warning in `quiesceEarlierCascades`
- autoreview: clean, no actionable findings