### PR TITLE
Add explicit stream flush

### DIFF
--- a/.changeset/explicit-stream-flush.md
+++ b/.changeset/explicit-stream-flush.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': minor
+---
+
+Add an explicit `flush()` method to workflow writable streams for read-after-write synchronization.

--- a/docs/content/docs/v5/api-reference/workflow/get-writable.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/get-writable.mdx
@@ -67,17 +67,42 @@ export default getWritable;`}
   showSections={["returns"]}
 />
 
-Returns a `WritableStream<W>` where `W` is the type of data you plan to write to the stream.
+Returns a `WorkflowWritableStream<W>`, a standard `WritableStream<W>` extended with a `flush()` method.
 
 ## Good to know
 
 - **Workflow functions can only obtain the stream** - Call `getWritable()` in a workflow to get the stream reference, but you cannot call methods like `getWriter()`, `write()`, or `close()` directly in the workflow context.
-- **Step functions can interact with streams** - Steps can receive the stream as an argument or call `getWritable()` directly, and they can freely interact with it (write, close, etc.).
+- **Step functions can interact with streams** - Steps can receive the stream as an argument or call `getWritable()` directly, and they can freely interact with it (write, flush, close, etc.).
 - When called from a workflow, the stream must be passed as an argument to steps for interaction.
 - When called from a step, it retrieves the same workflow-scoped stream directly.
 - Always release the writer lock after writing to prevent resource leaks.
 - The stream can write binary data (using `TextEncoder`) or structured objects.
 - Remember to close the stream when finished to signal completion.
+
+## Waiting for durable writes
+
+`writer.write()` resolves after the chunk enters the stream's bounded client-side buffer. The Workflow server PUT may still be in flight. If later work must read the chunk immediately, call `flush()` explicitly:
+
+```typescript lineNumbers
+import type { WorkflowWritableStream } from "workflow";
+
+async function writeSnapshot(
+  writable: WorkflowWritableStream<Uint8Array>,
+  snapshot: Uint8Array,
+) {
+  "use step";
+
+  const writer = writable.getWriter();
+  await writer.write(snapshot);
+  writer.releaseLock();
+
+  await writable.flush(); // [!code highlight]
+}
+```
+
+`flush()` waits until chunks from completed `writer.write()` calls are durable on the Workflow server. It does not close the stream, so later steps can continue writing. Concurrent writes may join the same drain. It can only be called inside a step function.
+
+Most streaming code should not call `flush()`: allowing the next step to start while stream writes remain in flight preserves producer/consumer concurrency. Use it only for an explicit read-after-write boundary.
 
 ## Examples
 

--- a/packages/core/src/flushable-stream.ts
+++ b/packages/core/src/flushable-stream.ts
@@ -119,6 +119,18 @@ const getLockPollIntervalMs = (): number =>
 export interface FlushableStreamState extends PromiseWithResolvers<void> {
   /** Number of write operations currently in flight to the server */
   pendingOps: number;
+  /** Serialized frames emitted by this pipe's producer. */
+  producedFrames: number;
+  /** Produced frames accepted by this pipe's sink. */
+  acceptedFrames: number;
+  /** Terminal pipe failure, retained for flushes requested after failure. */
+  pipeError?: unknown;
+  /** Flush callers waiting for their producer snapshot to reach the sink. */
+  frameWaiters: Array<{
+    target: number;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }>;
   /** Whether the `done` promise has been resolved */
   doneResolved: boolean;
   /** Whether the underlying stream has actually closed/errored */
@@ -140,6 +152,9 @@ export function createFlushableState(): FlushableStreamState {
   const state: FlushableStreamState = {
     ...withResolvers<void>(),
     pendingOps: 0,
+    producedFrames: 0,
+    acceptedFrames: 0,
+    frameWaiters: [],
     doneResolved: false,
     streamEnded: false,
   };
@@ -227,6 +242,40 @@ function resolveAfterDrain(state: FlushableStreamState): void {
     () => state.resolve(),
     (err) => state.reject(err)
   );
+}
+
+/** Record a frame synchronously when serialization emits it into this pipe. */
+export function markFlushableFrameProduced(state: FlushableStreamState): void {
+  state.producedFrames++;
+}
+
+/**
+ * Wait until every frame produced before this call has reached the sink, then
+ * await the sink's durability barrier. This does not close the stream or
+ * release a writer lock; concurrent writes may join the same sink drain.
+ */
+export async function flushFlushableState(
+  state: FlushableStreamState
+): Promise<void> {
+  if (state.pipeError !== undefined) throw state.pipeError;
+  const target = state.producedFrames;
+  if (state.acceptedFrames < target) {
+    await new Promise<void>((resolve, reject) => {
+      state.frameWaiters.push({ target, resolve, reject });
+    });
+  }
+  if (state.pipeError !== undefined) throw state.pipeError;
+  await state.drainBarrier?.();
+}
+
+/** Attach a workflow-specific `flush()` helper to a native writable stream. */
+export function withWorkflowFlush<T extends WritableStream>(
+  writable: T,
+  state: FlushableStreamState
+): T & { flush(): Promise<void> } {
+  return Object.assign(writable, {
+    flush: () => flushFlushableState(state),
+  });
 }
 
 /**
@@ -393,13 +442,25 @@ async function flushablePipePerChunk(
       state.pendingOps++;
       try {
         await writer.write(readResult.value);
+        state.acceptedFrames++;
+        const ready = state.frameWaiters.filter(
+          (waiter) => waiter.target <= state.acceptedFrames
+        );
+        state.frameWaiters = state.frameWaiters.filter(
+          (waiter) => waiter.target > state.acceptedFrames
+        );
+        for (const waiter of ready) waiter.resolve();
       } finally {
         state.pendingOps--;
       }
     }
   } catch (err) {
     state.streamEnded = true;
+    state.pipeError = err;
     cancelReason = err;
+    const frameWaiters = state.frameWaiters;
+    state.frameWaiters = [];
+    for (const waiter of frameWaiters) waiter.reject(err);
     // Against an early-ack sink, chunks can still be buffered or in flight
     // when the pipe fails (pendingOps only counts un-acked writes). Deliver
     // that accepted prefix before settling the failure: once the state

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,5 +40,6 @@ export {
 } from './step/get-workflow-metadata.js';
 export {
   getWritable,
+  type WorkflowWritableStream,
   type WorkflowWritableStreamOptions,
 } from './step/writable-stream.js';

--- a/packages/core/src/serialization.test.ts
+++ b/packages/core/src/serialization.test.ts
@@ -600,8 +600,12 @@ describe('workflow arguments', () => {
         'dpl_child'
       )) as WritableStream<string>;
 
+      expect(typeof (hydrated as { flush?: unknown }).flush).toBe('function');
       const writer = hydrated.getWriter();
       await writer.write('cross-deployment');
+      await (
+        hydrated as WritableStream<string> & { flush(): Promise<void> }
+      ).flush();
       await writer.close();
       await Promise.all(ops);
 

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -16,8 +16,10 @@ import {
   getMaxBytesPerBatch,
   getMaxChunksPerBatch,
   getMaxInflightChunks,
+  markFlushableFrameProduced,
   pollReadableLock,
   pollWritableLock,
+  withWorkflowFlush,
 } from './flushable-stream.js';
 import { getStepFunction } from './private.js';
 // V2: use getWorldLazy in step-side code paths so Turbopack can statically
@@ -271,7 +273,8 @@ async function recordGuestCodeExecutions(stats: GuestCodeStats): Promise<void> {
 
 export function getSerializeStream(
   reducers: Partial<Reducers>,
-  cryptoKey: EncryptionKeyParam
+  cryptoKey: EncryptionKeyParam,
+  onFrameProduced?: () => void
 ): TransformStream<any, Uint8Array> {
   const encoder = new TextEncoder();
   // Resolve the key input once on first use and cache the result.
@@ -332,6 +335,7 @@ export function getSerializeStream(
         const frame = new Uint8Array(FRAME_HEADER_SIZE + prefixed.length);
         new DataView(frame.buffer).setUint32(0, prefixed.length, false);
         frame.set(prefixed, FRAME_HEADER_SIZE);
+        onFrameProduced?.();
         controller.enqueue(frame);
       } catch (error) {
         // Encryption failures must keep their RuntimeDecryptionError
@@ -3314,9 +3318,11 @@ function getStepRevivers(
               value.encryptionPublicKey
             );
 
+      const state = createFlushableState();
       const serialize = getSerializeStream(
         getStepReducers(global, ops, targetRunId, targetKey),
-        targetKey
+        targetKey,
+        () => markFlushableFrameProduced(state)
       );
       const serverWritable = new WorkflowServerWritableStream(
         targetRunId,
@@ -3324,7 +3330,6 @@ function getStepRevivers(
       );
 
       // Create flushable state for this stream
-      const state = createFlushableState();
       ops.push(state.promise);
 
       // Start the flushable pipe in the background
@@ -3335,29 +3340,27 @@ function getStepRevivers(
       // Start polling to detect when user releases lock
       pollWritableLock(serialize.writable, state);
 
+      const writable = withWorkflowFlush(serialize.writable, state);
+
       // Record the underlying `(runId, name)` so downstream reducers can
       // recognize that this writable is already backed by a workflow
       // server stream. When forwarded across `start()` again (e.g.
       // the child passes this writable on to a grandchild), the
       // external reducer needs both to emit the original `runId` in
       // the descriptor.
-      Object.defineProperty(serialize.writable, STREAM_NAME_SYMBOL, {
+      Object.defineProperty(writable, STREAM_NAME_SYMBOL, {
         value: value.name,
         writable: false,
       });
-      Object.defineProperty(serialize.writable, STREAM_SERVER_RUN_ID_SYMBOL, {
+      Object.defineProperty(writable, STREAM_SERVER_RUN_ID_SYMBOL, {
         value: targetRunId,
         writable: false,
       });
       if (targetDeploymentId) {
-        Object.defineProperty(
-          serialize.writable,
-          STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
-          {
-            value: targetDeploymentId,
-            writable: false,
-          }
-        );
+        Object.defineProperty(writable, STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, {
+          value: targetDeploymentId,
+          writable: false,
+        });
       }
       // Keep the owner's public key on the handle so a further forward stays on
       // the zero-lookup sealed path.
@@ -3381,27 +3384,19 @@ function getStepRevivers(
         targetRunId === runId &&
         isRunPayloadKeys(cryptoKey)
       ) {
-        Object.defineProperty(
-          serialize.writable,
-          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
-          {
-            value: bytesToBase64(cryptoKey.keyPair.publicKey),
-            writable: false,
-          }
-        );
+        Object.defineProperty(writable, STREAM_SERVER_PUBLIC_KEY_SYMBOL, {
+          value: bytesToBase64(cryptoKey.keyPair.publicKey),
+          writable: false,
+        });
       }
       if (typeof value.encryptionPublicKey === 'string') {
-        Object.defineProperty(
-          serialize.writable,
-          STREAM_SERVER_PUBLIC_KEY_SYMBOL,
-          {
-            value: value.encryptionPublicKey,
-            writable: false,
-          }
-        );
+        Object.defineProperty(writable, STREAM_SERVER_PUBLIC_KEY_SYMBOL, {
+          value: value.encryptionPublicKey,
+          writable: false,
+        });
       }
 
-      return serialize.writable;
+      return writable;
     },
 
     AbortController: (value) => reviveAbortController(value, ops, runId),

--- a/packages/core/src/step/writable-stream.test.ts
+++ b/packages/core/src/step/writable-stream.test.ts
@@ -57,6 +57,71 @@ describe('step-level getWritable', () => {
     vi.clearAllMocks();
   });
 
+  it('flush waits for durability without requiring writer lock release', async () => {
+    const { contextStorage } = await import('./context-storage.js');
+    const { getWorldLazy } = await import('../runtime/get-world-lazy.js');
+    const world = await getWorldLazy();
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    vi.mocked(world.streams.writeMulti).mockImplementation(async () => {
+      await writeGate;
+    });
+    vi.mocked(world.streams.write).mockImplementation(async () => {
+      await writeGate;
+    });
+
+    const writable = await contextStorage.run(makeStepCtx(), async () => {
+      const { getWritable } = await import('./writable-stream.js');
+      return getWritable<string>();
+    });
+    const writer = writable.getWriter();
+    await writer.write('snapshot');
+
+    let flushed = false;
+    const flush = writable.flush().then(() => {
+      flushed = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(flushed).toBe(false);
+    expect(writable.locked).toBe(true);
+
+    releaseWrite();
+    await flush;
+    expect(writable.locked).toBe(true);
+
+    await writer.write('after-flush');
+    await writable.flush();
+    expect(
+      vi.mocked(world.streams.write).mock.calls.length +
+        vi.mocked(world.streams.writeMulti).mock.calls.length
+    ).toBe(2);
+    writer.releaseLock();
+  });
+
+  it('flush rejects when the durable write fails', async () => {
+    const { contextStorage } = await import('./context-storage.js');
+    const { getWorldLazy } = await import('../runtime/get-world-lazy.js');
+    const world = await getWorldLazy();
+    vi.mocked(world.streams.write).mockRejectedValue(
+      new Error('durable write failed')
+    );
+    vi.mocked(world.streams.writeMulti).mockRejectedValue(
+      new Error('durable write failed')
+    );
+
+    const writable = await contextStorage.run(makeStepCtx(), async () => {
+      const { getWritable } = await import('./writable-stream.js');
+      return getWritable<string>();
+    });
+    const writer = writable.getWriter();
+    await writer.write('snapshot');
+
+    await expect(writable.flush()).rejects.toThrow('durable write failed');
+    writer.releaseLock();
+  });
+
   it('ops promise should resolve when writer lock is released (without closing stream)', async () => {
     const { contextStorage } = await import('./context-storage.js');
 

--- a/packages/core/src/step/writable-stream.ts
+++ b/packages/core/src/step/writable-stream.ts
@@ -2,7 +2,9 @@ import { throwNotInWorkflowOrStepContext } from '../context-errors.js';
 import {
   createFlushableState,
   flushablePipe,
+  markFlushableFrameProduced,
   pollWritableLock,
+  withWorkflowFlush,
 } from '../flushable-stream.js';
 import { bytesToBase64 } from '../sealed-box.js';
 import {
@@ -23,6 +25,18 @@ import { type CachedWritable, contextStorage } from './context-storage.js';
 /**
  * The options for {@link getWritable}.
  */
+export type WorkflowWritableStream<W = any> = WritableStream<W> & {
+  /**
+   * Waits until chunks from completed `writer.write()` calls are durable on
+   * the Workflow server. Does not close the stream; concurrent writes may join
+   * the same drain.
+   *
+   * Call after releasing the writer lock when the next workflow step needs to
+   * observe those chunks.
+   */
+  flush(): Promise<void>;
+};
+
 export interface WorkflowWritableStreamOptions {
   /**
    * An optional namespace to distinguish between multiple streams associated
@@ -43,7 +57,7 @@ export interface WorkflowWritableStreamOptions {
  */
 export function getWritable<W = any>(
   options: WorkflowWritableStreamOptions = {}
-): WritableStream<W> {
+): WorkflowWritableStream<W> {
   const ctx = contextStorage.getStore();
   if (!ctx) {
     throwNotInWorkflowOrStepContext(
@@ -74,13 +88,14 @@ export function getWritable<W = any>(
   const cache = ctx.writables;
   const cached = cache.get(name);
   if (cached) {
-    return cached.writable as WritableStream<W>;
+    return cached.writable as WorkflowWritableStream<W>;
   }
 
   // Create a transform stream that serializes chunks and pipes to the workflow server.
   // The target run is the workflow run that owns this step, which (per
   // version skew protection) is on this same SDK version, so byte-stream
   // framing is always safe here.
+  const state = createFlushableState();
   const serialize = getSerializeStream(
     // In turbo optimistic start the body runs before `run_started` is durable.
     // Thread the run-ready barrier so that a nested ReadableStream written into
@@ -94,7 +109,8 @@ export function getWritable<W = any>(
       true,
       ctx.runReadyBarrier
     ),
-    ctx.encryptionKey
+    ctx.encryptionKey,
+    () => markFlushableFrameProduced(state)
   );
 
   // Use flushable pipe so the ops promise resolves when the user releases
@@ -109,7 +125,6 @@ export function getWritable<W = any>(
     name,
     ctx.runReadyBarrier
   );
-  const state = createFlushableState();
   ctx.ops.push(state.promise);
 
   flushablePipe(serialize.readable, serverWritable, state).catch(() => {
@@ -118,6 +133,8 @@ export function getWritable<W = any>(
 
   pollWritableLock(serialize.writable, state);
 
+  const writable = withWorkflowFlush(serialize.writable, state);
+
   // Tag the writable with its underlying `(runId, name)` so downstream
   // reducers can recognize that it's already backed by a workflow
   // server stream. Calling `start(child, [args, theWritable])` from
@@ -125,36 +142,32 @@ export function getWritable<W = any>(
   // dehydrated descriptor, so the child's reviver can open the
   // writable against the original `(runId, name)` directly, with no
   // in-process bridge tied to this step's lifetime.
-  Object.defineProperty(serialize.writable, STREAM_NAME_SYMBOL, {
+  Object.defineProperty(writable, STREAM_NAME_SYMBOL, {
     value: name,
     writable: false,
   });
-  Object.defineProperty(serialize.writable, STREAM_SERVER_RUN_ID_SYMBOL, {
+  Object.defineProperty(writable, STREAM_SERVER_RUN_ID_SYMBOL, {
     value: runId,
     writable: false,
   });
   if (ctx.workflowDeploymentId) {
-    Object.defineProperty(
-      serialize.writable,
-      STREAM_SERVER_DEPLOYMENT_ID_SYMBOL,
-      {
-        value: ctx.workflowDeploymentId,
-        writable: false,
-      }
-    );
+    Object.defineProperty(writable, STREAM_SERVER_DEPLOYMENT_ID_SYMBOL, {
+      value: ctx.workflowDeploymentId,
+      writable: false,
+    });
   }
   // Publish this run's X25519 public key on the handle so that a run this
   // writable is forwarded to can seal frames without looking anything up.
   // The key is already resolved on the step context, so this costs nothing
   // here and saves the receiver a round trip.
   if (isRunPayloadKeys(ctx.encryptionKey)) {
-    Object.defineProperty(serialize.writable, STREAM_SERVER_PUBLIC_KEY_SYMBOL, {
+    Object.defineProperty(writable, STREAM_SERVER_PUBLIC_KEY_SYMBOL, {
       value: bytesToBase64(ctx.encryptionKey.keyPair.publicKey),
       writable: false,
     });
   }
 
-  cache.set(name, { writable: serialize.writable, state });
+  cache.set(name, { writable, state });
 
-  return serialize.writable as WritableStream<W>;
+  return writable as WorkflowWritableStream<W>;
 }

--- a/packages/core/src/workflow/index.ts
+++ b/packages/core/src/workflow/index.ts
@@ -18,7 +18,11 @@ export {
   type SetAttributesOptions,
   setAttributes,
 } from './set-attributes.js';
-export { getWritable } from './writable-stream.js';
+export {
+  getWritable,
+  type WorkflowWritableStream,
+  type WorkflowWritableStreamOptions,
+} from './writable-stream.js';
 
 // workflows can't use these functions, but we still need to provide
 // the export so bundling doesn't fail when step and workflow are in same file

--- a/packages/core/src/workflow/writable-stream.ts
+++ b/packages/core/src/workflow/writable-stream.ts
@@ -1,15 +1,30 @@
-import type { WorkflowWritableStreamOptions } from '../step/writable-stream.js';
+import type {
+  WorkflowWritableStream,
+  WorkflowWritableStreamOptions,
+} from '../step/writable-stream.js';
 import { STREAM_NAME_SYMBOL, WORKFLOW_GET_STREAM_ID } from '../symbols.js';
+
+export type {
+  WorkflowWritableStream,
+  WorkflowWritableStreamOptions,
+} from '../step/writable-stream.js';
 
 export function getWritable<W = any>(
   options: WorkflowWritableStreamOptions = {}
-): WritableStream<W> {
+): WorkflowWritableStream<W> {
   const { namespace } = options;
   const name = (globalThis as any)[WORKFLOW_GET_STREAM_ID](namespace);
-  return Object.create(globalThis.WritableStream.prototype, {
+  const stream = Object.create(globalThis.WritableStream.prototype, {
     [STREAM_NAME_SYMBOL]: {
       value: name,
       writable: false,
+    },
+  });
+  return Object.assign(stream, {
+    flush: async (): Promise<void> => {
+      throw new Error(
+        'WorkflowWritableStream.flush() can only be called inside a step function'
+      );
     },
   });
 }


### PR DESCRIPTION
## Summary & Motivation

`getWritable()` now returns a `WorkflowWritableStream` — a `WritableStream` with a `flush()` method that resolves once chunks from completed `write()` calls are durable on the Workflow server. It doesn't close the stream or need the writer lock released, so it can serve as a read-after-write boundary without giving up the default concurrency between stream writes and later steps.

## Test Plan

- Unit tests added for flush's durability wait, repeated flushes, failure propagation, and forwarded writable handles.
- `pnpm --filter @workflow/core build`
- `pnpm --filter @workflow/core typecheck`
- `pnpm --filter @workflow/core test` — 2,322 passed, 3 expected failures, 1 skipped

## Docs Preview

| Page | Preview |
| --- | --- |
| `getWritable` | [Preview](https://workflow-docs-git-alangenfeld-workflow-explicit-stream-flush.vercel.sh/docs/api-reference/workflow/get-writable#waiting-for-durable-writes) |

