### PR TITLE
[docs] Document changeset and DCO requirements in README

### DIFF
--- a/.changeset/readme-contributing-requirements.md
+++ b/.changeset/readme-contributing-requirements.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document the changeset and DCO sign-off requirements in the README's Contributing section.

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -88,6 +88,14 @@ Contributions are welcome. Use
 with the team and wider community. By participating, you agree to our
 [Code of Conduct](https://github.com/vercel/workflow/blob/main/CODE_OF_CONDUCT.md).
 
+Two things are required before a pull request can merge:
+
+- A changeset. Run `pnpm changeset` and pick the semver bump that matches your
+  change, or `pnpm changeset --empty` for documentation and workbench-only
+  changes.
+- A [Developer Certificate of Origin](https://github.com/vercel/workflow/blob/main/DCO.txt)
+  sign-off on every commit. Commit with `git commit --signoff`.
+
 ## Security
 
 If you find a security vulnerability in Workflow SDK, **_disclose it responsibly instead of opening a public issue_**.


### PR DESCRIPTION
### Description

The PR checklist requires a changeset and a DCO sign-off on every commit, but the README's Contributing section doesn't mention either — contributors only find out after opening a PR. This adds both to the Contributing section.

Note: `README.md` at the repo root is a symlink to `packages/workflow/README.md`, so the edit is on the symlink target.

### How did you test your changes?

Documentation-only change; no code paths affected. Rendered markdown reviewed for correct list formatting and links (`DCO.txt` link resolves to the file at the repo root).

### PR Checklist - Required to merge

- [x] 📦 `pnpm changeset` was run to create a changelog for this PR
  - Empty changeset, since this is a documentation-only change.
- [x] 🔒 DCO sign-off passes (run `git commit --signoff` on your commits)
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete