### PR TITLE
fix(core): stop reconnecting cancelled streams

### DIFF
--- a/.changeset/calm-streams-stop.md
+++ b/.changeset/calm-streams-stop.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Stop framed stream reconnects after the consumer cancels, including while completion checks or reconnect acquisition are still pending.

--- a/packages/core/src/reconnecting-framed-stream.test.ts
+++ b/packages/core/src/reconnecting-framed-stream.test.ts
@@ -329,6 +329,118 @@ describe('createReconnectingFramedStream', () => {
     expect(cancelSpy).toHaveBeenCalled();
   });
 
+  it('does not reconnect when canceled during completion verification', async () => {
+    const infoStarted = Promise.withResolvers<void>();
+    const infoGate = Promise.withResolvers<void>();
+    const { world, calls } = makeWorldWithScriptedStreams(
+      {
+        0: () =>
+          scriptedStream([
+            { kind: 'value', value: payloadFrame(1) },
+            { kind: 'close' },
+          ]),
+      },
+      async () => {
+        infoStarted.resolve();
+        await infoGate.promise;
+        return { tailIndex: 0, done: false };
+      }
+    );
+    setWorld(world);
+
+    const reader = createReconnectingFramedStream(RUN_ID, 's', 0).getReader();
+    expect((await reader.read()).value).toEqual(payloadFrame(1));
+    const pendingRead = reader.read();
+    await infoStarted.promise;
+
+    await reader.cancel('client abort');
+    infoGate.resolve();
+    await pendingRead;
+
+    expect(calls).toEqual([0]);
+  });
+
+  it('cancels a reconnect source acquired after the consumer cancels', async () => {
+    const reconnectStarted = Promise.withResolvers<void>();
+    const reconnectGate = Promise.withResolvers<void>();
+    const cancelSpy = vi.fn();
+    let connections = 0;
+    const world = {
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: {
+        get: vi.fn(async () => {
+          connections++;
+          if (connections === 1) {
+            return scriptedStream([
+              { kind: 'value', value: payloadFrame(1) },
+              { kind: 'error', err: new Error('connection dropped') },
+            ]);
+          }
+          reconnectStarted.resolve();
+          await reconnectGate.promise;
+          return new ReadableStream<Uint8Array>({
+            async pull() {
+              await new Promise(() => {});
+            },
+            cancel(reason) {
+              cancelSpy(reason);
+            },
+          });
+        }),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const reader = createReconnectingFramedStream(RUN_ID, 's', 0).getReader();
+    expect((await reader.read()).value).toEqual(payloadFrame(1));
+    const pendingRead = reader.read();
+    await reconnectStarted.promise;
+
+    await reader.cancel('client abort');
+    reconnectGate.resolve();
+    await pendingRead;
+
+    await vi.waitFor(() => {
+      expect(cancelSpy).toHaveBeenCalledWith('client abort');
+    });
+    expect(world.streams.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops retrying when a pending reconnect rejects after cancellation', async () => {
+    const reconnectStarted = Promise.withResolvers<void>();
+    const reconnectGate = Promise.withResolvers<void>();
+    let connections = 0;
+    const world = {
+      specVersion: SPEC_VERSION_CURRENT,
+      streams: {
+        get: vi.fn(async () => {
+          connections++;
+          if (connections === 1) {
+            return scriptedStream([
+              { kind: 'value', value: payloadFrame(1) },
+              { kind: 'error', err: new Error('connection dropped') },
+            ]);
+          }
+          reconnectStarted.resolve();
+          await reconnectGate.promise;
+          throw new Error('reconnect failed');
+        }),
+      },
+    } as unknown as World;
+    setWorld(world);
+
+    const reader = createReconnectingFramedStream(RUN_ID, 's', 0).getReader();
+    expect((await reader.read()).value).toEqual(payloadFrame(1));
+    const pendingRead = reader.read();
+    await reconnectStarted.promise;
+
+    await reader.cancel('client abort');
+    reconnectGate.resolve();
+    await pendingRead;
+
+    expect(world.streams.get).toHaveBeenCalledTimes(2);
+  });
+
   it('emits every complete frame packed into a single read', async () => {
     // One transport read carrying three back-to-back frames must surface as
     // three separate downstream chunks — exercises the inner drain loop.

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -899,6 +899,8 @@ export function createReconnectingFramedStream(
   let reconnectCount = 0;
   let totalReconnectCount = 0;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let canceled = false;
+  let cancelReason: unknown;
   let buffer = new Uint8Array(0);
   // Read telemetry (same semantics as WorkflowServerReadableStream):
   // dispatch time, first-connect duration, first-frame latch, and totals.
@@ -908,15 +910,22 @@ export function createReconnectingFramedStream(
   let chunksDelivered = 0;
   let bytesDelivered = 0;
 
-  async function connect(): Promise<void> {
+  async function connect(): Promise<boolean> {
+    if (canceled) return false;
     const world = await getWorldLazy();
+    if (canceled) return false;
     const effectiveStartIndex = reconnectSupported
       ? currentStartIndex + consumedFrames
       : startIndex;
     const connectStart = Date.now();
     const stream = await world.streams.get(runId, name, effectiveStartIndex);
+    if (canceled) {
+      await stream.cancel(cancelReason).catch(() => {});
+      return false;
+    }
     if (connectMs === undefined) connectMs = Date.now() - connectStart;
     reader = stream.getReader();
+    return true;
   }
 
   /**
@@ -937,11 +946,13 @@ export function createReconnectingFramedStream(
     }
   }
 
-  async function reconnect(): Promise<void> {
+  async function reconnect(): Promise<boolean> {
+    if (canceled) return false;
     if (reader) {
       await reader.cancel().catch(() => {});
       reader = undefined;
     }
+    if (canceled) return false;
     // Advance the resume position past the frames already delivered, then
     // drop any partial-frame bytes: the reopened connection re-sends from a
     // frame boundary at the new index.
@@ -971,9 +982,10 @@ export function createReconnectingFramedStream(
         );
       }
       try {
-        await connect();
-        return;
+        if (!(await connect())) return false;
+        return true;
       } catch (error) {
+        if (canceled) return false;
         // Retention expiry is terminal and retrying cannot restore the stream.
         // Preserve the typed error immediately instead of turning one 410 into
         // 50 reconnect attempts and a generic budget-exhaustion error.
@@ -986,6 +998,7 @@ export function createReconnectingFramedStream(
 
   return new ReadableStream<Uint8Array>({
     pull: async (controller) => {
+      if (canceled) return;
       if (readStart === undefined) readStart = Date.now();
       // Loop until we emit something, hit EOF, or fatally error. Reads that
       // only extend the in-flight-frame buffer don't enqueue anything; we
@@ -993,8 +1006,9 @@ export function createReconnectingFramedStream(
       for (;;) {
         if (!reader) {
           try {
-            await connect();
+            if (!(await connect())) return;
           } catch (err) {
+            if (canceled) return;
             controller.error(err);
             return;
           }
@@ -1005,12 +1019,13 @@ export function createReconnectingFramedStream(
           // biome-ignore lint/style/noNonNullAssertion: connect() guarantees reader
           result = await reader!.read();
         } catch (err) {
+          if (canceled) return;
           if (!reconnectSupported) {
             controller.error(err);
             return;
           }
           try {
-            await reconnect();
+            if (!(await reconnect())) return;
           } catch (reconnectErr) {
             controller.error(reconnectErr);
             return;
@@ -1018,6 +1033,7 @@ export function createReconnectingFramedStream(
           continue;
         }
 
+        if (canceled) return;
         if (result.done || !result.value) {
           reader = undefined;
           // A clean EOF is only trustworthy if the stream is actually
@@ -1027,9 +1043,12 @@ export function createReconnectingFramedStream(
           // errored body, but on some paths it reaches the client as a clean
           // EOF), and a completed stream can still be cut mid-body; both
           // would otherwise be silently read as a shorter, complete stream.
-          if (reconnectSupported && !(await isVerifiedComplete())) {
+          const verifiedComplete =
+            !reconnectSupported || (await isVerifiedComplete());
+          if (canceled) return;
+          if (!verifiedComplete) {
             try {
-              await reconnect();
+              if (!(await reconnect())) return;
             } catch (reconnectErr) {
               controller.error(reconnectErr);
               return;
@@ -1100,12 +1119,15 @@ export function createReconnectingFramedStream(
         // Only partial bytes: read more.
       }
     },
-    cancel: async () => {
-      if (reader) {
-        await reader.cancel().catch((err) => {
+    cancel: async (reason) => {
+      canceled = true;
+      cancelReason = reason;
+      const currentReader = reader;
+      reader = undefined;
+      if (currentReader) {
+        await currentReader.cancel(reason).catch((err) => {
           console.warn('Error closing ReadableStream reader:', err);
         });
-        reader = undefined;
       }
     },
   });


### PR DESCRIPTION
### Description

Cancelling a reconnecting framed stream could be mistaken for a clean, incomplete EOF. The pending pull then reopened the World stream after cancellation, leaving the new reader unowned; local World consumers retained emitter listeners and polling intervals, eventually producing `MaxListenersExceededWarning` after repeated reads of the same durable stream.

The reader now latches cancellation across pending reads, completion checks, and reconnect acquisition. Reconnect work stops after cancellation, and a World stream that finishes opening after cancellation is immediately cancelled instead of being installed as the active reader.

### How did you test your changes?

Added focused regressions for cancellation while completion metadata is pending and while a reconnect acquisition is pending. The complete `@workflow/core` suite passes: 107 test files passed, 1 skipped; 2,285 tests passed, 3 expected failures, and 1 skipped. `@workflow/core` also typechecks. Before applying the fix, a 20-turn local eve session deterministically retained one World reader per turn and warned on listener 11; with this change, the same run peaked at one reader and ended with zero.

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Use the correct semver bump type: `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
  - Use `pnpm changeset --empty` if you are changing documentation or workbench apps
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete
