### PR TITLE
Prevent payload flicker during decryption

### DIFF
--- a/.changeset/calm-events-wait.md
+++ b/.changeset/calm-events-wait.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Prevent event payload flicker during decryption.

--- a/packages/web-shared/src/components/event-list-view.tsx
+++ b/packages/web-shared/src/components/event-list-view.tsx
@@ -1007,10 +1007,10 @@ export function EventRow({
   }, []);
 
   // When encryption key changes and this event was previously loaded,
-  // re-load to get decrypted data
+  // re-load to get decrypted data. Keep the encrypted value visible until the
+  // refreshed data arrives so the payload does not flash empty while decrypting.
   useEffect(() => {
     if (encryptionKey && hasAttemptedLoad && onLoadEventData) {
-      setLoadedEventData(null);
       setHasAttemptedLoad(false);
       onLoadEventData(event)
         .then((data) => {


### PR DESCRIPTION
Keeps the existing event payload visible while decrypted data reloads.