### PR TITLE
Validate pending changesets in CI so a bad one fails the PR instead of the Release job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,6 +87,29 @@ jobs:
       - name: Run .github/scripts unit tests
         run: node --test ".github/scripts/**/*.test.js"
 
+  changesets:
+    name: Changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: true
+          require-lockfile: true
+          runtime: node@22
+          cache: true
+
+      # `changeset version` (release.yml) assembles a release plan from every
+      # pending changeset before it bumps anything. A changeset it cannot
+      # place in that plan, such as one that mixes an `ignore`d private
+      # package with published ones, fails the Release job on main and blocks
+      # publishing until it is fixed (#3963). Run the same assembly here.
+      - name: Check pending changesets assemble into a release plan
+        run: node scripts/check-changesets.mjs
+
   docs-links:
     name: Docs Links
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,6 +428,7 @@ Because those PRs have no deployment of their own, CI treats them specially: the
 - To check if one is needed, run `pnpm changeset status --since=main >/dev/null 2>&1 && echo "no changeset needed" || echo "changeset needed"`
 - Create a changeset using `pnpm changeset add`
   - All changed packages should be included in the changeset. Never include unchanged packages.
+  - Never list a package from the `ignore` array in `.changeset/config.json` (private workbench and simulation packages such as `@workflow/world-sim`), even when the PR changes it. Changesets rejects a changeset that mixes ignored and published packages, and the failure only surfaces in the Release job on `main`. `node scripts/check-changesets.mjs` runs that validation locally; CI runs it in `lint.yml`.
   - Use the correct semver bump type: `patch` for bug fixes, `minor` for new features, `major` for breaking changes
   - On `main` (pre-release mode), the bump type doesn't affect beta numbering (it always increments `beta.N`) but it **does matter** when changes are backported to `stable`
 - Remember to always build any packages that get changed before running downstream tests like e2e tests in the workbench

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Fails when the pending changesets cannot be assembled into a release plan.
+ *
+ * `changeset version`, which .github/workflows/release.yml runs on every push
+ * to `main`, builds a release plan from every file in `.changeset/` before it
+ * bumps a single version. Two kinds of changeset make that step throw, and
+ * the throw leaves `main` unpublishable until someone reads the red Release
+ * job:
+ *
+ *   - one naming a package that is not in the workspace (a typo, or a
+ *     package renamed or removed after the changeset was written);
+ *   - one mixing packages from `.changeset/config.json#ignore` (private
+ *     workbench and simulation packages such as `@workflow/world-sim`) with
+ *     published ones. Changesets rejects the whole file rather than dropping
+ *     the ignored entries. #3938 shipped one of these and blocked every
+ *     release until #3963.
+ *
+ * Nothing at PR time exercised that step. `changeset status --since=main`
+ * does not see a changeset once it is on the base branch, and it also fails
+ * for the unrelated reason of a package changing without a changeset, so it
+ * cannot serve as this gate. This script runs the same assembly `changeset
+ * version` runs, on the same inputs, and stops there: it skips the changelog
+ * generation, which is the slow, network-bound part of the real command, so
+ * it is cheap enough to run on every PR.
+ *
+ * The libraries are resolved from `@changesets/cli`'s own install rather than
+ * declared as root dependencies. That keeps them at exactly the versions the
+ * CLI uses, so this check cannot drift from what the Release job will do, and
+ * it avoids adding five packages to the root manifest for a lint step.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cwd = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// `require.resolve` returns the real path of the CLI's entry point inside
+// pnpm's virtual store, where its dependencies sit beside it. A `require`
+// created from there resolves them the same way the CLI itself does.
+const cliEntry = createRequire(import.meta.url).resolve('@changesets/cli');
+const cliRequire = createRequire(cliEntry);
+
+const assembleReleasePlan = cliRequire(
+  '@changesets/assemble-release-plan'
+).default;
+const { read: readConfig } = cliRequire('@changesets/config');
+const { readPreState } = cliRequire('@changesets/pre');
+const readChangesets = cliRequire('@changesets/read').default;
+const { getPackages } = cliRequire('@manypkg/get-packages');
+
+const packages = await getPackages(cwd);
+const config = await readConfig(cwd, packages);
+const [changesets, preState] = await Promise.all([
+  readChangesets(cwd),
+  readPreState(cwd),
+]);
+
+let plan;
+try {
+  plan = assembleReleasePlan(changesets, packages, config, preState);
+} catch (error) {
+  console.error(
+    '✗ The pending changesets cannot be turned into a release plan.'
+  );
+  console.error('  `changeset version` will fail on main with this error:\n');
+  console.error(
+    String(error?.message ?? error)
+      .split('\n')
+      .map((line) => `    ${line}`)
+      .join('\n')
+  );
+  console.error(
+    '\n  A changeset may only list packages that are published, and never one from the `ignore` array in .changeset/config.json.'
+  );
+  process.exit(1);
+}
+
+const pending = plan.changesets.length;
+const releasing = plan.releases.filter((r) => r.type !== 'none').length;
+console.log(
+  `✓ ${changesets.length} changeset(s) read, ${pending} pending${preState ? ` (${preState.mode} mode, tag "${preState.tag}")` : ''}; ${releasing} package(s) would be released.`
+);


### PR DESCRIPTION
Follow-up to #3963, which fixed the changeset that blocked releases today.

## Why

`changeset version` assembles a release plan from every pending changeset before it bumps anything, and throws on a changeset it cannot place there:

- one naming a package that is not in the workspace;
- one mixing a package from `.changeset/config.json#ignore` (private workbench/sim packages like `@workflow/world-sim`) with published ones.

#3938 shipped the second kind, and every push to `main` after it failed in the Release job with nothing published, until #3963. Nothing at PR time ran that step. `changeset status --since=main` cannot serve as the gate: it only sees changesets added since the base, and it also exits non-zero when a package changes without a changeset, which this repo does not enforce in CI.

## What

- **`scripts/check-changesets.mjs`** runs the same assembly `changeset version` runs, on the same inputs (`getPackages`, config, changesets, `pre.json`), and stops before the network-bound changelog generation. It resolves the changesets libraries from `@changesets/cli`'s own install, so it uses exactly the versions the Release job uses and adds no root dependencies. Declaring them as root devDependencies was tried first and reshuffled ~2300 lockfile lines through a `supports-color` peer re-resolution, so that approach was dropped.
- **`lint.yml`** gains a `Changesets` job that runs the script on every PR and push to `main`.
- **CLAUDE.md / AGENTS.md** tell agents not to list `ignore`d packages in a changeset. The existing "include all changed packages" rule is what led to the bad changeset in #3938.

## Verified locally

On current `main`:

```
✓ 682 changeset(s) read, 12 pending (pre mode, tag "beta"); 21 package(s) would be released.
```

With the `@workflow/world-sim` line re-added to `hook-conflict-delta-worlds.md` (exit 1):

```
✗ The pending changesets cannot be turned into a release plan.
  `changeset version` will fail on main with this error:

    Found mixed changeset hook-conflict-delta-worlds
    Found ignored packages: @workflow/world-sim
    Found not ignored packages: @workflow/world @workflow/world-local
    Mixed changesets that contain both ignored and not ignored packages are not allowed
```

With a changeset naming `@workflow/does-not-exist` (exit 1):

```
    Found changeset tmp-bogus for package @workflow/does-not-exist which is not in the workspace
```

No changeset: CI, scripts, and agent docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)