### PR TITLE
Surface Zod issue paths when a world response fails schema validation

### DIFF
--- a/.changeset/world-contract-error-diagnostics.md
+++ b/.changeset/world-contract-error-diagnostics.md
@@ -1,0 +1,6 @@
+---
+'@workflow/world-vercel': patch
+'@workflow/core': patch
+---
+
+Surface the actual validation failure when a world response is rejected. `decodeCreateEventResponse` (and the batch, max-events-header, and error-frame decoders) now include the Zod issue paths and codes in the thrown `WorkflowWorldError` message instead of only attaching them as an unlogged `cause`, and the runtime's terminal `Error while running workflow` log now prints the underlying error message and world error code alongside the classified `errorCode`. Previously a terminal-write schema rejection surfaced in production as a bare `WORLD_CONTRACT_ERROR` with no indication of which response field failed — undiagnosable, since the cleanup `run_failed` is rejected (run already completed) or its payload is encrypted at rest. Issue paths only; received values are never logged.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4654,6 +4654,22 @@ export function workflowEntrypoint(
                           workflowRunId: runId,
                           errorCode,
                           errorName,
+                          // The classified errorCode is a coarse bucket
+                          // (WORLD_CONTRACT_ERROR covers both a malformed
+                          // world response and an exhausted transport
+                          // failure), so also print the message and, for
+                          // world errors, the underlying code — otherwise a
+                          // production log shows only the bucket and the
+                          // actual failure is undiagnosable (this is how
+                          // terminal-write schema rejections went unexplained
+                          // while the runs themselves succeeded).
+                          errorMessage,
+                          ...(WorkflowWorldError.is(terminalError)
+                            ? {
+                                worldErrorCode: terminalError.code,
+                                worldErrorStatus: terminalError.status,
+                              }
+                            : {}),
                           errorStack,
                         });
 

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -963,6 +963,70 @@ describe('createWorkflowRunEventV4 over HTTP', () => {
     agent.assertNoPendingInterceptors();
   });
 
