### PR TITLE
fix(web-shared): stop event payload stub flash in events view

### DIFF
--- a/.changeset/spotty-pandas-flicker.md
+++ b/.changeset/spotty-pandas-flicker.md
@@ -1,0 +1,5 @@
+---
+'@workflow/web-shared': patch
+---
+
+Fix the events view flashing a partial eventData stub (ref fields stripped by `resolveData: 'none'`) before the full payload loads; events whose type carries no payload ref fields now render their complete inline data immediately without a redundant fetch.

--- a/packages/web-shared/src/components/event-list-view.tsx
+++ b/packages/web-shared/src/components/event-list-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { parseStepName, parseWorkflowName } from '@workflow/utils/parse-name';
-import type { Event, WorkflowRun } from '@workflow/world';
+import {
+  type Event,
+  getEventDataRefFields,
+  type WorkflowRun,
+} from '@workflow/world';
 import { Check, ChevronRight, Copy } from 'lucide-react';
 import type {
   KeyboardEvent as ReactKeyboardEvent,
@@ -924,7 +928,17 @@ export function EventRow({
   const displayedCreatedAt = showSeparateEventOccurrenceTimestamps
     ? createdAt
     : getEffectiveEventDate(event);
-  const hasExistingEventData = 'eventData' in event && event.eventData != null;
+  // List endpoints resolve events with `resolveData: 'none'`, which strips the
+  // ref/payload fields (input, result, error, …) and leaves a partial stub
+  // (stepName, timings, …). Rendering that stub while the full payload loads
+  // flashes an incomplete JSON document whose missing fields pop in after a
+  // skeleton, so only trust inline eventData when it can't be a stub: either
+  // there is no loader to fetch the full payload, or the event type carries
+  // no ref fields (its eventData is never stripped).
+  const hasExistingEventData =
+    'eventData' in event &&
+    event.eventData != null &&
+    (!onLoadEventData || getEventDataRefFields(event.eventType).length === 0);
   const isRun = isRunLevel(event.eventType);
   const eventName = isRun
     ? (workflowName ?? '-')
@@ -957,6 +971,12 @@ export function EventRow({
     }
     if (cachedEventData !== null) {
       setLoadedEventData(cachedEventData);
+      setHasAttemptedLoad(true);
+      return;
+    }
+    // Inline eventData of a ref-less event type is already complete (ref
+    // fields are the only ones ever stripped), so there is nothing to fetch.
+    if (hasExistingEventData) {
       setHasAttemptedLoad(true);
       return;
     }
@@ -995,6 +1015,7 @@ export function EventRow({
     encryptionKey,
     onEncryptedDataDetected,
     cachedEventData,
+    hasExistingEventData,
   ]);
 
   // Auto-load event data when remounting in expanded state without cached data


### PR DESCRIPTION
## Problem

In the events view, opening an event's payload flickered: a partial JSON document flashed first, then a skeleton, then the full payload (with the Decrypt button on encrypted fields).

Root cause: list endpoints resolve events with `resolveData: 'none'`, which strips the ref/payload fields (`input`, `result`, `error`, …) via `stripEventDataRefs` and leaves a partial `eventData` stub (stepName, timings, …). `EventRow` treated that stub as displayable payload, rendering it during the load window even though a full-payload fetch was already in flight.

## Fix

Only trust inline `eventData` when it can't be a stub:

- when there is no `onLoadEventData` loader (inline data is all there is), or
- when the event type carries no ref fields (`stripEventDataRefs` never strips those, so inline data is already complete — e.g. `wait_created`, `attr_set`). Those now render immediately and skip the redundant fetch.

## Verification

Reproduced end-to-end against a local world with encryption enabled (recorded DOM state transitions via MutationObserver):

- Before: `json(stub, missing result) → skeleton → json+decrypt-btns`; same flash when already decrypted.
- After: `skeleton → json+decrypt-btns` (encrypted), `skeleton → json` (decrypted), ref-less events render instantly, decrypt transition swaps encrypted → decrypted content with no flash.

`@workflow/web-shared` typecheck + 225 tests pass.