### PR TITLE
feat(streams): add bounded WebSocket write pipelining

### DIFF
--- a/.changeset/ws-stream-write-pipelining.md
+++ b/.changeset/ws-stream-write-pipelining.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': minor
+'@workflow/world': minor
+'@workflow/world-vercel': minor
+---
+
+Add opt-in bounded pipelining for WebSocket stream writes.

--- a/docs/content/docs/v5/configuration/worlds.mdx
+++ b/docs/content/docs/v5/configuration/worlds.mdx
@@ -289,6 +289,14 @@ Platform-provided values such as `VERCEL_DEPLOYMENT_ID`, `VERCEL_PROJECT_ID`, an
 - Experimental stream-write transport capability. Set to exactly `ws` to attempt `workflow-stream-ws/v1`. The server authoritatively accepts or declines each upgrade; a decline uses HTTP directly for that writer lifetime. Stream reads remain HTTP and demand-driven.
 - This is not tenant rollout policy or a package-version check. HTTP remains the compatibility path. `/websockets/v1` is independent of REST v2/v4 and persisted workflow `specVersion` values.
 
+### `WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH`
+
+- Factory option: none
+- CLI flag: none
+- Default: `1`
+- Experimental WebSocket stream-write request depth. Supported exact values are `1`, `2`, and `4`; invalid values fail closed to `1`. HTTP writers remain serial.
+- Depths above `1` require a coordinated server batch-flush experiment. The current server accepts at most four pending messages but commits frames serially, and client-only pipelining can regress grouping and latency. Unknown sent outcomes poison all unresolved writes and are never replayed.
+
 ### `WORKFLOW_DISABLE_ANALYTICS_READS`
 
 - Factory option: none

