### PR TITLE
fix(world-vercel): resolve terminal run event responses

### DIFF
--- a/.changeset/resolve-terminal-run-events.md
+++ b/.changeset/resolve-terminal-run-events.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Resolve terminal run event responses so completed and failed runs satisfy the client response schema.

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -436,6 +436,49 @@ async function postStepStartedMeta(
   return capturedMeta ?? {};
 }
 
+describe('createWorkflowRunEvent terminal run response resolution', () => {
+  it.each([
+    [
+      'run_completed',
+      { eventType: 'run_completed', eventData: { output: new Uint8Array() } },
+      { status: 'completed', output: new Uint8Array() },
+    ],
+    [
+      'run_failed',
+      { eventType: 'run_failed', eventData: { error: new Uint8Array() } },
+      { status: 'failed', error: new Uint8Array() },
+    ],
+  ] as const)('requests a resolved run for %s', async (eventType, data, run) => {
+    const agent = mockAgent();
+    let capturedMeta: Record<string, unknown> | undefined;
+
+    agent
+      .get(ORIGIN)
+      .intercept({
+        path: `/api/v4/runs/wrun_1/events/${eventType}`,
+        method: 'POST',
+      })
+      .reply(200, (opts: { body?: unknown }) => {
+        capturedMeta = decodePostedMeta(opts.body);
+        return createEventBody(data as AnyEventRequest, {
+          run: {
+            ...runningRun,
+            ...run,
+            completedAt: STARTED_AT,
+          },
+        });
+      });
+
+    await createWorkflowRunEvent('wrun_1', data as AnyEventRequest, undefined, {
+      token: 'test-token',
+      dispatcher: agent,
+    });
+
+    expect(capturedMeta?.remoteRefBehavior).toBe('resolve');
+    agent.assertNoPendingInterceptors();
+  });
+});
+
 describe('createWorkflowRunEvent computeInstanceId wire field', () => {
   const INSTANCE = 'cinst_01JZZZTESTINSTANCE00000001';
 

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -104,6 +104,8 @@ type EventDataField<E = AnyEventRequest> = E extends { eventData?: infer D }
 const eventsNeedingResolve = new Set<string>([
   'run_created', // runtime reads result.run.runId
   'run_started', // runtime reads result.run (checks startedAt, status)
+  'run_completed', // response schema requires run.output
+  'run_failed', // response schema requires run.error
   'step_started', // runtime reads result.step (checks attempt, state)
 ]);
 


### PR DESCRIPTION
See https://vercel.slack.com/archives/C09G3EQAL84/p1788067398501359 for context.

`run_completed` returns a `outputRef` not `output` because world-vercel does not include it in `eventsNeedingResolve`. However the schema requires an `output` and it errors. This causes the workflow to then try and fail the run. However `run_failed` errors because `run_completed` has been committed.

Fix is to add `run_completed | run_failed` to `eventsNeedingResolve` so they return an `output`.

<details>
## Summary

- request resolved materialization for `run_completed` and `run_failed` responses
- cover both terminal event types with a wire-level regression test
- add a patch changeset for `@workflow/world-vercel`

## Why

The v4 event server commits terminal events and includes the updated run in its response. Lazy materialization returns `outputRef` or `errorRef`, but the client validates completed and failed runs against schemas requiring resolved `output` or `error`. The resulting schema error occurs after the terminal event is durable and causes noisy `WORLD_CONTRACT_ERROR` telemetry plus an ineffective attempt to fail an already completed run.

## Test plan

- `pnpm --filter @workflow/world-vercel test`
- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm exec biome check packages/world-vercel/src/events.ts packages/world-vercel/src/events.test.ts .changeset/resolve-terminal-run-events.md` (passes with two existing complexity warnings in `events.ts`)
</details>
