### PR TITLE
Name WS client spans for their transport instead of dressing them as HTTP

### DIFF
--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -62,7 +62,7 @@ import {
   instrumentedFetch,
   parseRetryAfter,
   recordClientSpanStatus,
-  withHttpClientSpan,
+  withWsFrameSpan,
 } from './http-core.js';
 import { hasSerializedDataFormatPrefix } from './serialized-data.js';
 import { deserializeStep, StepWireSchema } from './steps.js';
@@ -77,7 +77,7 @@ import {
   WorkflowWsRequestId,
   WorkflowWsUrl,
 } from './telemetry.js';
-import { type APIConfig, getHttpConfig, getHttpUrl } from './utils.js';
+import { type APIConfig, getHttpConfig } from './utils.js';
 import { version } from './version.js';
 import type { WsFrameReply } from './ws-transport.js';
 import {
@@ -1177,6 +1177,13 @@ function wsReplyStatus(reply: WsFrameReply, endpoint: string): number {
 }
 
 /**
+ * The frame span's Datadog resource: the socket route every event frame
+ * actually travels through, parameterized like an HTTP route. One resource
+ * for all frame writes; the per-event dimension is `workflow.event.type`.
+ */
+const WS_EVENTS_RESOURCE = '/api/websockets/v1/runs/:runId';
+
+/**
  * Synthesize the per-write client span the WS path would otherwise not have.
  *
  * On HTTP every event write goes through `fetchV4` → `instrumentedFetch`, which
@@ -1186,21 +1193,19 @@ function wsReplyStatus(reply: WsFrameReply, endpoint: string): number {
  * flipped, and with it the per-event view of a run's writes, which is the
  * thing a trace of a step execution is mostly made of.
  *
- * Nothing about the request/response *semantics* changed, though: one frame out,
- * one correlated reply back, one status. So the span is synthesized here with
- * the same name, kind and attributes the fetch path emits, over the v4 REST
- * endpoint the server forwards the frame into. Two consequences that are the
- * point rather than a side effect:
+ * Nothing about the request/response *semantics* changed: one frame out, one
+ * correlated reply back, one status. But the span does NOT wear HTTP shape —
+ * it is named `ws.events.post` with the socket route as its resource, carries
+ * no `http.request.method` and no `url.full` (an earlier version synthesized
+ * the REST URL the event would have been POSTed to, which made every frame
+ * render as a bare `POST` and invited misreading frames as HTTP requests).
+ * Cross-transport comparison keys on the attributes both paths share:
+ * `workflow.event.type` + `workflow.events.transport`, plus the status code,
+ * which is real on both.
  *
- *   - a trace looks the same either side of `WORKFLOW_EVENTS_TRANSPORT`, so the
- *     A/B the flag exists for compares like with like, and
- *   - dashboards keyed on `http POST` + `url.full` keep working unchanged.
- *
- * What is *not* elided: `workflow.events.transport: 'ws'`,
- * `network.protocol.name: 'websocket'` and `workflow.events.ws.url` say plainly
- * that no HTTP request was issued, and `workflow.events.ws.req_id` is the join
- * key to the server's log line for the same frame. A synthetic span that hid
- * which transport produced it would be a trap, not a convenience.
+ * `workflow.events.ws.url` names the actual wire destination, and
+ * `workflow.events.ws.req_id` is the join key to the server's log line for
+ * the same frame.
  *
  * Two things the HTTP envelope has that this one deliberately does not: the
  * cache-bust header (a frame is memoized by nothing) and a per-frame
@@ -1232,19 +1237,11 @@ async function postEventFrameOverWs(
   if (!resolved) return undefined;
   const { transport, wsUrl } = resolved;
   const endpoint = `${wsUrl}#runs/${encodeURIComponent(runId)}/events`;
-  // Same helper the HTTP path builds its URL with. `resolveWsTransport` already
-  // returned null for the proxy World, so this is always the direct
-  // workflow-server origin the socket itself points at.
-  const restUrl = eventsV4Url(
-    getHttpUrl(config).baseUrl,
-    runId,
-    input.eventType
-  );
 
-  return withHttpClientSpan(
+  return withWsFrameSpan(
     {
-      method: 'POST',
-      url: restUrl,
+      wsUrl,
+      resourceName: WS_EVENTS_RESOURCE,
       attributes: {
         ...WorkflowEventsTransport('ws'),
         ...WorkflowEventType(input.eventType),

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -37,6 +37,7 @@ import {
   NODE_HTTP_HEADERS_TIMEOUT_MS,
 } from './http-client.js';
 import {
+  DatadogResourceName,
   ErrorType,
   getSpanKind,
   HttpRequestMethod,
@@ -446,6 +447,54 @@ export interface HttpClientSpanOptions {
  * is parented to this span rather than to the caller's, which is the contract
  * CLAUDE.md's trace-propagation rule describes.
  */
+/**
+ * Open the CLIENT span for one WS event frame and run `fn` inside it.
+ *
+ * Deliberately NOT `withHttpClientSpan`: a frame is not an HTTP request, and
+ * the two lies that made it look like one — a synthesized `url.full` naming a
+ * REST endpoint no request ever hit, and an `http.request.method` that made
+ * Datadog derive the resource as a bare `POST` — are exactly what this span
+ * omits. The resource is the socket route the frame actually travels through
+ * (`resource.name`, Datadog-reserved), the span name is `ws.events.post`, and
+ * the real wire destination lives in `workflow.events.ws.url` (passed by the
+ * caller in `attributes`). Everything HTTP-shaped that remains is true: the
+ * reply's status code is a real status the server produced.
+ *
+ * `fn` runs inside the active span, so anything it injects trace context into
+ * is parented to this span rather than to the caller's — same contract as
+ * `withHttpClientSpan`.
+ */
+export async function withWsFrameSpan<T>(
+  opts: {
+    /** The socket URL, for server.address/port. */
+    wsUrl: string;
+    /** Parameterized socket route, e.g. `/api/websockets/v1/runs/:runId`. */
+    resourceName: string;
+    /** Extra attributes (transport, event type, stso, …). */
+    attributes?: Record<string, string | number | string[]>;
+  },
+  fn: (span?: Span) => Promise<T>
+): Promise<T> {
+  const { wsUrl, resourceName, attributes } = opts;
+  return trace(
+    'ws.events.post',
+    { kind: await getSpanKind('CLIENT') },
+    async (span) => {
+      const { serverAddress, serverPort } = parseServer(wsUrl);
+      span?.setAttributes({
+        ...DatadogResourceName(resourceName),
+        ...(serverAddress ? ServerAddress(serverAddress) : {}),
+        ...(serverPort ? ServerPort(serverPort) : {}),
+        ...PeerService('workflow-server'),
+        ...RpcSystem('websocket'),
+        ...RpcService('workflow-server'),
+      });
+      if (attributes) span?.setAttributes(attributes);
+      return fn(span);
+    }
+  );
+}
+
 export async function withHttpClientSpan<T>(
   opts: HttpClientSpanOptions,
   fn: (span?: Span) => Promise<T>

--- a/packages/world-vercel/src/telemetry.ts
+++ b/packages/world-vercel/src/telemetry.ts
@@ -322,12 +322,22 @@ export const StepLatencyOptimizations = SemanticConvention<string[]>(
 
 /**
  * The socket a WS event write actually travelled over
- * (workflow.events.ws.url). `url.full` names the v4 REST endpoint the frame is
- * forwarded into, so this is where the real wire destination is recorded.
+ * (workflow.events.ws.url). Frame spans carry no `url.full` (no HTTP request
+ * exists to name), so this is where the real wire destination is recorded.
  */
 export const WorkflowWsUrl = SemanticConvention<string>(
   'workflow.events.ws.url'
 );
+
+/**
+ * Datadog-reserved resource override (resource.name). Set where the derived
+ * resource would mislead: Datadog computes an HTTP-semconv CLIENT span's
+ * resource from `http.request.method` (+ route), ignoring the span name — so
+ * WS frame spans would render as a bare `POST` and the upgrade as `GET`.
+ * Spans without HTTP semconv fall back to the span name, where this override
+ * is belt-and-braces.
+ */
+export const DatadogResourceName = SemanticConvention<string>('resource.name');
 
 /**
  * Per-connection request id this write was multiplexed under

--- a/packages/world-vercel/src/ws-transport-spans.test.ts
+++ b/packages/world-vercel/src/ws-transport-spans.test.ts
@@ -237,13 +237,20 @@ const spansNamed = (name: string): ReadableSpan[] =>
   exporter.getFinishedSpans().filter((s) => s.name === name);
 
 const writeSpan = (): ReadableSpan => {
+  const spans = spansNamed('ws.events.post');
+  expect(spans).toHaveLength(1);
+  return spans[0];
+};
+
+/** The HTTP path's write span, unchanged by the WS rename. */
+const httpWriteSpan = () => {
   const spans = spansNamed('http POST');
   expect(spans).toHaveLength(1);
   return spans[0];
 };
 
 describe('per-write client span', () => {
-  it('emits one `http POST` CLIENT span per event write', async () => {
+  it('emits one `ws.events.post` CLIENT span per event write', async () => {
     await withOpenChannel();
 
     await createWorkflowRunEventV4(input, { token: 'test-token' });
@@ -252,26 +259,35 @@ describe('per-write client span', () => {
     // SpanKind.CLIENT === 2. Asserted as the literal so a change to the kind
     // (which is what makes it render as an outgoing request) is visible here.
     expect(span.kind).toBe(2);
-    expect(span.attributes['http.request.method']).toBe('POST');
+    // No HTTP shape: a frame is not an HTTP request. The method is absent so
+    // Datadog's method-derived resource cannot flatten every frame to `POST`;
+    // the resource is the socket route instead.
+    expect(span.attributes['http.request.method']).toBeUndefined();
+    expect(span.attributes['resource.name']).toBe(
+      '/api/websockets/v1/runs/:runId'
+    );
+    // The status is real — the server's reply status for this frame.
     expect(span.attributes['http.response.status_code']).toBe(201);
     expect(span.attributes['error.type']).toBeUndefined();
   });
 
-  it('reports the v4 REST endpoint as url.full, byte-identical to the HTTP path', async () => {
+  it('carries no synthesized URL: the wire destination is the ws url', async () => {
     await withOpenChannel();
 
     await createWorkflowRunEventV4(input, { token: 'test-token' });
 
-    // Not the socket URL: the server forwards the frame into this route, and
-    // naming it is what keeps a dashboard keyed on `http POST` + `url.full`
-    // working across the transport flag. The HTTP-path assertion in
-    // `transport parity` below pins that these two strings are the same one.
-    expect(writeSpan().attributes['url.full']).toBe(REST_URL);
+    // An earlier version synthesized the REST URL the event would have been
+    // POSTed to as `url.full`. No request to that URL occurs, and the fiction
+    // invited misreading frames as HTTP requests — so it is gone. The only
+    // URL on the span is the socket it actually travelled through.
+    expect(writeSpan().attributes['url.full']).toBeUndefined();
+    expect(writeSpan().attributes['workflow.events.ws.url']).toBe(WS_URL);
     expect(writeSpan().attributes['server.address']).toBe(
       new URL(ORIGIN).hostname
     );
     expect(writeSpan().attributes['peer.service']).toBe('workflow-server');
     expect(writeSpan().attributes['rpc.service']).toBe('workflow-server');
+    expect(writeSpan().attributes['rpc.system']).toBe('websocket');
   });
 
   it('says plainly that it was a frame, not an HTTP request', async () => {
@@ -308,7 +324,7 @@ describe('per-write client span', () => {
       { token: 'test-token' }
     );
 
-    const ids = spansNamed('http POST').map(
+    const ids = spansNamed('ws.events.post').map(
       (s) => s.attributes['workflow.events.ws.req_id']
     );
     expect(ids).toEqual([1, 2]);
@@ -417,7 +433,7 @@ describe('failure reporting', () => {
     );
     expect(result.event.eventId).toBe('evnt_1');
 
-    const spans = spansNamed('http POST');
+    const spans = spansNamed('ws.events.post');
     expect(spans).toHaveLength(2);
     expect(spans.map((s) => s.attributes['http.response.status_code'])).toEqual(
       [500, 201]
@@ -442,6 +458,11 @@ describe('connection span', () => {
     expect(connect).toHaveLength(1);
     expect(connect[0].kind).toBe(2);
     expect(connect[0].attributes['url.full']).toBe(WS_URL);
+    // A real HTTP GET, so it keeps HTTP attributes — the resource override
+    // alone stops the drain rendering it as a bare `GET`.
+    expect(connect[0].attributes['resource.name']).toBe(
+      'WS CONNECT /api/websockets/v1/runs/:runId'
+    );
     expect(connect[0].attributes['workflow.events.transport']).toBe('ws');
     expect(connect[0].attributes['workflow.events.ws.reconnect_attempt']).toBe(
       0
@@ -508,7 +529,7 @@ describe('transport parity', () => {
     agent.assertNoPendingInterceptors();
   });
 
-  it('emits the same span name and url.full on HTTP as on ws', async () => {
+  it('keeps full HTTP shape on the HTTP path: the asymmetry is the contract', async () => {
     // As above. This one is a write, so unset would now open the gate and the
     // test would only still pass by falling through resolveWsTransport's null
     // — passing for the wrong reason, which is the exact failure this file
@@ -531,10 +552,11 @@ describe('transport parity', () => {
       dispatcher: agent,
     });
 
-    // The whole point of synthesizing the WS span: a trace taken either side of
-    // the flag reads the same, so the A/B the flag exists for compares like
-    // with like. Only `workflow.events.transport` separates them.
-    const span = writeSpan();
+    // After the rename the invariant is: HTTP-shaped attributes mean HTTP
+    // happened. The HTTP path keeps `http POST` + `url.full` untouched;
+    // cross-transport comparison keys on `workflow.event.type` +
+    // `workflow.events.transport`, which both paths carry.
+    const span = httpWriteSpan();
     expect(span.attributes['url.full']).toBe(REST_URL);
     expect(span.attributes['http.request.method']).toBe('POST');
     expect(span.attributes['workflow.event.type']).toBe('step_completed');

--- a/packages/world-vercel/src/ws-transport.ts
+++ b/packages/world-vercel/src/ws-transport.ts
@@ -32,6 +32,7 @@ import {
   withHttpClientSpan,
 } from './http-core.js';
 import {
+  DatadogResourceName,
   ErrorType,
   injectTraceContextIntoHeaders,
   NetworkProtocolName,
@@ -86,6 +87,9 @@ const MALFORMED_FRAME_REQ_ID = -1;
 // Bounded so a server that is down, or an upgrade being rejected outright,
 // can't become a hot reconnect loop. Once exhausted the transport goes quiet
 // and the next `request()` reconnects lazily instead.
+/** Datadog resource for the handshake span (see `connectWithSpan`). */
+const WS_CONNECT_RESOURCE = 'WS CONNECT /api/websockets/v1/runs/:runId';
+
 const RECONNECT_MAX_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 100;
 const RECONNECT_MAX_DELAY_MS = 5_000;
@@ -390,6 +394,10 @@ class WsEventsTransport {
         url: this.wsUrl,
         spanName: 'workflow.events.ws.connect',
         attributes: {
+          // The upgrade is a real HTTP GET, so it keeps its HTTP attributes;
+          // the resource override alone stops Datadog rendering it as a bare
+          // `GET` (the method-derived resource ignores the span name).
+          ...DatadogResourceName(WS_CONNECT_RESOURCE),
           ...WorkflowEventsTransport('ws'),
           ...NetworkProtocolName('websocket'),
           ...WorkflowWsReconnectAttempt(this.reconnectAttempts),


### PR DESCRIPTION
## What

WS event **frame spans** become:
- span name: `ws.events.post` (was `http POST`)
- Datadog resource: `/api/websockets/v1/runs/:runId` — the socket route the frame actually travels through (set via reserved `resource.name`)
- **removed**: `http.request.method`, `url.full` (and derived url_details) — the synthesized REST URL was a fiction; no request to it ever occurred
- kept: `workflow.events.ws.url` (the real wire destination), `workflow.event.type`, `workflow.events.transport`, stso/optimizations, reply status (real on both transports), `rpc.system: websocket`

The **handshake span** keeps its honest HTTP attributes (it is a real GET) and gains resource `WS CONNECT /api/websockets/v1/runs/:runId`.

The **HTTP write path is untouched**. Post-change invariant: HTTP-shaped attributes on a span mean HTTP happened.

## Why

Frame writes rendered as a bare-`POST` resource fleet-wide — one resource hash (`ba66c0209b09ac3a`) for every event type, run and service — because Datadog derives an HTTP-semconv CLIENT span's resource from the method, ignoring the span name (demonstrated in production: the connect span already passed a spanName and still rendered as `GET`). The HTTP costume also repeatedly invited misreading frames as HTTP requests during the STSO/handshake investigations.

## Query migration

Cross-transport per-event comparisons key on `workflow.event.type` + `workflow.events.transport` (both paths carry them; 1:1 with the old path filter). Queries keyed on the synthesized `url.full`/path_group match only pre-rollout data; mixed-window dashboards need `(path OR event.type)` during retention overlap.

## Testing

`ws-transport-spans.test.ts` updated to pin the new contract: frame spans carry `resource.name` and **no** `http.request.method`/`url.full`; the retry/reqId tests follow the new span name; the old "transport parity" test is inverted into an asymmetry test (HTTP path keeps full HTTP shape). Connect span asserts its `WS CONNECT` resource alongside its real HTTP attributes.

628 world-vercel tests / 28 files pass; `tsc --noEmit` clean; Biome clean (2 pre-existing complexity warnings untouched).