+  it('names the failing response field when schema validation rejects a 200 body', async () => {
+    const origin =
+      WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    agent
+      .get(origin)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events/run_completed',
+        method: 'POST',
+      })
+      .reply(
+        200,
+        // A run_completed event row with no eventData object: valid CBOR,
+        // invalid against RunCompletedEventSchema (eventData is required).
+        encode({
+          event: {
+            eventType: 'run_completed',
+            specVersion: 7,
+            eventId: 'evnt_1',
+            runId: 'wrun_1',
+            createdAt: CREATED_AT,
+          },
+          maxEvents: 100000,
+        }),
+        {
+          headers: {
+            'x-wf-event-id': 'evnt_1',
+            'x-wf-run-id': 'wrun_1',
+            'x-wf-created-at': CREATED_AT,
+          },
+        }
+      );
+
+    // The message must carry the Zod issue paths: it is the only part of
+    // this error visible in production logs (the cause is never logged, and
+    // the run_failed cleanup payload is rejected or encrypted at rest).
+    const error = await createWorkflowRunEventV4(
+      {
+        runId: 'wrun_1',
+        eventType: 'run_completed',
+        specVersion: 7,
+        payload: new TextEncoder().encode('"output"'),
+      },
+      { token: 'test-token', dispatcher: agent }
+    ).then(
+      () => {
+        throw new Error('expected createWorkflowRunEventV4 to reject');
+      },
+      (err: unknown) => err
+    );
+
+    expect(WorkflowWorldError.is(error)).toBe(true);
+    expect((error as WorkflowWorldError).code).toBe('SCHEMA_VALIDATION');
+    expect((error as Error).message).toContain(
+      'invalid response body (run_completed)'
+    );
+    expect((error as Error).message).toContain('event.eventData');
+    // Issue paths only — the response payload itself must not leak.
+    expect((error as Error).message).not.toContain('evnt_1');
+    agent.assertNoPendingInterceptors();
+  });
+
   it('requests and decodes the event stream for run_started', async () => {
     const origin =
       WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -815,6 +815,29 @@ export async function createWorkflowRunEventV4<T extends EventType>(
   return decodeCreateEventResponse(response, input.eventType);
 }
 
+/**
+ * Render the first few issues of a response-validation ZodError into one
+ * log-safe line, so the failing field is identifiable from the error MESSAGE
+ * alone. The message is the only part of this error that reliably survives
+ * to where anyone can see it: the runtime's terminal-failure log prints only
+ * name/code/message, and the `run_failed` cleanup write serializes (and on
+ * encrypted projects encrypts) the thrown error, so a `cause`-only ZodError
+ * is invisible in production — which is exactly how the terminal-write
+ * WORLD_CONTRACT_ERROR reports stayed undiagnosable. Issue paths and codes
+ * only; no received values, so response payloads cannot leak into logs.
+ */
+function formatResponseIssues(error: z.ZodError, max = 5): string {
+  const issues = error.issues
+    .slice(0, max)
+    .map(
+      (issue) =>
+        `${issue.path.length > 0 ? issue.path.join('.') : '<root>'}: ${issue.code} (${issue.message})`
+    );
+  const extra =
+    error.issues.length > max ? `; +${error.issues.length - max} more` : '';
+  return issues.join('; ') + extra;
+}
+
 /** Takes `FrameResponseLike` rather than `Response` because the WS branch has
  *  none to hand over; it synthesizes one. A real `Response` satisfies the
  *  interface, so the HTTP callers are unaffected. */
@@ -835,10 +858,14 @@ async function decodeCreateEventResponse<T extends EventType>(
     );
   const parsedBody = schema.safeParse(decode(bodyBytes));
   if (!parsedBody.success) {
-    throw new WorkflowWorldError('v4 createEvent: invalid response body', {
-      code: 'SCHEMA_VALIDATION',
-      cause: parsedBody.error,
-    });
+    throw new WorkflowWorldError(
+      `v4 createEvent: invalid response body (${eventType}): ` +
+        formatResponseIssues(parsedBody.error),
+      {
+        code: 'SCHEMA_VALIDATION',
+        cause: parsedBody.error,
+      }
+    );
   }
   return parsedBody.data;
 }
@@ -859,10 +886,14 @@ export async function createWorkflowRunStartedEventV4(
     response.headers.get(MAX_EVENTS_HEADER)
   );
   if (!maxEvents.success) {
-    throw new WorkflowWorldError('v4 createEvent: invalid max-events header', {
-      code: 'SCHEMA_VALIDATION',
-      cause: maxEvents.error,
-    });
+    throw new WorkflowWorldError(
+      `v4 createEvent: invalid max-events header: ` +
+        formatResponseIssues(maxEvents.error),
+      {
+        code: 'SCHEMA_VALIDATION',
+        cause: maxEvents.error,
+      }
+    );
   }
 
   return { events, ...page, maxEvents: maxEvents.data };
@@ -1010,7 +1041,8 @@ export async function createWorkflowRunEventsBatchV4(
       const parsed = CreateEventV4BodySchemas[eventType].safeParse(raw);
       if (!parsed.success) {
         throw new WorkflowWorldError(
-          `v4 createEventBatch: invalid result body at index ${index} (${eventType})`,
+          `v4 createEventBatch: invalid result body at index ${index} ` +
+            `(${eventType}): ${formatResponseIssues(parsed.error)}`,
           { code: 'SCHEMA_VALIDATION', cause: parsed.error }
         );
       }
@@ -1428,7 +1460,8 @@ function streamErrorFrameToError(
   const parsed = EventStreamErrorSchema.safeParse(meta);
   if (!parsed.success) {
     return new WorkflowWorldError(
-      `v4 ${opName}: malformed terminal error frame`,
+      `v4 ${opName}: malformed terminal error frame: ` +
+        formatResponseIssues(parsed.error),
       { code: 'SCHEMA_VALIDATION', cause: parsed.error }
     );
   }


### PR DESCRIPTION
## Why

Production workflows on vercel-site (and an external beta tester, coderabbitai) complete durably yet print a bare `WORLD_CONTRACT_ERROR`, then attempt a `run_failed` that is rejected 409 because the run already completed. The initiating error was undiagnosable from any production artifact:

- `decodeCreateEventResponse` attaches the ZodError only as an **unlogged `cause`**;
- the runtime's terminal `Error while running workflow` log prints only the classified `errorCode` (a coarse bucket that also covers exhausted transport failures);
- the cleanup `run_failed` payload is either **rejected** (run already completed — nothing persists) or **encrypted at rest** behind `errorRef`, and its plaintext `errorCode` is again just the bucket.

## What

- `decodeCreateEventResponse` (plus the batch, max-events-header, and error-frame decoders) now include bounded Zod **issue paths and codes** in the thrown `WorkflowWorldError` message — never received values, so response payloads cannot leak into logs.
- The runtime's terminal log now prints `errorMessage` and, for world errors, the underlying `worldErrorCode`/`worldErrorStatus` alongside the classified `errorCode`, so a schema rejection is distinguishable from a transport give-up.
- Test: a 200 body that fails the per-type schema produces an error naming the failing path.

## Root cause this would have named on day one

While building this we reproduced the underlying bug: **zod 4.4 changed required-key semantics** — a required key whose schema accepts `undefined` (e.g. `SerializedDataSchema`'s `z.any()` arm) may no longer be *absent*. `WorkflowRunSchema`'s completed arm requires `output` and the failed arm requires `error`, but lazy terminal-write responses carry only `outputRef`/`errorRef` — so under zod 4.4.x **every** lazy `run_completed`/`run_failed` 200 body fails validation with `run.output: invalid_type — expected nonoptional, received undefined`. The packages pin `zod: ~4.3.6` (catalog), but vercel/front forces `'@workflow/world>zod': 4.4.3` (+ core, world-vercel) via pnpm-workspace overrides, and the external reporter presumably resolves zod 4.4.x similarly. That is why only terminal run writes fail (step/hook/wait payloads live in `event.eventData`, which is present as a ref descriptor), why runs still succeed (the write commits before the client parses the response), and why clean-lockfile repro projects could never reproduce it.

Follow-ups (separate PRs): make the status-arm payload fields explicitly `.optional()` (semantically honest — lazy bodies omit them) or otherwise zod-4.4-safe; and fix/remove the front override.

Investigation notes: clanker-hub session `devbox_2f78qosz4bl1mc9jlkxgin0hmrky-pegmatite`, report `51dc1101`.

🤖 Generated with opencode