### PR TITLE
Fix the Release job: drop `@workflow/world-sim` from the hook_conflict delta changeset

### DIFF
--- a/.changeset/hook-conflict-delta-worlds.md
+++ b/.changeset/hook-conflict-delta-worlds.md
@@ -1,7 +1,6 @@
 ---
 '@workflow/world': patch
 '@workflow/world-local': patch
-'@workflow/world-sim': patch
 ---
 
 Answer the `sinceCursor` event-log delta on a `hook_conflict` write the same way as on `hook_created`.


### PR DESCRIPTION
## Problem

The Release workflow has failed on every push to `main` since #3938 landed, so no beta has been published:

- https://github.com/vercel/workflow/actions/runs/33803151985/job/100807197872 (`7cc5c88a8`)
- https://github.com/vercel/workflow/actions/runs/33806163595 (`f9073d073`)

`changeset version` aborts before doing anything:

```
🦋  error Error: Found mixed changeset hook-conflict-delta-worlds
🦋  error Found ignored packages: @workflow/world-sim
🦋  error Found not ignored packages: @workflow/world @workflow/world-local
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`.changeset/hook-conflict-delta-worlds.md` (added by #3938, my PR) bumps `@workflow/world-sim` alongside `@workflow/world` and `@workflow/world-local`. `@workflow/world-sim` is private and listed under `ignore` in `.changeset/config.json`, and changesets refuses a changeset that mixes ignored and published packages.

## Fix

Remove the `@workflow/world-sim` line. The package is never published, so it has no changelog to lose. `pnpm changeset version` now completes locally (verified, then reverted).

Nothing at PR time validates changesets today, and `pnpm changeset status --since=main` does not catch this either when run on the merge commit. A follow-up PR adds a CI check that assembles the release plan the way `changeset version` does, so the next one of these fails on the PR instead of on `main`.

No changeset: this PR only edits an existing changeset file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)