### PR TITLE
Add an experimental durable journal World API

### DIFF
--- a/.changeset/calm-pandas-journal-local.md
+++ b/.changeset/calm-pandas-journal-local.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': minor
+---
+
+Implement durable journals in Local World with filesystem-backed revision and idempotency fencing.

--- a/.changeset/tidy-spoons-journal-world.md
+++ b/.changeset/tidy-spoons-journal-world.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world': minor
+---
+
+Add an optional durable journal contract for idempotent compare-and-set state independent of workflow runs.

--- a/packages/world-local/README.md
+++ b/packages/world-local/README.md
@@ -15,3 +15,25 @@ const world = createWorld({
   dataDir: './custom-workflow-data',
 });
 ```
+
+## Experimental journals
+
+Local World implements the optional `world.journals` capability for opaque
+state that must outlive an individual workflow run. Commits use optimistic
+revisions and idempotency keys. Revision files and directory metadata are
+synced before a commit resolves on POSIX filesystems; directory syncing is
+best-effort on Windows.
+
+```ts
+const created = await world.journals.commit(
+  'session:123',
+  new TextEncoder().encode('{"status":"idle"}'),
+  { expectedRevision: null, idempotencyKey: 'create' }
+);
+
+await world.journals.commit(
+  'session:123',
+  new TextEncoder().encode('{"status":"running"}'),
+  { expectedRevision: created.revision, idempotencyKey: 'claim-turn' }
+);
+```

--- a/packages/world-local/src/index.ts
+++ b/packages/world-local/src/index.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
-import type { QueuePrefix, World } from '@workflow/world';
+import type { Journals, QueuePrefix, World } from '@workflow/world';
 import { reenqueueActiveRuns, SPEC_VERSION_CURRENT } from '@workflow/world';
 import { warnIfRunningInVercelDeployment } from './build-target-mismatch.js';
 import type { Config } from './config.js';
@@ -17,6 +17,7 @@ import {
 } from './fs.js';
 import { initDataDir } from './init.js';
 import { instrumentObject } from './instrumentObject.js';
+import { clearJournals, createJournals, withJournalsLock } from './journals.js';
 import { createQueue, type DirectHandler } from './queue.js';
 import { hashToken, hookRecoveryMarkerPath } from './storage/helpers.js';
 import { resetHookIndexEnsureCache } from './storage/hook-index.js';
@@ -36,10 +37,12 @@ export {
 
 export type { DirectHandler } from './queue.js';
 
-export type LocalWorld = World & {
+export type LocalWorld = Omit<World, 'journals'> & {
+  /** Durable opaque state independent of workflow run lifetimes. */
+  journals: Journals;
   /** Register a direct in-process handler for a queue prefix, bypassing HTTP. */
   registerHandler(prefix: QueuePrefix, handler: DirectHandler): void;
-  /** Clear all workflow data (runs, steps, events, hooks, streams). */
+  /** Clear all workflow data (runs, steps, events, hooks, streams, journals). */
   clear(): Promise<void>;
 };
 
@@ -83,6 +86,10 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
     },
     ...queue,
     ...storage,
+    journals: instrumentObject(
+      'world.journals',
+      createJournals(mergedConfig.dataDir, tag)
+    ),
     ...instrumentObject('world.streams', {
       ...createStreamer(mergedConfig.dataDir, tag),
       ...(mergedConfig.streamFlushIntervalMs !== undefined && {
@@ -123,6 +130,7 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
       if (tag) {
         // Selectively delete only files matching this tag
         const basedir = mergedConfig.dataDir;
+        await clearJournals(basedir, tag);
 
         // Delete hook token constraint files (and recovery markers,
         // for disk hygiene) BEFORE deleting the hooks, since we need
@@ -235,11 +243,13 @@ export function createWorld(args?: Partial<Config>): LocalWorld {
         // Clear the in-memory write cache so deleted paths are forgotten
         clearCreatedFilesCache();
       } else {
-        // `rm()` removes directories that the write path may have cached.
-        clearCreatedFilesCache();
-        resetHookIndexEnsureCache();
-        await rm(mergedConfig.dataDir, { recursive: true, force: true });
-        await initDataDir(mergedConfig.dataDir);
+        await withJournalsLock(mergedConfig.dataDir, async () => {
+          // `rm()` removes directories that the write path may have cached.
+          clearCreatedFilesCache();
+          resetHookIndexEnsureCache();
+          await rm(mergedConfig.dataDir, { recursive: true, force: true });
+          await initDataDir(mergedConfig.dataDir);
+        });
       }
     },
   };

--- a/packages/world-local/src/journals.test.ts
+++ b/packages/world-local/src/journals.test.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { EntityConflictError } from '@workflow/errors';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorld } from './index.js';
+import { createJournals } from './journals.js';
+
+describe('world-local journals', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-journals-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('creates, reads, and updates opaque state', async () => {
+    const journals = createJournals(testDir);
+
+    expect(await journals.get('session:123')).toBeNull();
+
+    const created = await journals.commit(
+      'session:123',
+      new Uint8Array([0, 1, 255]),
+      { expectedRevision: null, idempotencyKey: 'create' }
+    );
+    expect(created).toEqual({
+      journalId: 'session:123',
+      revision: '1',
+      state: new Uint8Array([0, 1, 255]),
+    });
+    expect(await journals.get('session:123')).toEqual(created);
+
+    const updated = await journals.commit('session:123', new Uint8Array([2]), {
+      expectedRevision: created.revision,
+      idempotencyKey: 'update',
+    });
+    expect(updated.revision).toBe('2');
+    expect(await journals.get('session:123')).toEqual(updated);
+  });
+
+  it('returns the original commit when an idempotent retry follows later writes', async () => {
+    const journals = createJournals(testDir);
+    const created = await journals.commit('session:123', new Uint8Array([1]), {
+      expectedRevision: null,
+      idempotencyKey: 'create',
+    });
+    await journals.commit('session:123', new Uint8Array([2]), {
+      expectedRevision: created.revision,
+      idempotencyKey: 'update',
+    });
+
+    await expect(
+      journals.commit('session:123', new Uint8Array([1]), {
+        expectedRevision: null,
+        idempotencyKey: 'create',
+      })
+    ).resolves.toEqual(created);
+  });
+
+  it('rejects stale revisions and conflicting idempotency-key reuse', async () => {
+    const journals = createJournals(testDir);
+    await journals.commit('session:123', new Uint8Array([1]), {
+      expectedRevision: null,
+      idempotencyKey: 'create',
+    });
+
+    await expect(
+      journals.commit('session:123', new Uint8Array([2]), {
+        expectedRevision: null,
+        idempotencyKey: 'second-create',
+      })
+    ).rejects.toBeInstanceOf(EntityConflictError);
+    await expect(
+      journals.commit('session:123', new Uint8Array([2]), {
+        expectedRevision: null,
+        idempotencyKey: 'create',
+      })
+    ).rejects.toBeInstanceOf(EntityConflictError);
+    expect((await journals.get('session:123'))?.revision).toBe('1');
+  });
+
+  it('allows one winner when independent instances commit the same revision', async () => {
+    const first = createJournals(testDir);
+    const second = createJournals(testDir);
+    const created = await first.commit('session:123', new Uint8Array([1]), {
+      expectedRevision: null,
+      idempotencyKey: 'create',
+    });
+
+    const results = await Promise.allSettled([
+      first.commit('session:123', new Uint8Array([2]), {
+        expectedRevision: created.revision,
+        idempotencyKey: 'writer-1',
+      }),
+      second.commit('session:123', new Uint8Array([3]), {
+        expectedRevision: created.revision,
+        idempotencyKey: 'writer-2',
+      }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled')
+    ).toHaveLength(1);
+    const rejected = results.find((result) => result.status === 'rejected');
+    expect(rejected).toMatchObject({ reason: { name: 'EntityConflictError' } });
+    expect((await first.get('session:123'))?.revision).toBe('2');
+  });
+
+  it('converges concurrent retries of the same logical commit', async () => {
+    const first = createJournals(testDir);
+    const second = createJournals(testDir);
+
+    const [left, right] = await Promise.all([
+      first.commit('session:123', new Uint8Array([1]), {
+        expectedRevision: null,
+        idempotencyKey: 'create',
+      }),
+      second.commit('session:123', new Uint8Array([1]), {
+        expectedRevision: null,
+        idempotencyKey: 'create',
+      }),
+    ]);
+
+    expect(left).toEqual(right);
+    expect(left.revision).toBe('1');
+  });
+
+  it('persists across World instances and isolates tagged journals', async () => {
+    const first = createWorld({
+      dataDir: testDir,
+      recoverActiveRuns: false,
+      tag: 'first',
+    });
+    const second = createWorld({
+      dataDir: testDir,
+      recoverActiveRuns: false,
+      tag: 'second',
+    });
+    const firstState = await first.journals.commit(
+      'session:123',
+      new Uint8Array([1]),
+      { expectedRevision: null, idempotencyKey: 'create-first' }
+    );
+    const secondState = await second.journals.commit(
+      'session:123',
+      new Uint8Array([2]),
+      { expectedRevision: null, idempotencyKey: 'create-second' }
+    );
+
+    expect((await first.journals.get('session:123'))?.state).toEqual(
+      firstState.state
+    );
+    expect((await second.journals.get('session:123'))?.state).toEqual(
+      secondState.state
+    );
+
+    await first.clear();
+    expect(await first.journals.get('session:123')).toBeNull();
+    expect(await second.journals.get('session:123')).toEqual(secondState);
+
+    const reopened = createWorld({
+      dataDir: testDir,
+      recoverActiveRuns: false,
+      tag: 'second',
+    });
+    expect(await reopened.journals.get('session:123')).toEqual(secondState);
+    await Promise.all([first.close?.(), second.close?.(), reopened.close?.()]);
+  });
+
+  it.each([
+    { name: 'tagged', tag: 'clear-race' },
+    { name: 'untagged', tag: undefined },
+  ])('serializes $name clear with an active commit', async ({ tag }) => {
+    const world = createWorld({
+      dataDir: testDir,
+      recoverActiveRuns: false,
+      tag,
+    });
+    const created = await world.journals.commit(
+      'session:123',
+      new Uint8Array([1]),
+      { expectedRevision: null, idempotencyKey: 'create' }
+    );
+
+    const [commit, clear] = await Promise.allSettled([
+      world.journals.commit('session:123', new Uint8Array([2]), {
+        expectedRevision: created.revision,
+        idempotencyKey: 'update',
+      }),
+      world.clear(),
+    ]);
+
+    expect(clear.status).toBe('fulfilled');
+    const current = await world.journals.get('session:123');
+    if (commit.status === 'fulfilled') {
+      expect(current === null || current.revision === '2').toBe(true);
+    } else {
+      expect(commit.reason).toMatchObject({ name: 'EntityConflictError' });
+      expect(current).toBeNull();
+    }
+    await world.close?.();
+  });
+
+  it('treats an empty tag as the untagged scope', async () => {
+    const emptyTag = createJournals(testDir, '');
+    const untagged = createJournals(testDir);
+    const created = await emptyTag.commit('session:123', new Uint8Array([1]), {
+      expectedRevision: null,
+      idempotencyKey: 'create',
+    });
+
+    expect(await untagged.get('session:123')).toEqual(created);
+  });
+});

--- a/packages/world-local/src/journals.ts
+++ b/packages/world-local/src/journals.ts
@@ -1,0 +1,359 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs, { type FileHandle } from 'node:fs/promises';
+import path from 'node:path';
+import { EntityConflictError, WorkflowWorldError } from '@workflow/errors';
+import {
+  type JournalCommitOptions,
+  JournalCommitOptionsSchema,
+  JournalIdSchema,
+  type JournalState,
+  JournalStateSchema,
+  type Journals,
+} from '@workflow/world';
+import { lock } from 'proper-lockfile';
+import { z } from 'zod';
+import {
+  ensureDir,
+  jsonReplacer,
+  readJSON,
+  resolveWithinBase,
+  withWindowsRetry,
+} from './fs.js';
+
+const JOURNAL_REVISION_WIDTH = 16;
+const journalEntrySchema = JournalStateSchema.extend({
+  idempotencyKey: z.string(),
+});
+
+type JournalEntry = z.infer<typeof journalEntrySchema>;
+
+export function createJournals(basedir: string, tag?: string): Journals {
+  return {
+    async get(rawJournalId) {
+      const journalId = JournalIdSchema.parse(rawJournalId);
+      return withJournalsLock(basedir, async () => {
+        const entries = await readJournalEntries(basedir, journalId, tag);
+        const latest = entries.at(-1);
+        return latest === undefined ? null : toJournalState(latest);
+      });
+    },
+
+    async commit(rawJournalId, rawState, rawOptions) {
+      const journalId = JournalIdSchema.parse(rawJournalId);
+      const state = Uint8Array.from(rawState);
+      const options = JournalCommitOptionsSchema.parse(rawOptions);
+      const directory = journalDirectory(basedir, journalId, tag);
+
+      return withJournalsLock(basedir, () =>
+        withJournalLock(directory, (signal) =>
+          commitJournalRevision({
+            basedir,
+            directory,
+            journalId,
+            options,
+            signal,
+            state,
+            tag,
+          })
+        )
+      );
+    },
+  };
+}
+
+async function commitJournalRevision(input: {
+  basedir: string;
+  directory: string;
+  journalId: string;
+  options: JournalCommitOptions;
+  signal: AbortSignal;
+  state: Uint8Array;
+  tag?: string;
+}): Promise<JournalState> {
+  const entries = await readJournalEntries(
+    input.basedir,
+    input.journalId,
+    input.tag
+  );
+  const priorCommit = entries.find(
+    (entry) => entry.idempotencyKey === input.options.idempotencyKey
+  );
+  if (priorCommit !== undefined) {
+    if (bytesEqual(priorCommit.state, input.state)) {
+      return toJournalState(priorCommit);
+    }
+    throw new EntityConflictError(
+      `Journal "${input.journalId}" idempotency key was reused with different state.`
+    );
+  }
+
+  const latest = entries.at(-1);
+  assertExpectedRevision(input.journalId, latest, input.options);
+  const revisionNumber = entries.length + 1;
+  if (!Number.isSafeInteger(revisionNumber)) {
+    throw new WorkflowWorldError(
+      `Journal "${input.journalId}" exhausted its local revision range.`
+    );
+  }
+  const revision = String(revisionNumber);
+  const entry: JournalEntry = {
+    idempotencyKey: input.options.idempotencyKey,
+    journalId: input.journalId,
+    revision,
+    state: Uint8Array.from(input.state),
+  };
+  const destination = path.join(
+    input.directory,
+    `${formatRevision(revisionNumber)}.json`
+  );
+
+  input.signal.throwIfAborted();
+  const published = await writeJournalRevision(
+    destination,
+    JSON.stringify(entry, jsonReplacer, 2)
+  );
+  if (!published) {
+    throw new WorkflowWorldError(
+      `Journal "${input.journalId}" revision ${revision} was concurrently committed.`
+    );
+  }
+  input.signal.throwIfAborted();
+  return toJournalState(entry);
+}
+
+export async function clearJournals(
+  basedir: string,
+  tag?: string
+): Promise<void> {
+  await withJournalsLock(basedir, async () => {
+    await fs.rm(journalScopeDirectory(basedir, tag), {
+      recursive: true,
+      force: true,
+    });
+  });
+}
+
+function journalScopeDirectory(basedir: string, tag?: string): string {
+  const scope = !tag
+    ? 'untagged'
+    : `tag-${createHash('sha256').update(tag).digest('hex')}`;
+  return resolveWithinBase(basedir, 'journals', scope);
+}
+
+function journalDirectory(
+  basedir: string,
+  journalId: string,
+  tag?: string
+): string {
+  const digest = createHash('sha256').update(journalId).digest('hex');
+  return path.join(journalScopeDirectory(basedir, tag), digest);
+}
+
+async function readJournalEntries(
+  basedir: string,
+  journalId: string,
+  tag?: string
+): Promise<JournalEntry[]> {
+  const directory = journalDirectory(basedir, journalId, tag);
+  let files: string[];
+  try {
+    files = await fs.readdir(directory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const revisionFiles = files.filter((file) => file.endsWith('.json')).sort();
+  const entries: JournalEntry[] = [];
+  for (let index = 0; index < revisionFiles.length; index++) {
+    const expectedRevision = index + 1;
+    const expectedFile = `${formatRevision(expectedRevision)}.json`;
+    const file = revisionFiles[index];
+    if (file !== expectedFile) {
+      throw new WorkflowWorldError(
+        `Journal "${journalId}" has a missing or malformed revision at ${expectedRevision}.`
+      );
+    }
+    const entry = await readJSON(
+      path.join(directory, file),
+      journalEntrySchema
+    );
+    if (
+      entry === null ||
+      entry.journalId !== journalId ||
+      entry.revision !== String(expectedRevision)
+    ) {
+      throw new WorkflowWorldError(
+        `Journal "${journalId}" revision ${expectedRevision} is invalid.`
+      );
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+function assertExpectedRevision(
+  journalId: string,
+  latest: JournalEntry | undefined,
+  options: JournalCommitOptions
+): void {
+  const actualRevision = latest?.revision ?? null;
+  if (options.expectedRevision === actualRevision) return;
+  throw new EntityConflictError(
+    `Journal "${journalId}" expected revision ${formatNullableRevision(
+      options.expectedRevision
+    )}, but found ${formatNullableRevision(actualRevision)}.`
+  );
+}
+
+function formatNullableRevision(revision: string | null): string {
+  return revision === null ? 'null' : `"${revision}"`;
+}
+
+function formatRevision(revision: number): string {
+  return String(revision).padStart(JOURNAL_REVISION_WIDTH, '0');
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return Buffer.from(left).equals(Buffer.from(right));
+}
+
+function toJournalState(entry: JournalEntry): JournalState {
+  return {
+    journalId: entry.journalId,
+    revision: entry.revision,
+    state: Uint8Array.from(entry.state),
+  };
+}
+
+/** Publishes bytes atomically and syncs both contents and directory metadata. */
+async function writeJournalRevision(
+  filePath: string,
+  data: string
+): Promise<boolean> {
+  const directory = path.dirname(filePath);
+  await ensureDir(directory);
+  const temporaryPath = `${filePath}.tmp.${randomUUID()}`;
+  let temporaryFile: FileHandle | undefined;
+  try {
+    temporaryFile = await fs.open(temporaryPath, 'wx');
+    await temporaryFile.writeFile(data);
+    await temporaryFile.sync();
+    await temporaryFile.close();
+    temporaryFile = undefined;
+
+    try {
+      await withWindowsRetry(() => fs.link(temporaryPath, filePath));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+      throw error;
+    }
+    await syncJournalHierarchy(directory);
+    return true;
+  } finally {
+    await temporaryFile?.close().catch(() => {});
+    await withWindowsRetry(() => fs.unlink(temporaryPath), 3).catch(() => {});
+  }
+}
+
+async function syncJournalHierarchy(directory: string): Promise<void> {
+  let current = path.resolve(directory);
+  while (true) {
+    await syncDirectory(current);
+    const parent = path.dirname(current);
+    if (parent === current) return;
+    current = parent;
+  }
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  let handle: FileHandle | undefined;
+  try {
+    handle = await fs.open(directory, 'r');
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (
+      process.platform !== 'win32' ||
+      (code !== 'EINVAL' && code !== 'EPERM')
+    ) {
+      throw error;
+    }
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+export function withJournalsLock<T>(
+  basedir: string,
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const resolved = path.resolve(basedir);
+  const digest = createHash('sha256').update(resolved).digest('hex');
+  const target = path.join(
+    path.dirname(resolved),
+    `.${path.basename(resolved)}.journals-${digest}`
+  );
+  return withFileLock(target, 'journals', fn);
+}
+
+async function withJournalLock<T>(
+  directory: string,
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  return withFileLock(path.join(directory, '.commit'), 'journal commit', fn);
+}
+
+async function withFileLock<T>(
+  target: string,
+  label: string,
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  await ensureDir(path.dirname(target));
+  const controller = new AbortController();
+  let release: () => Promise<void>;
+  try {
+    release = await lock(target, {
+      realpath: false,
+      stale: 30_000,
+      update: 1_000,
+      retries: {
+        retries: 350,
+        factor: 1,
+        minTimeout: 100,
+        maxTimeout: 100,
+      },
+      onCompromised(error) {
+        controller.abort(
+          new WorkflowWorldError(`${label} lock was compromised.`, {
+            cause: error,
+          })
+        );
+      },
+    });
+  } catch (error) {
+    throw new WorkflowWorldError(`Could not acquire ${label} lock.`, {
+      cause: error,
+    });
+  }
+
+  let result: T;
+  try {
+    result = await fn(controller.signal);
+    controller.signal.throwIfAborted();
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      await release().catch(() => {});
+    }
+    throw error;
+  }
+
+  try {
+    await release();
+  } catch (error) {
+    throw new WorkflowWorldError(`Could not release ${label} lock.`, {
+      cause: error,
+    });
+  }
+  return result;
+}

--- a/packages/world/README.md
+++ b/packages/world/README.md
@@ -5,3 +5,7 @@ Core interfaces and types for Workflow SDK storage backends.
 This package defines the `World` interface that abstracts workflow storage, queuing, authentication, and streaming operations. Implementation packages like `@workflow/world-local` and `@workflow/world-vercel` provide concrete implementations.
 
 Used internally by `@workflow/core` and world implementations. Should not be used directly in application code.
+
+Worlds may optionally expose `world.journals`, an experimental compare-and-set
+store for opaque durable state whose lifetime is independent of workflow runs.
+The namespace is absent when a World does not support this capability.

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -68,6 +68,17 @@ export {
   HookSchema,
 } from './hooks.js';
 export type * from './interfaces.js';
+export type * from './journals.js';
+export {
+  JOURNAL_ID_MAX_LENGTH,
+  JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH,
+  JOURNAL_REVISION_MAX_LENGTH,
+  JournalCommitOptionsSchema,
+  JournalIdempotencyKeySchema,
+  JournalIdSchema,
+  JournalRevisionSchema,
+  JournalStateSchema,
+} from './journals.js';
 export type * from './queue.js';
 export {
   getQueueTopicPrefix,

--- a/packages/world/src/interfaces.ts
+++ b/packages/world/src/interfaces.ts
@@ -14,6 +14,7 @@ import type {
   RunCreatedEventRequest,
 } from './events.js';
 import type { GetHookParams, Hook, ListHooksParams } from './hooks.js';
+import type { Journals } from './journals.js';
 import type { Queue } from './queue.js';
 import type {
   BulkCancelWorkflowRunsRequest,
@@ -430,6 +431,13 @@ export interface World extends Queue, Streamer, Storage {
    * resolution path.
    */
   analytics?: Analytics;
+
+  /**
+   * Optional durable opaque state independent of workflow run lifetimes.
+   * Namespace presence is the capability declaration; unsupported Worlds
+   * leave it undefined rather than providing a non-durable fallback.
+   */
+  journals?: Journals;
 
   /**
    * The Workflow protocol spec version this World implements.

--- a/packages/world/src/journals.test.ts
+++ b/packages/world/src/journals.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  JOURNAL_ID_MAX_LENGTH,
+  JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH,
+  JOURNAL_REVISION_MAX_LENGTH,
+  JournalCommitOptionsSchema,
+  JournalIdSchema,
+  JournalRevisionSchema,
+  JournalStateSchema,
+} from './journals.js';
+
+describe('journal schemas', () => {
+  it('preserves opaque bytes', () => {
+    const state = new Uint8Array([0, 1, 255]);
+
+    const parsed = JournalStateSchema.parse({
+      journalId: 'session:123',
+      revision: 'revision-1',
+      state,
+    });
+
+    expect(parsed.state).toBe(state);
+  });
+
+  it('requires bounded identifiers and an explicit creation revision', () => {
+    expect(() => JournalIdSchema.parse('')).toThrow();
+    expect(() =>
+      JournalIdSchema.parse('x'.repeat(JOURNAL_ID_MAX_LENGTH + 1))
+    ).toThrow();
+    expect(() => JournalRevisionSchema.parse('')).toThrow();
+    expect(() =>
+      JournalRevisionSchema.parse('x'.repeat(JOURNAL_REVISION_MAX_LENGTH + 1))
+    ).toThrow();
+    expect(() =>
+      JournalCommitOptionsSchema.parse({
+        expectedRevision: null,
+        idempotencyKey: '',
+      })
+    ).toThrow();
+    expect(() =>
+      JournalCommitOptionsSchema.parse({ idempotencyKey: 'create-session' })
+    ).toThrow();
+    expect(() =>
+      JournalCommitOptionsSchema.parse({
+        expectedRevision: null,
+        idempotencyKey: 'x'.repeat(JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH + 1),
+      })
+    ).toThrow();
+    expect(
+      JournalCommitOptionsSchema.parse({
+        expectedRevision: null,
+        idempotencyKey: 'create-session',
+      })
+    ).toEqual({ expectedRevision: null, idempotencyKey: 'create-session' });
+    expect(
+      JournalIdSchema.parse('x'.repeat(JOURNAL_ID_MAX_LENGTH))
+    ).toHaveLength(JOURNAL_ID_MAX_LENGTH);
+    expect(
+      JournalRevisionSchema.parse('x'.repeat(JOURNAL_REVISION_MAX_LENGTH))
+    ).toHaveLength(JOURNAL_REVISION_MAX_LENGTH);
+    expect(
+      JournalCommitOptionsSchema.parse({
+        expectedRevision: null,
+        idempotencyKey: 'x'.repeat(JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH),
+      }).idempotencyKey
+    ).toHaveLength(JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH);
+  });
+});

--- a/packages/world/src/journals.ts
+++ b/packages/world/src/journals.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+export const JOURNAL_ID_MAX_LENGTH = 512;
+export const JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH = 512;
+export const JOURNAL_REVISION_MAX_LENGTH = 128;
+
+export const JournalIdSchema = z.string().min(1).max(JOURNAL_ID_MAX_LENGTH);
+export const JournalIdempotencyKeySchema = z
+  .string()
+  .min(1)
+  .max(JOURNAL_IDEMPOTENCY_KEY_MAX_LENGTH);
+export const JournalRevisionSchema = z
+  .string()
+  .min(1)
+  .max(JOURNAL_REVISION_MAX_LENGTH);
+
+/** The latest opaque state committed to a durable journal. */
+export const JournalStateSchema = z.object({
+  journalId: JournalIdSchema,
+  revision: JournalRevisionSchema,
+  state: z.instanceof(Uint8Array),
+});
+
+export type JournalState = z.infer<typeof JournalStateSchema>;
+
+export const JournalCommitOptionsSchema = z.object({
+  expectedRevision: JournalRevisionSchema.nullable(),
+  idempotencyKey: JournalIdempotencyKeySchema,
+});
+
+export type JournalCommitOptions = z.infer<typeof JournalCommitOptionsSchema>;
+
+/**
+ * Durable opaque state whose lifetime is independent of any workflow run.
+ *
+ * Revisions are opaque compare-and-set tokens. A successful commit must be
+ * immediately visible to later reads. Implementations must check idempotency
+ * before `expectedRevision`: retrying the same key and bytes returns the
+ * original commit, even if the journal has advanced. Reusing a key with
+ * different bytes or committing against a stale revision throws
+ * `EntityConflictError`. Persistence follows the durability guarantees of the
+ * implementing World.
+ */
+export interface Journals {
+  /** Returns the latest committed state, or `null` when no state exists. */
+  get(journalId: string): Promise<JournalState | null>;
+
+  /**
+   * Atomically commits a complete state value and advances the revision.
+   * `expectedRevision: null` creates the journal only when it does not exist.
+   */
+  commit(
+    journalId: string,
+    state: Uint8Array,
+    options: JournalCommitOptions
+  ): Promise<JournalState>;
+}


### PR DESCRIPTION
## Motivation

eve wants each conversation turn to run as an independent, terminating workflow on the latest deployment. That requires a small piece of durable state whose identity and lifetime are independent of any workflow run, with enough concurrency control for multiple runs to coordinate safely.

Run-scoped hooks and streams cannot provide that boundary after their owning run terminates.

## What this proposes

- Add an optional `world.journals` namespace. Presence is the capability signal, so existing and third-party Worlds remain compatible.
- Expose two operations: `get(journalId)` and idempotent compare-and-set `commit(journalId, state, { expectedRevision, idempotencyKey })`.
- Keep values as opaque `Uint8Array` data so consumers own serialization, encryption, schema versions, and migrations.
- Require retries of the same key and bytes to return the original commit before revision validation. Stale revisions and conflicting key reuse raise `EntityConflictError`.
- Provide a Local World reference implementation using immutable revision files, cross-process locks, atomic hard-link publication, and filesystem sync before acknowledgement.
- Fence tagged and untagged `clear()` against active journal operations.

## Scope

This is intentionally a draft of the provider-level primitive. `world-vercel` does not advertise journals yet because the managed workflow server needs corresponding storage and endpoints first. There is also no high-level workflow-function API in this PR.

## Validation

- `pnpm exec vitest run packages/world/src`
- `pnpm --filter @workflow/world-local test`
- `pnpm --filter @workflow/world build`
- `pnpm --filter @workflow/world-local build`
- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm --filter @workflow/world-postgres typecheck`
- Targeted Biome checks over all changed source and README files

All checks passed locally. The checkout used Node 26, so pnpm emitted the repository engine warning; supported versions stop at Node 24.