--- a/docs/content/worlds/v5/vercel.mdx
+++ b/docs/content/worlds/v5/vercel.mdx
@@ -206,9 +206,15 @@ Experimental stream-write transport capability. Default: `http`. Set `WORKFLOW_S
 
 This setting does not own tenant rollout policy and does not infer server support from package versions. HTTP remains the compatibility path. The protocol route (`/websockets/v1`) is versioned independently from REST v2/v4 and persisted workflow `specVersion` values.
 
-Writes and close requests execute serially. The first operation waits up to 250 ms for an opted-in socket to open; this is an implementation-level measurement knob, not protocol semantics. If the budget expires, or the upgrade fails or is declined before acceptance, the writer uses HTTP without racing the same operation over both transports. After the socket accepts a write, a missing acknowledgement has an unknown outcome: the writer fails rather than replaying the write over HTTP and risking a duplicate append.
+### `WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH`
 
-Before routine authentication expiry or server max duration, the server sends a v1 `drain` control. The client stops sending, lets an already-admitted request receive its reply, and reconnects after the server closes with code 1001. Authentication drains re-resolve a fresh bearer. A request that was sent but receives no reply before close still has an unknown outcome and is never replayed.
+Experimental WebSocket writer request depth. Default: `1`. Supported exact values are `1`, `2`, and `4`; invalid values fail closed to `1`. HTTP writers remain serial. Any unknown outcome poisons the writer and is never replayed.
+
+Depths above `1` are intended only for coordinated experiments with server-side batch flush support; the current server accepts up to four pending messages but still commits frames serially. Client-only pipelining can fragment groups and regress latency, so keep depth `1` outside a paired experiment.
+
+The first group uses HTTP without constructing a socket. The second HTTP request starts the background connection at dispatch, and complete groups continue over HTTP until the socket opens. The writer switches only after the sealed HTTP prefix succeeds. A missing acknowledgement after a frame is sent has an unknown outcome: the writer fails rather than replaying the write over HTTP and risking a duplicate append.
+
+Before routine authentication expiry or server max duration, the server sends a v1 `drain` control. The client stops sending, lets admitted requests receive their replies, and reconnects after the server closes with code 1001. Authentication drains re-resolve a fresh bearer. Any request that was sent but receives no reply before close still has an unknown outcome and is never replayed.
 
 ### `WORKFLOW_EVENTS_TRANSPORT`
 

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -1359,8 +1359,24 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
     let inFlightChunks = 0;
     let inFlightBytes = 0;
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    /** The in-flight dispatch chain. At most one, preserving chunk order. */
-    let inFlight: Promise<void> | null = null;
+    type ActiveGroup = {
+      id: number;
+      chunkSeq: number;
+      chunks: Uint8Array[];
+      bytes: number;
+      groupT0: number | undefined;
+    };
+    const activeGroups = new Map<number, ActiveGroup>();
+    let nextGroupId = 1;
+    let dispatchScheduled = false;
+    let resolvedDispatchDepth: number | undefined;
+    const dispatchDepth = writeSessionPromise.then((session) => {
+      const advertised = session?.maxInFlightWrites;
+      if (typeof advertised !== 'number' || !Number.isFinite(advertised)) {
+        return 1;
+      }
+      return Math.min(4, Math.max(1, Math.floor(advertised)));
+    });
     /**
      * Sticky failure: once a dispatch fails, the failed group is re-queued
      * (retained, exactly as the previous implementation retained its buffer)
@@ -1424,13 +1440,6 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
     };
 
     /**
-     * Dispatch loop: while chunks are buffered, send them group by group.
-     * Exactly one loop runs at a time (`inFlight`), so groups reach the
-     * server in write order. Chunks that arrive while a group's request is
-     * in flight accumulate and form the next group: the group-commit
-     * behavior, now independent of how the producer pipes.
-     */
-    /**
      * Send one group to the server: gate on run readiness, then one
      * `writeMulti` (or sequential `write`s when the world lacks it). Emits
      * the write-flush span; dwell is measured up to just before the RPC so a
@@ -1440,14 +1449,15 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
     const sendGroup = async (
       group: Uint8Array[],
       bytes: number,
-      groupT0: number | undefined
+      groupT0: number | undefined,
+      chunkSeq: number
     ): Promise<void> => {
       await ensureRunReady();
       const world = await worldPromise;
       const session = await writeSessionPromise;
       const dispatchAt = Date.now();
       if (session) {
-        await session.write(nextChunkSeq, group);
+        await session.write(chunkSeq, group);
       } else if (
         typeof world.streams.writeMulti === 'function' &&
         group.length > 1
@@ -1459,9 +1469,6 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
           await world.streams.write(runId, name, chunk);
         }
       }
-      // `inFlight` admits only one dispatch loop, so no second group can read
-      // this sequence space until the current group has advanced it.
-      nextChunkSeq += group.length;
       if (groupT0 !== undefined) {
         recordStreamWriteFlush(
           groupT0,
@@ -1475,74 +1482,98 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
       }
     };
 
-    const dispatchLoop = async (): Promise<void> => {
-      while (buffer.length > 0) {
-        if (flushTimer) {
-          clearTimeout(flushTimer);
-          flushTimer = null;
-        }
-        const groupT0 = bufferT0;
-        const groupTakenAt = Date.now();
-        const { group, bytes } = takeGroup();
-        inFlightChunks = group.length;
-        inFlightBytes = bytes;
-        bufferT0 = buffer.length > 0 ? groupTakenAt : undefined;
-
-        try {
-          await sendGroup(group, bytes, groupT0);
-          inFlightChunks = 0;
-          inFlightBytes = 0;
-        } catch (error) {
-          // Retain the failed group (and its original t0) at the front of
-          // the buffer, poison the sink, and surface the failure to every
-          // blocked writer and drain waiter.
-          buffer = group.concat(buffer);
-          bufferBytes += bytes;
-          inFlightChunks = 0;
-          inFlightBytes = 0;
-          bufferT0 =
-            groupT0 !== undefined && bufferT0 !== undefined
-              ? Math.min(groupT0, bufferT0)
-              : (groupT0 ?? bufferT0);
-          throw error;
-        }
-
-        // This group is durable: relieve writers blocked on the bound (they
-        // re-check it and may block again).
-        const relieved = capacityWaiters;
-        capacityWaiters = [];
-        for (const w of relieved) w.resolve();
-      }
+    const settleIfDrained = (): void => {
+      if (buffer.length > 0 || activeGroups.size > 0) return;
+      const settled = drainWaiters;
+      drainWaiters = [];
+      for (const waiter of settled) waiter.resolve();
     };
 
-    /** Start (or join) the dispatch chain. Never leaves an unhandled rejection. */
-    const startDispatch = (): void => {
-      if (inFlight || sinkError !== undefined || buffer.length === 0) return;
-      inFlight = dispatchLoop().then(
-        () => {
-          inFlight = null;
-          // A write can land in the microtask gap between the loop's
-          // empty-buffer exit and this reaction. scheduleGroupCommit saw
-          // inFlight still set and armed no timer, so without this check
-          // the chunk would sit stranded until a later write/close/drain.
-          // Treat it like an in-request arrival: dispatch immediately (the
-          // new chain settles the drain waiters when it finishes).
-          if (buffer.length > 0) {
-            startDispatch();
-            return;
-          }
-          // Fully idle (the loop only exits with an empty buffer): settle
-          // the durability barrier.
-          const settled = drainWaiters;
-          drainWaiters = [];
-          for (const w of settled) w.resolve();
-        },
-        (error) => {
-          inFlight = null;
-          sinkError ??= error;
-          rejectWaiters(sinkError);
-        }
+    const failActiveGroups = (error: unknown): void => {
+      if (sinkError !== undefined) return;
+      sinkError = error;
+      const unresolved = [...activeGroups.values()].sort(
+        (a, b) => a.chunkSeq - b.chunkSeq
       );
+      activeGroups.clear();
+      inFlightChunks = 0;
+      inFlightBytes = 0;
+      if (unresolved.length > 0) {
+        buffer = unresolved.flatMap((item) => item.chunks).concat(buffer);
+        bufferBytes += unresolved.reduce((sum, item) => sum + item.bytes, 0);
+        const firstT0 = unresolved.reduce<number | undefined>(
+          (earliest, item) =>
+            item.groupT0 === undefined
+              ? earliest
+              : Math.min(earliest ?? item.groupT0, item.groupT0),
+          bufferT0
+        );
+        bufferT0 = firstT0;
+      }
+      rejectWaiters(sinkError);
+    };
+
+    const launchGroup = (): void => {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      const groupT0 = bufferT0;
+      const groupTakenAt = Date.now();
+      const { group, bytes } = takeGroup();
+      const chunkSeq = nextChunkSeq;
+      nextChunkSeq += group.length;
+      const active: ActiveGroup = {
+        id: nextGroupId++,
+        chunkSeq,
+        chunks: group,
+        bytes,
+        groupT0,
+      };
+      activeGroups.set(active.id, active);
+      inFlightChunks += group.length;
+      inFlightBytes += bytes;
+      bufferT0 = buffer.length > 0 ? groupTakenAt : undefined;
+      void sendGroup(group, bytes, groupT0, chunkSeq).then(() => {
+        if (!activeGroups.delete(active.id)) return;
+        inFlightChunks -= group.length;
+        inFlightBytes -= bytes;
+        const relieved = capacityWaiters;
+        capacityWaiters = [];
+        for (const waiter of relieved) waiter.resolve();
+        startDispatch();
+        settleIfDrained();
+      }, failActiveGroups);
+    };
+
+    const fillPipeline = (depth: number): void => {
+      while (
+        sinkError === undefined &&
+        buffer.length > 0 &&
+        activeGroups.size < depth
+      ) {
+        launchGroup();
+      }
+      settleIfDrained();
+    };
+
+    /** Fill the advertised session pipeline without changing serial Worlds. */
+    const startDispatch = (): void => {
+      if (sinkError !== undefined || buffer.length === 0) return;
+      // Preserve zero-dwell leading dispatch before async session creation
+      // reveals whether this World supports more than one active group.
+      if (activeGroups.size === 0) launchGroup();
+      if (resolvedDispatchDepth !== undefined) {
+        fillPipeline(resolvedDispatchDepth);
+        return;
+      }
+      if (dispatchScheduled) return;
+      dispatchScheduled = true;
+      void dispatchDepth.then((depth) => {
+        dispatchScheduled = false;
+        resolvedDispatchDepth = depth;
+        fillPipeline(depth);
+      }, failActiveGroups);
     };
 
     /**
@@ -1564,7 +1595,11 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
      * `sendGroup` awaits the same promise before any request leaves.
      */
     const scheduleGroupCommit = (): void => {
-      if (flushTimer || inFlight) return;
+      if (flushTimer) return;
+      if (activeGroups.size > 0) {
+        startDispatch();
+        return;
+      }
       if (resolvedFlushIntervalMs === undefined) {
         // Promise.resolve: everywhere else the world is only ever awaited,
         // which tolerates a synchronous value (tests stub getWorldLazy that
@@ -1608,7 +1643,7 @@ export class WorkflowServerWritableStream extends WritableStream<Uint8Array> {
     const drain = async (): Promise<void> => {
       while (true) {
         if (sinkError !== undefined) throw sinkError;
-        if (buffer.length === 0 && !inFlight) return;
+        if (buffer.length === 0 && activeGroups.size === 0) return;
         startDispatch();
         await new Promise<void>((resolve, reject) => {
           drainWaiters.push({ resolve, reject });

--- a/packages/core/src/writable-stream.test.ts
+++ b/packages/core/src/writable-stream.test.ts
@@ -137,6 +137,177 @@ describe('WorkflowServerWritableStream', () => {
       expect(group.map((c: Uint8Array) => c[0])).toEqual([1, 2, 3, 4]);
     });
 
+    it('pipelines only for a session that advertises bounded depth', async () => {
+      const releases: Array<() => void> = [];
+      const session = {
+        maxInFlightWrites: 4,
+        write: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releases.push(resolve);
+            })
+        ),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockStreams.createWriteSession = vi.fn(() => session);
+      const stream = new WorkflowServerWritableStream('run-123', 'test-stream');
+      const writer = stream.getWriter();
+
+      for (let i = 0; i < 6; i++) await writer.write(new Uint8Array([i]));
+      await waitFor(() => expect(session.write).toHaveBeenCalledTimes(4));
+      expect(session.write.mock.calls.map(([seq]) => seq)).toEqual([
+        0, 1, 2, 3,
+      ]);
+
+      const closing = writer.close();
+      expect(session.close).not.toHaveBeenCalled();
+      releases.shift()?.();
+      await waitFor(() => expect(session.write).toHaveBeenCalledTimes(5));
+      expect(session.write.mock.calls[4]?.[0]).toBe(4);
+      expect(session.write.mock.calls[4]?.[1]).toHaveLength(2);
+      while (releases.length > 0) releases.shift()?.();
+      await closing;
+      expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      [1.5, 1],
+      [2.5, 2],
+      [Number.NaN, 1],
+      [Number.POSITIVE_INFINITY, 1],
+    ])('normalizes arbitrary session depth %s to %i active groups', async (maxInFlightWrites, expected) => {
+      const releases: Array<() => void> = [];
+      const session = {
+        maxInFlightWrites,
+        write: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releases.push(resolve);
+            })
+        ),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockStreams.createWriteSession = vi.fn(() => session);
+      const writer = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream'
+      ).getWriter();
+      for (let index = 0; index < 4; index++) {
+        await writer.write(new Uint8Array([index]));
+      }
+      await waitFor(() =>
+        expect(session.write).toHaveBeenCalledTimes(expected)
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(session.write).toHaveBeenCalledTimes(expected);
+      const closing = writer.close();
+      for (let attempt = 0; attempt < 4; attempt++) {
+        while (releases.length > 0) releases.shift()?.();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      await closing;
+    });
+
+    it('poisons drain when any active pipelined group fails', async () => {
+      let rejectFirst: ((error: Error) => void) | undefined;
+      const pending = new Promise<void>((_resolve, reject) => {
+        rejectFirst = reject;
+      });
+      const session = {
+        maxInFlightWrites: 4,
+        write: vi
+          .fn()
+          .mockImplementationOnce(() => pending)
+          .mockImplementation(() => new Promise<void>(() => {})),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockStreams.createWriteSession = vi.fn(() => session);
+      const writer = new WorkflowServerWritableStream(
+        'run-123',
+        'test-stream'
+      ).getWriter();
+      for (let i = 0; i < 3; i++) await writer.write(new Uint8Array([i]));
+      await waitFor(() => expect(session.write).toHaveBeenCalledTimes(3));
+      const closing = writer.close();
+      rejectFirst?.(new Error('pipeline failed'));
+      await expect(closing).rejects.toThrow('pipeline failed');
+      expect(session.close).not.toHaveBeenCalled();
+    });
+
+    it('counts every active pipelined group against the chunk bound', async () => {
+      process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS = '2';
+      const releases: Array<() => void> = [];
+      const session = {
+        maxInFlightWrites: 4,
+        write: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releases.push(resolve);
+            })
+        ),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockStreams.createWriteSession = vi.fn(() => session);
+      try {
+        const writer = new WorkflowServerWritableStream(
+          'run-123',
+          'test-stream'
+        ).getWriter();
+        await writer.write(new Uint8Array([0]));
+        const second = writer.write(new Uint8Array([1]));
+        await waitFor(() => expect(session.write).toHaveBeenCalledTimes(2));
+        let secondSettled = false;
+        void second.then(() => {
+          secondSettled = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(secondSettled).toBe(false);
+        releases.shift()?.();
+        await second;
+        releases.shift()?.();
+        await writer.close();
+      } finally {
+        delete process.env.WORKFLOW_STREAM_MAX_INFLIGHT_CHUNKS;
+      }
+    });
+
+    it('counts every active pipelined group against the byte bound', async () => {
+      process.env.WORKFLOW_STREAM_MAX_BUFFERED_BYTES = '2';
+      const releases: Array<() => void> = [];
+      const session = {
+        maxInFlightWrites: 4,
+        write: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releases.push(resolve);
+            })
+        ),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockStreams.createWriteSession = vi.fn(() => session);
+      try {
+        const writer = new WorkflowServerWritableStream(
+          'run-123',
+          'test-stream'
+        ).getWriter();
+        await writer.write(new Uint8Array([0]));
+        const second = writer.write(new Uint8Array([1]));
+        await waitFor(() => expect(session.write).toHaveBeenCalledTimes(2));
+        let secondSettled = false;
+        void second.then(() => {
+          secondSettled = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(secondSettled).toBe(false);
+        releases.shift()?.();
+        await second;
+        releases.shift()?.();
+        await writer.close();
+      } finally {
+        delete process.env.WORKFLOW_STREAM_MAX_BUFFERED_BYTES;
+      }
+    });
+
     it('should fall back to sequential writes when writeMulti is unavailable', async () => {
       // Remove writeMulti from mock world
       delete (mockStreams as any).writeMulti;

--- a/packages/world-vercel/src/ws-stream-session.test.ts
+++ b/packages/world-vercel/src/ws-stream-session.test.ts
@@ -123,6 +123,7 @@ beforeEach(() => {
   writeSpans.length = 0;
   delete process.env.WORKFLOW_STREAMS_TRANSPORT;
   delete process.env.WORKFLOW_REQUEST_TIMEOUT_MS;
+  delete process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH;
 });
 
 afterEach(() => {
@@ -159,6 +160,116 @@ function makeSession(
 }
 
 describe('v1 stream WebSocket writer lifecycle', () => {
+  it.each([
+    [undefined, 1],
+    ['1', 1],
+    ['2', 2],
+    ['4', 4],
+  ])('advertises effective pipeline depth %j', (value, expected) => {
+    if (value === undefined) {
+      delete process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH;
+    } else {
+      process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = value;
+    }
+    expect(makeSession().session.maxInFlightWrites).toBe(expected);
+  });
+
+  it('bounds and correlates pipelined writes by reqId', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = '4';
+    const { session } = makeSession();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const socket = sockets[0];
+    socket.open();
+    const writes = Array.from({ length: 5 }, (_, index) =>
+      session.write(index, [new Uint8Array([index])])
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(4));
+    expect(
+      await Promise.all(
+        socket.sent.map(async (frame) => (await decodeOne(frame)).meta)
+      )
+    ).toMatchObject([
+      { reqId: 1, chunkSeq: 0 },
+      { reqId: 2, chunkSeq: 1 },
+      { reqId: 3, chunkSeq: 2 },
+      { reqId: 4, chunkSeq: 3 },
+    ]);
+    socket.reply(
+      encodeFrame({ type: 'write_ack', reqId: 3 }, new Uint8Array())
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(5));
+    for (const reqId of [1, 2, 4, 5]) {
+      socket.reply(encodeFrame({ type: 'write_ack', reqId }, new Uint8Array()));
+    }
+    await Promise.all(writes);
+  });
+
+  it('caps split-group frames at the global pipeline depth', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = '2';
+    const { session } = makeSession();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const socket = sockets[0];
+    socket.open();
+    const writing = session.write(
+      0,
+      Array.from({ length: 2001 }, () => new Uint8Array([1]))
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(2));
+    socket.reply(
+      encodeFrame({ type: 'write_ack', reqId: 1 }, new Uint8Array())
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    for (const reqId of [2, 3]) {
+      socket.reply(encodeFrame({ type: 'write_ack', reqId }, new Uint8Array()));
+    }
+    await writing;
+    expect(writeSpans.slice(0, 3)).toMatchObject([
+      {
+        'workflow.stream.ws.pipeline_depth': 2,
+        'workflow.stream.ws.frame_index': 0,
+        'workflow.stream.ws.frame_count': 3,
+      },
+      {
+        'workflow.stream.ws.pipeline_depth': 2,
+        'workflow.stream.ws.frame_index': 1,
+        'workflow.stream.ws.frame_count': 3,
+      },
+      {
+        'workflow.stream.ws.pipeline_depth': 2,
+        'workflow.stream.ws.frame_index': 2,
+        'workflow.stream.ws.frame_count': 3,
+      },
+    ]);
+  });
+
+  it('never replays a split group after any sibling frame was sent', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = '1';
+    const { session, writeHttp } = makeSession();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const socket = sockets[0];
+    socket.open();
+    const writing = session.write(
+      0,
+      Array.from({ length: 1001 }, () => new Uint8Array([1]))
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+
+    // The first frame may already be durable. If the socket becomes unusable
+    // before its queued sibling is sent, failing the whole group over to HTTP
+    // would duplicate that prefix.
+    socket.close(1006, 'connection lost');
+    socket.emit('close', 1006);
+
+    await expect(writing).rejects.toThrow('closed before reply');
+    expect(writeHttp).not.toHaveBeenCalled();
+    await expect(session.write(1001, ['later'])).rejects.toThrow(
+      'closed before reply'
+    );
+  });
+
   it('keeps HTTP as the default without constructing a socket', async () => {
     const { session, writeHttp, closeHttp } = makeSession();
     await session.write(0, ['one']);
@@ -224,6 +335,42 @@ describe('v1 stream WebSocket writer lifecycle', () => {
       encodeFrame({ type: 'write_ack', reqId: 1 }, new Uint8Array())
     );
     await fourth;
+  });
+
+  it('seals the HTTP prefix before pipelined WS takeover', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = '4';
+    let releaseSecond: (() => void) | undefined;
+    const secondPending = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+    await session.write(0, ['one']);
+    writeHttp.mockImplementationOnce(
+      async (_chunks, _attributes, dispatched) => {
+        dispatched?.();
+        await secondPending;
+      }
+    );
+    const second = session.write(1, ['two']);
+    const third = session.write(2, ['three']);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].open();
+    const fourth = session.write(3, ['four']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sockets[0].sent).toHaveLength(0);
+    expect(writeHttp).toHaveBeenCalledTimes(2);
+    releaseSecond?.();
+    await Promise.all([second, third]);
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    expect((await decodeOne(sockets[0].sent[0])).meta).toMatchObject({
+      chunkSeq: 3,
+    });
+    sockets[0].reply(
+      encodeFrame({ type: 'write_ack', reqId: 1 }, new Uint8Array())
+    );
+    await fourth;
+    expect(writeHttp.mock.calls[2]?.[0]).toEqual(['three']);
   });
 
   it('closes over HTTP without waiting for the background socket', async () => {
@@ -712,6 +859,40 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     expect(writeSpans[1]['workflow.stream.ws.connect_ms']).toEqual(
       expect.any(Number)
     );
+  });
+
+  it('settles queued writes over HTTP when drain reconnect is declined', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = '2';
+    const { session, writeHttp } = makeSession();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const firstSocket = sockets[0];
+    firstSocket.open();
+
+    const writes = [
+      session.write(0, ['one']),
+      session.write(1, ['two']),
+      session.write(2, ['three']),
+    ];
+    await vi.waitFor(() => expect(firstSocket.sent).toHaveLength(2));
+    firstSocket.reply(
+      encodeFrame(
+        { type: 'drain', reason: 'max_duration', graceMs: 10_000 },
+        new Uint8Array()
+      )
+    );
+    for (const reqId of [1, 2]) {
+      firstSocket.reply(
+        encodeFrame({ type: 'write_ack', reqId }, new Uint8Array())
+      );
+    }
+    firstSocket.emit('close', 1001);
+    await vi.waitFor(() => expect(sockets).toHaveLength(2));
+    sockets[1].emit('unexpected-response', {}, {});
+
+    await Promise.all(writes);
+    expect(writeHttp).toHaveBeenCalledTimes(1);
+    expect(writeHttp).toHaveBeenCalledWith(['three']);
   });
 
   it('requests fresh auth after an auth-expiry drain', async () => {

--- a/packages/world-vercel/src/ws-stream-session.ts
+++ b/packages/world-vercel/src/ws-stream-session.ts
@@ -25,7 +25,10 @@ import {
   STREAM_WS_INITIAL_CONNECT_TIMEOUT_MS,
   STREAM_WS_RECONNECT_BUDGET_MS,
 } from './ws-stream-connect.js';
-import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
+import {
+  getWsStreamWritePipelineDepth,
+  isWsStreamsTransportEnabled,
+} from './ws-transport-enabled.js';
 
 type Mode =
   | 'deferred'
@@ -43,6 +46,8 @@ type WriteTiming = {
 type WriteMetadata = {
   chunkSeq: number;
   numChunks: number;
+  frameIndex: number;
+  frameCount: number;
 };
 type ConnectionTiming = {
   attempt: number;
@@ -52,13 +57,23 @@ type ConnectionTiming = {
   openedAt?: number;
   firstWriteSent: boolean;
 };
+type RequestGroupState = {
+  sentAny: boolean;
+};
 type PendingRequest = {
   reqId: number;
+  frame: Uint8Array;
+  group?: RequestGroupState;
+  fallback?: () => Promise<Record<string, unknown>>;
   resolve: (meta: Record<string, unknown>) => void;
   reject: (error: unknown) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timer?: ReturnType<typeof setTimeout>;
   sentAt?: number;
   replyReceivedAt?: number;
+  span?: Span;
+  writeTiming?: WriteTiming;
+  writeMetadata?: WriteMetadata;
+  connectionTiming?: ConnectionTiming;
 };
 const MAX_IDLE_RECONNECTS = 3;
 
@@ -196,10 +211,18 @@ class VercelStreamWriteSession implements StreamWriteSession {
   private socket: WebSocket | undefined;
   private connect = Promise.resolve();
   private transportDecision = Promise.resolve();
-  private tail = Promise.resolve();
+  readonly maxInFlightWrites = getWsStreamWritePipelineDepth();
+  private httpTail = Promise.resolve();
   private inbound = Promise.resolve();
   private nextReqId = 1;
-  private pending: PendingRequest | undefined;
+  private activeRequests = 0;
+  private requestQueue: PendingRequest[] = [];
+  private pending = new Map<number, PendingRequest>();
+  private completedThroughReqId = 0;
+  private completedOutOfOrderReqIds = new Set<number>();
+  private writeOperations = new Set<Promise<void>>();
+  private closing = false;
+  private writeOrdinal = 0;
   private poisonError: unknown;
   private wsUrl: string | undefined;
   private closeAcknowledged = false;
@@ -234,82 +257,132 @@ class VercelStreamWriteSession implements StreamWriteSession {
   }
 
   write(chunkSeq: number, chunks: (string | Uint8Array)[]): Promise<void> {
+    if (this.closing)
+      return Promise.reject(new Error('stream writer is closing'));
     const timing: WriteTiming = {
       startedAt: now(),
       sessionFirstWrite: !this.sessionHasWrite,
     };
     this.sessionHasWrite = true;
-    return this.enqueue(() => this.writeInternal(chunkSeq, chunks, timing));
+    const ordinal = ++this.writeOrdinal;
+    const operation = this.writeInternal(chunkSeq, chunks, timing, ordinal);
+    this.writeOperations.add(operation);
+    void operation.then(
+      () => this.writeOperations.delete(operation),
+      () => this.writeOperations.delete(operation)
+    );
+    return operation;
   }
 
   private async writeInternal(
     chunkSeq: number,
     chunks: (string | Uint8Array)[],
-    timing: WriteTiming
+    timing: WriteTiming,
+    ordinal: number
   ): Promise<void> {
     this.assertUsable();
-    if (this.mode === 'deferred') {
-      await this.writeFirstGroup(chunks, timing);
-      return;
+    if (this.connectAfterFirstWrite && ordinal === 1) {
+      return this.writeFirstGroup(chunks, timing);
     }
-    if (this.mode === 'waiting_to_connect') {
-      await this.writeSecondGroupAndStartConnect(chunks, timing);
-      return;
+    if (this.connectAfterFirstWrite && ordinal === 2) {
+      return this.writeSecondGroupAndStartConnect(chunks, timing);
     }
-    if (this.shouldWriteHttpWhileConnecting()) {
-      await this.writeWhileInitialConnectRuns(chunks, timing);
-      return;
+    // Every group classified before the initial OPEN belongs to the sealed HTTP
+    // prefix. The shared tail preserves order and prevents an OPEN from moving
+    // already-admitted work onto WS.
+    if (
+      this.connectionAttempt <= 1 &&
+      (this.mode === 'deferred' ||
+        this.mode === 'waiting_to_connect' ||
+        this.mode === 'connecting')
+    ) {
+      return this.writeWhileInitialConnectRuns(chunks, timing);
     }
     await this.transportDecision;
+    await this.httpTail;
     this.assertUsable();
-    if (this.mode === 'http') {
-      await this.writeHttp(chunks);
+    if (this.mode === 'http')
+      return this.enqueueHttp(() => this.writeHttp(chunks));
+
+    const frameCount = Math.ceil(
+      chunks.length / STREAM_WS_V1_MAX_CHUNKS_PER_WRITE
+    );
+    const group: RequestGroupState = { sentAny: false };
+    const frames: Array<{
+      reqId: number;
+      frame: Uint8Array;
+      timing: WriteTiming | undefined;
+      metadata: WriteMetadata;
+      fallback: () => Promise<Record<string, unknown>>;
+    }> = [];
+    try {
+      for (
+        let offset = 0, frameIndex = 0;
+        offset < chunks.length;
+        offset += STREAM_WS_V1_MAX_CHUNKS_PER_WRITE, frameIndex++
+      ) {
+        const batch = chunks.slice(
+          offset,
+          offset + STREAM_WS_V1_MAX_CHUNKS_PER_WRITE
+        );
+        const reqId = this.nextReqId++;
+        frames.push({
+          reqId,
+          frame: encodeStreamWsWriteRequest(
+            {
+              type: 'write',
+              reqId,
+              chunkSeq: chunkSeq + offset,
+              numChunks: batch.length,
+            },
+            batch
+          ),
+          timing: offset === 0 ? timing : undefined,
+          metadata: {
+            chunkSeq: chunkSeq + offset,
+            numChunks: batch.length,
+            frameIndex,
+            frameCount,
+          },
+          fallback: async () => {
+            await this.enqueueHttp(() => this.writeHttp(batch));
+            return { type: 'write_ack', reqId };
+          },
+        });
+      }
+    } catch {
+      this.fallbackToHttpBeforeSend();
+      await this.enqueueHttp(() => this.writeHttp(chunks));
       return;
     }
-    // Core's default group cap equals the wire cap, so splitting is normally
-    // dormant. Keep it here as a guard against configured or future cap drift;
-    // v1 deliberately defines no separate whole-message byte budget.
-    for (
-      let offset = 0;
-      offset < chunks.length;
-      offset += STREAM_WS_V1_MAX_CHUNKS_PER_WRITE
-    ) {
-      const batch = chunks.slice(
-        offset,
-        offset + STREAM_WS_V1_MAX_CHUNKS_PER_WRITE
-      );
-      let reply: Record<string, unknown>;
-      try {
-        reply = await this.request(
-          (reqId) =>
-            encodeStreamWsWriteRequest(
-              {
-                type: 'write',
-                reqId,
-                chunkSeq: chunkSeq + offset,
-                numChunks: batch.length,
-              },
-              batch
-            ),
-          offset === 0 ? timing : undefined,
-          { chunkSeq: chunkSeq + offset, numChunks: batch.length }
-        );
-      } catch (error) {
-        if (!(error instanceof StreamWsRequestNotSentError)) throw error;
-        this.fallbackToHttpBeforeSend();
-        await this.writeHttp(chunks.slice(offset));
-        return;
-      }
+    const requests = frames.map(
+      ({ reqId, frame, timing, metadata, fallback }) =>
+        this.requestFrame(reqId, frame, timing, metadata, group, fallback)
+    );
+    let replies: Record<string, unknown>[];
+    try {
+      replies = await Promise.all(requests);
+    } catch (error) {
+      if (!(error instanceof StreamWsRequestNotSentError)) throw error;
+      this.fallbackToHttpBeforeSend();
+      await this.enqueueHttp(() => this.writeHttp(chunks));
+      return;
+    }
+    for (const reply of replies) {
       if (reply.type !== 'write_ack') {
-        throw this.poison(
+        this.failUnknown(
           new Error(`stream WebSocket write received ${reply.type}`)
         );
+        throw this.poisonError;
       }
     }
   }
 
-  private shouldWriteHttpWhileConnecting(): boolean {
-    return this.mode === 'connecting' && this.connectionAttempt === 1;
+  private enqueueHttp(operation: () => Promise<void>): Promise<void> {
+    const result = this.httpTail.then(operation);
+    this.httpTail = result;
+    void result.catch(() => {});
+    return result;
   }
 
   private async writeWhileInitialConnectRuns(
@@ -321,13 +394,15 @@ class VercelStreamWriteSession implements StreamWriteSession {
     // prevents WS from overtaking HTTP. An HTTP failure poisons the writer
     // because its outcome may be unknown and must never be replayed over WS.
     try {
-      await this.writeHttp(chunks, {
-        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
-        'workflow.stream.ws.connection_attempt': this.connectionAttempt,
-        'workflow.stream.ws.connecting_at_write': true,
-        'workflow.stream.ws.session_to_write_ms':
-          timing.startedAt - this.sessionCreatedAt,
-      });
+      await this.enqueueHttp(() =>
+        this.writeHttp(chunks, {
+          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+          'workflow.stream.ws.connection_attempt': this.connectionAttempt,
+          'workflow.stream.ws.connecting_at_write': true,
+          'workflow.stream.ws.session_to_write_ms':
+            timing.startedAt - this.sessionCreatedAt,
+        })
+      );
     } catch (error) {
       this.failUnknown(error);
       throw this.poisonError;
@@ -339,20 +414,22 @@ class VercelStreamWriteSession implements StreamWriteSession {
     timing: WriteTiming
   ): Promise<void> {
     try {
-      await this.writeHttp(
-        chunks,
-        {
-          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
-          'workflow.stream.ws.connection_attempt': 0,
-          'workflow.stream.ws.connecting_at_write': false,
-          'workflow.stream.ws.connect_after_http_group': 2,
-          'workflow.stream.ws.session_to_write_ms':
-            timing.startedAt - this.sessionCreatedAt,
-        },
-        () => {
-          if (this.mode !== 'waiting_to_connect') return;
-          this.startInitialConnect();
-        }
+      await this.enqueueHttp(() =>
+        this.writeHttp(
+          chunks,
+          {
+            'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+            'workflow.stream.ws.connection_attempt': 0,
+            'workflow.stream.ws.connecting_at_write': false,
+            'workflow.stream.ws.connect_after_http_group': 2,
+            'workflow.stream.ws.session_to_write_ms':
+              timing.startedAt - this.sessionCreatedAt,
+          },
+          () => {
+            if (this.mode !== 'waiting_to_connect') return;
+            this.startInitialConnect();
+          }
+        )
       );
     } catch (error) {
       this.failUnknown(error);
@@ -368,15 +445,17 @@ class VercelStreamWriteSession implements StreamWriteSession {
     // HTTP success may start the background upgrade; an ambiguous outcome must
     // never be followed by work on another transport.
     try {
-      await this.writeHttp(chunks, {
-        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
-        'workflow.stream.ws.connection_attempt': 0,
-        'workflow.stream.ws.connecting_at_write': false,
-        'workflow.stream.ws.connect_deferred_at_write': true,
-        'workflow.stream.ws.http_group_ordinal': 1,
-        'workflow.stream.ws.session_to_write_ms':
-          timing.startedAt - this.sessionCreatedAt,
-      });
+      await this.enqueueHttp(() =>
+        this.writeHttp(chunks, {
+          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+          'workflow.stream.ws.connection_attempt': 0,
+          'workflow.stream.ws.connecting_at_write': false,
+          'workflow.stream.ws.connect_deferred_at_write': true,
+          'workflow.stream.ws.http_group_ordinal': 1,
+          'workflow.stream.ws.session_to_write_ms':
+            timing.startedAt - this.sessionCreatedAt,
+        })
+      );
     } catch (error) {
       this.failUnknown(error);
       throw this.poisonError;
@@ -388,63 +467,45 @@ class VercelStreamWriteSession implements StreamWriteSession {
     if (this.mode === 'closed') return;
     this.mode = 'closed';
     this.finishDrainWait();
-    const pending = this.pending;
-    this.pending = undefined;
-    if (pending) {
-      clearTimeout(pending.timer);
-      pending.reject(new Error('stream writer transport disposed'));
-    }
+    this.rejectAll(new Error('stream writer transport disposed'));
     this.socket?.close(1000, 'stream writer disposed');
   }
 
-  close(): Promise<void> {
-    return this.enqueue(async () => {
-      this.assertUsable();
-      if (
-        this.mode === 'deferred' ||
-        this.mode === 'waiting_to_connect' ||
-        (this.connectAfterFirstWrite &&
-          this.mode === 'connecting' &&
-          this.connectionAttempt === 1)
-      ) {
-        await this.closeHttp();
-        this.mode = 'closed';
-        this.socket?.close(1000, 'stream closed over HTTP');
-        return;
-      }
-      await this.transportDecision;
-      this.assertUsable();
-      if (this.mode === 'http') {
-        await this.closeHttp();
-        this.mode = 'closed';
-        return;
-      }
-      let reply: Record<string, unknown>;
-      try {
-        reply = await this.request((reqId) =>
-          encodeStreamWsCloseRequest({ type: 'close', reqId })
-        );
-      } catch (error) {
-        if (!(error instanceof StreamWsRequestNotSentError)) throw error;
-        this.fallbackToHttpBeforeSend();
-        await this.closeHttp();
-        this.mode = 'closed';
-        return;
-      }
-      if (reply.type !== 'close_ack') {
-        throw this.poison(
-          new Error(`stream WebSocket close received ${reply.type}`)
-        );
-      }
+  async close(): Promise<void> {
+    this.assertUsable();
+    this.closing = true;
+    await Promise.all(this.writeOperations);
+    await this.httpTail;
+    if (
+      this.mode === 'deferred' ||
+      this.mode === 'waiting_to_connect' ||
+      (this.connectAfterFirstWrite &&
+        this.mode === 'connecting' &&
+        this.connectionAttempt === 1)
+    ) {
+      await this.closeHttp();
       this.mode = 'closed';
-      if (this.socket) beginNormalWsClose(this.socket, 'stream closed');
-    });
-  }
-
-  private enqueue(operation: () => Promise<void>): Promise<void> {
-    const result = this.tail.then(operation);
-    this.tail = result.catch(() => {});
-    return result;
+      this.socket?.close(1000, 'stream closed over HTTP');
+      return;
+    }
+    await this.transportDecision;
+    this.assertUsable();
+    if (this.mode === 'http') {
+      await this.closeHttp();
+      this.mode = 'closed';
+      return;
+    }
+    const reply = await this.request((reqId) =>
+      encodeStreamWsCloseRequest({ type: 'close', reqId })
+    );
+    if (reply.type !== 'close_ack') {
+      this.failUnknown(
+        new Error(`stream WebSocket close received ${reply.type}`)
+      );
+      throw this.poisonError;
+    }
+    this.mode = 'closed';
+    if (this.socket) beginNormalWsClose(this.socket, 'stream closed');
   }
 
   private assertUsable(): void {
@@ -473,6 +534,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
           if (this.mode === 'connecting') {
             this.mode = 'http';
             this.socket?.close(1000, 'connect budget expired');
+            this.flushQueuedOverHttp();
           }
           decide();
         },
@@ -496,7 +558,10 @@ class VercelStreamWriteSession implements StreamWriteSession {
     return this.connectSocket(forceRefresh, timing).catch(() => {
       // Every failure before OPEN is a safe, session-long HTTP fallback. The
       // HTTP request itself still surfaces auth/configuration errors normally.
-      if (this.mode === 'connecting') this.mode = 'http';
+      if (this.mode === 'connecting') {
+        this.mode = 'http';
+        this.flushQueuedOverHttp();
+      }
     });
   }
 
@@ -506,6 +571,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
   ): Promise<void> {
     if (!isWsStreamsTransportEnabled()) {
       this.mode = 'http';
+      this.flushQueuedOverHttp();
       return;
     }
     if (forceRefresh) {
@@ -534,11 +600,13 @@ class VercelStreamWriteSession implements StreamWriteSession {
       // A Vercel invocation's context token cannot be refreshed in place. Do
       // not reconnect with the bearer the server is explicitly draining.
       this.mode = 'http';
+      this.flushQueuedOverHttp();
       return;
     }
     this.lastAuthorization = readAuthorization(http.headers);
     if (http.usingProxy) {
       this.mode = 'http';
+      this.flushQueuedOverHttp();
       return;
     }
     if (this.mode !== 'connecting') return;
@@ -570,7 +638,10 @@ class VercelStreamWriteSession implements StreamWriteSession {
           let opened = false;
           const fallback = () => {
             if (opened) return;
-            if (this.mode === 'connecting') this.mode = 'http';
+            if (this.mode === 'connecting') {
+              this.mode = 'http';
+              this.flushQueuedOverHttp();
+            }
             resolve();
           };
           ws.once('open', () => {
@@ -582,6 +653,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
               return;
             }
             this.mode = 'ws';
+            this.pumpRequests();
             resolve();
           });
           ws.once('unexpected-response', (_request, response) => {
@@ -638,39 +710,47 @@ class VercelStreamWriteSession implements StreamWriteSession {
         this.handleDrain(reply.reason, reply.graceMs);
         return;
       }
-      const pending = this.pending;
-      if (
-        !pending ||
-        reply.reqId === undefined ||
-        reply.reqId !== pending.reqId
-      ) {
+      const pending =
+        reply.reqId === undefined ? undefined : this.pending.get(reply.reqId);
+      if (!pending) {
         if (reply.type === 'error') {
           throw new Error(
             `stream WebSocket connection failed (${reply.status}): ${reply.message ?? 'unknown error'}`
           );
         }
+        if (
+          reply.reqId !== undefined &&
+          (reply.reqId <= this.completedThroughReqId ||
+            this.completedOutOfOrderReqIds.has(reply.reqId))
+        ) {
+          return;
+        }
         throw new Error('stream WebSocket reply cannot be correlated');
       }
-      this.pending = undefined;
+      this.pending.delete(pending.reqId);
+      this.activeRequests--;
       pending.replyReceivedAt = receivedAt;
-      clearTimeout(pending.timer);
+      if (pending.timer) clearTimeout(pending.timer);
       if (reply.type === 'close_ack') this.closeAcknowledged = true;
       if (reply.type === 'error') {
-        // v1 is fail-stop and provides no machine-readable retry class. HTTP
-        // status alone cannot prove whether a rejected write was appended, so
-        // every correlated error remains terminal until the protocol can state
-        // that retrying (or continuing this connection) is safe.
-        pending.reject(
-          this.poison(
-            new Error(
-              `stream WebSocket request failed (${reply.status}): ${reply.message ?? 'unknown error'}`
-            )
+        const poisoned = this.poison(
+          new Error(
+            `stream WebSocket request failed (${reply.status}): ${reply.message ?? 'unknown error'}`
           )
         );
+        pending.reject(poisoned);
+        this.rejectAll(poisoned);
         this.socket?.close(1011, 'stream request failed');
       } else {
         if (reply.type === 'write_ack') this.idleReconnects = 0;
+        this.completedOutOfOrderReqIds.add(pending.reqId);
+        while (
+          this.completedOutOfOrderReqIds.delete(this.completedThroughReqId + 1)
+        ) {
+          this.completedThroughReqId++;
+        }
         pending.resolve(reply);
+        this.pumpRequests();
       }
     } catch (error) {
       this.failUnknown(error);
@@ -696,7 +776,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
       () => {
         this.drainTimer = undefined;
         if (this.mode !== 'draining' || socket !== this.socket) return;
-        if (this.pending) {
+        if (this.pending.size > 0) {
           this.failUnknown(
             new Error('stream WebSocket drain expired before request reply')
           );
@@ -724,7 +804,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
     ) {
       return;
     }
-    if (this.pending) {
+    if (this.pending.size > 0) {
       this.failUnknown(new Error('stream WebSocket closed before reply'));
       return;
     }
@@ -735,6 +815,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
       this.drainReason = undefined;
       this.mode = 'http';
       this.socket = undefined;
+      this.flushQueuedOverHttp();
       this.finishDrainWait();
       return;
     }
@@ -744,6 +825,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
       if (this.idleReconnects >= MAX_IDLE_RECONNECTS) {
         this.mode = 'http';
         this.socket = undefined;
+        this.flushQueuedOverHttp();
         this.finishDrainWait();
         return;
       }
@@ -765,6 +847,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
     if (this.idleReconnects >= MAX_IDLE_RECONNECTS) {
       this.mode = 'http';
       this.socket = undefined;
+      this.flushQueuedOverHttp();
       return;
     }
     this.idleReconnects++;
@@ -774,25 +857,31 @@ class VercelStreamWriteSession implements StreamWriteSession {
     this.transportDecision = this.makeTransportDecision(true);
   }
 
-  private async request(
+  private request(
     buildFrame: (reqId: number) => Uint8Array,
     writeTiming?: WriteTiming,
     writeMetadata?: WriteMetadata
   ): Promise<Record<string, unknown>> {
     this.assertUsable();
-    const ws = this.socket;
-    if (this.mode !== 'ws' || !ws || ws.readyState !== 1) {
-      throw new StreamWsRequestNotSentError(
-        new Error('stream WebSocket is not open before send')
-      );
-    }
     const reqId = this.nextReqId++;
     let frame: Uint8Array;
     try {
       frame = buildFrame(reqId);
     } catch (error) {
-      throw new StreamWsRequestNotSentError(error);
+      return Promise.reject(new StreamWsRequestNotSentError(error));
     }
+    return this.requestFrame(reqId, frame, writeTiming, writeMetadata);
+  }
+
+  private requestFrame(
+    reqId: number,
+    frame: Uint8Array,
+    writeTiming?: WriteTiming,
+    writeMetadata?: WriteMetadata,
+    group?: RequestGroupState,
+    fallback?: () => Promise<Record<string, unknown>>
+  ): Promise<Record<string, unknown>> {
+    this.assertUsable();
     const connectionTiming = this.connectionTiming;
     const connectionFirstWrite = connectionTiming?.firstWriteSent === false;
     const detailedTiming =
@@ -807,10 +896,15 @@ class VercelStreamWriteSession implements StreamWriteSession {
         attributes: {
           'workflow.stream.transport': 'ws',
           'workflow.stream.ws.req_id': reqId,
+          'workflow.stream.ws.pipeline_depth': this.maxInFlightWrites,
           ...(writeMetadata
             ? {
                 'workflow.stream.ws.chunk_seq': writeMetadata.chunkSeq,
                 'workflow.stream.ws.num_chunks': writeMetadata.numChunks,
+                'workflow.stream.ws.frame_chunks': writeMetadata.numChunks,
+                'workflow.stream.ws.frame_bytes': frame.byteLength,
+                'workflow.stream.ws.frame_index': writeMetadata.frameIndex,
+                'workflow.stream.ws.frame_count': writeMetadata.frameCount,
               }
             : {}),
           ...firstWriteAttributes(
@@ -821,52 +915,123 @@ class VercelStreamWriteSession implements StreamWriteSession {
         },
       },
       async (span) => {
-        if (detailedTiming) {
-          recordFirstWriteSetup(span, detailedTiming, connectionTiming);
-        }
-        let pending: PendingRequest | undefined;
+        let queued: PendingRequest | undefined;
         const response = new Promise<Record<string, unknown>>(
           (resolve, reject) => {
-            // With no v1 progress/control reply, silence cannot distinguish a
-            // slow accepted request from a dead socket. Expiry is therefore an
-            // unknown outcome and must poison rather than replay.
-            const timer = setTimeout(() => {
-              this.failUnknown(
-                new Error(
-                  `stream WebSocket request ${reqId} timed out with no reply`
-                )
-              );
-            }, getRequestTimeoutMs());
-            timer.unref?.();
-            pending = { reqId, resolve, reject, timer };
-            this.pending = pending;
-            try {
-              if (detailedTiming) {
-                recordFirstWriteSend(
-                  span,
-                  detailedTiming,
-                  connectionTiming,
-                  pending
-                );
-              }
-              ws.send(frame, (error) => {
-                if (!error) return;
-                this.failUnknown(error);
-              });
-            } catch (error) {
-              this.failUnknown(error);
-            }
+            queued = {
+              reqId,
+              frame,
+              group,
+              fallback,
+              resolve,
+              reject,
+              span,
+              writeTiming,
+              writeMetadata,
+              connectionTiming,
+            };
+            this.requestQueue.push(queued);
+            this.pumpRequests();
           }
         );
         try {
           return await response;
         } finally {
-          if (detailedTiming) {
-            recordFirstWriteReply(span, detailedTiming, pending);
-          }
+          if (detailedTiming)
+            recordFirstWriteReply(span, detailedTiming, queued);
         }
       }
     );
+  }
+
+  private pumpRequests(): void {
+    while (
+      this.activeRequests < this.maxInFlightWrites &&
+      this.requestQueue.length > 0 &&
+      this.mode === 'ws'
+    ) {
+      const request = this.requestQueue.shift();
+      if (!request) return;
+      const ws = this.socket;
+      if (!ws || ws.readyState !== 1) {
+        const cause = new Error('stream WebSocket is not open before send');
+        if (request.group?.sentAny || this.pending.size > 0) {
+          this.failUnknown(cause);
+        } else {
+          const error = new StreamWsRequestNotSentError(cause);
+          request.reject(error);
+          this.rejectAll(error);
+        }
+        return;
+      }
+      const connectionTiming = this.connectionTiming;
+      const detailedTiming =
+        request.writeTiming &&
+        (request.writeTiming.sessionFirstWrite ||
+          connectionTiming?.firstWriteSent === false)
+          ? request.writeTiming
+          : undefined;
+      request.span?.setAttributes({
+        'workflow.stream.ws.inflight_at_send': this.activeRequests + 1,
+        ...firstWriteAttributes(
+          detailedTiming,
+          connectionTiming,
+          this.sessionCreatedAt
+        ),
+      });
+      if (detailedTiming) {
+        recordFirstWriteSetup(request.span, detailedTiming, connectionTiming);
+      }
+      request.connectionTiming = connectionTiming;
+      request.writeTiming = detailedTiming;
+      if (request.group) request.group.sentAny = true;
+      this.activeRequests++;
+      this.pending.set(request.reqId, request);
+      request.timer = setTimeout(() => {
+        this.failUnknown(
+          new Error(
+            `stream WebSocket request ${request.reqId} timed out with no reply`
+          )
+        );
+      }, getRequestTimeoutMs());
+      request.timer.unref?.();
+      if (request.writeTiming) {
+        recordFirstWriteSend(
+          request.span,
+          request.writeTiming,
+          request.connectionTiming,
+          request
+        );
+      }
+      try {
+        ws.send(request.frame, (error) => {
+          if (error) this.failUnknown(error);
+        });
+      } catch (error) {
+        this.failUnknown(error);
+      }
+    }
+  }
+
+  private flushQueuedOverHttp(): void {
+    const queued = this.requestQueue;
+    this.requestQueue = [];
+    void (async () => {
+      for (const request of queued) {
+        if (!request.fallback) {
+          this.failUnknown(
+            new Error('queued stream WebSocket request cannot fall back')
+          );
+          return;
+        }
+        try {
+          request.resolve(await request.fallback());
+        } catch (error) {
+          this.failUnknown(error);
+          return;
+        }
+      }
+    })();
   }
 
   private finishDrainWait(): void {
@@ -885,15 +1050,21 @@ class VercelStreamWriteSession implements StreamWriteSession {
     this.socket = undefined;
   }
 
+  private rejectAll(error: unknown): void {
+    const requests = [...this.pending.values(), ...this.requestQueue];
+    this.pending.clear();
+    this.requestQueue = [];
+    this.activeRequests = 0;
+    for (const request of requests) {
+      if (request.timer) clearTimeout(request.timer);
+      request.reject(error);
+    }
+  }
+
   private failUnknown(error: unknown): void {
     const poisoned = this.poison(error);
     this.finishDrainWait();
-    const pending = this.pending;
-    this.pending = undefined;
-    if (pending) {
-      clearTimeout(pending.timer);
-      pending.reject(poisoned);
-    }
+    this.rejectAll(poisoned);
     this.socket?.close(1011, 'unknown stream write outcome');
   }
 

--- a/packages/world-vercel/src/ws-streams-transport-enabled.test.ts
+++ b/packages/world-vercel/src/ws-streams-transport-enabled.test.ts
@@ -1,8 +1,32 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
+import {
+  getWsStreamWritePipelineDepth,
+  isWsStreamsTransportEnabled,
+} from './ws-transport-enabled.js';
 
 afterEach(() => {
   delete process.env.WORKFLOW_STREAMS_TRANSPORT;
+  delete process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH;
+});
+
+describe('getWsStreamWritePipelineDepth', () => {
+  it.each([
+    [undefined, 1],
+    ['', 1],
+    ['0', 1],
+    ['1', 1],
+    ['2', 2],
+    ['3', 1],
+    ['4', 4],
+    ['04', 1],
+  ])('uses only supported exact depths: %j', (value, expected) => {
+    if (value === undefined) {
+      delete process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH;
+    } else {
+      process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH = value;
+    }
+    expect(getWsStreamWritePipelineDepth()).toBe(expected);
+  });
 });
 
 describe('isWsStreamsTransportEnabled', () => {

--- a/packages/world-vercel/src/ws-transport-enabled.ts
+++ b/packages/world-vercel/src/ws-transport-enabled.ts
@@ -70,3 +70,11 @@ export function isWsEventsTransportStrict(): boolean {
 export function isWsStreamsTransportEnabled(): boolean {
   return process.env.WORKFLOW_STREAMS_TRANSPORT === 'ws';
 }
+
+/** Experimental bounded write depth; invalid values fail closed to serial. */
+export function getWsStreamWritePipelineDepth(): 1 | 2 | 4 {
+  const raw = process.env.WORKFLOW_STREAM_WRITE_PIPELINE_DEPTH;
+  if (raw === '2') return 2;
+  if (raw === '4') return 4;
+  return 1;
+}

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -41,6 +41,9 @@ import type {
 } from './steps.js';
 
 export interface StreamWriteSession {
+  /** Maximum ordered write requests core may dispatch concurrently. */
+  readonly maxInFlightWrites?: number;
+
   /**
    * Write one ordered group from this in-memory writer lifetime.
    * `chunkSeq` is writer-local and identifies the first chunk in `chunks`.


### PR DESCRIPTION
## Summary & Motivation

Adds an experimental, default-off bounded WebSocket write pipeline on top of the HTTP-first background takeover path. Core reserves ordered chunk sequences before concurrent dispatch and honors session-advertised depths up to four, while HTTP and non-capable Worlds remain serial.

The WebSocket session correlates frames by request ID, globally bounds split frames, waits for the complete sealed HTTP prefix before takeover, and treats every possibly-sent unresolved outcome as terminal without replay. Provably unsent whole groups may still fall back safely. Depths above one require paired server batch flush and are not intended for independent rollout.

Adds frame-level pipeline telemetry for configured depth, in-flight count, sequence, chunks, bytes, and split position.

## Test Plan

World-Vercel: 713 tests passed, plus package typecheck. Focused core writable-stream suite: 49 tests passed. Tests cover sequence reservation, active bounds, sticky failures, sealed takeover, split-frame limits, correlation, socket-loss fail-stop behavior, drain, close, timeout, reconnect, and safe fallback.