### PR TITLE
fix(world): accept lazy terminal run data - fix Zod schema for newer versions

### DIFF
--- a/.changeset/lazy-terminal-run-data.md
+++ b/.changeset/lazy-terminal-run-data.md
@@ -1,0 +1,5 @@
+---
+"@workflow/world": patch
+---
+
+Accept lazy completed and failed runs whose payload is represented by a remote reference.

--- a/packages/world/src/runs.test.ts
+++ b/packages/world/src/runs.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import {
   BULK_CANCEL_MAX_RUN_IDS,
   BulkCancelWorkflowRunResultSchema,
   BulkCancelWorkflowRunsRequestSchema,
   BulkCancelWorkflowRunsResultSchema,
+  WorkflowRunSchema,
 } from './runs.js';
+
+describe('WorkflowRunSchema', () => {
+  it('accepts terminal runs without materialized payloads', () => {
+    const completedSchema = WorkflowRunSchema.options[2];
+    const failedSchema = WorkflowRunSchema.options[3];
+    const run = {
+      runId: 'wrun_1',
+      deploymentId: 'dpl_1',
+      workflowName: 'workflow_1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      completedAt: new Date(),
+    };
+
+    expect(completedSchema.shape.output).toBeInstanceOf(z.ZodOptional);
+    expect(failedSchema.shape.error).toBeInstanceOf(z.ZodOptional);
+    expect(
+      WorkflowRunSchema.safeParse({ ...run, status: 'completed' }).success
+    ).toBe(true);
+    expect(
+      WorkflowRunSchema.safeParse({ ...run, status: 'failed' }).success
+    ).toBe(true);
+  });
+});
 
 describe('BulkCancelWorkflowRunsRequestSchema', () => {
   it('accepts 1 unique ID with an optional cancelReason', () => {

--- a/packages/world/src/runs.ts
+++ b/packages/world/src/runs.ts
@@ -146,7 +146,7 @@ export const WorkflowRunSchema = z.discriminatedUnion('status', [
   // Completed state - output can be v1 or v2 format
   WorkflowRunBaseSchema.extend({
     status: z.literal('completed'),
-    output: SerializedDataSchema,
+    output: SerializedDataSchema.optional(),
     error: z.undefined().optional(),
     completedAt: z.coerce.date(),
   }),
@@ -154,7 +154,7 @@ export const WorkflowRunSchema = z.discriminatedUnion('status', [
   WorkflowRunBaseSchema.extend({
     status: z.literal('failed'),
     output: z.undefined().optional(),
-    error: SerializedDataSchema,
+    error: SerializedDataSchema.optional(),
     completedAt: z.coerce.date(),
   }),
 ]);


### PR DESCRIPTION
## Problem
Lazy terminal responses carry `outputRef` or `errorRef` without materializing `output` or `error`. `WorkflowRunSchema` declared those terminal payload keys as required, which fails under Zod 4.4's [required object property semantics](https://github.com/colinhacks/zod/releases/tag/v4.4.0#required-object-properties-with-zundefined).

## Fix
Mark completed `output` and failed `error` explicitly optional, matching lazy World responses.

## Tests
- `pnpm --filter @workflow/world test -- src/runs.test.ts`
- `pnpm --filter @workflow/world build`
- Zod 4.4.3 one-step Preview: completed without callback errors
- Zod 4.5.4: terminal schemas and Next.js production build pass