### PR TITLE
[core] Reset the replay divergence budget once an invocation makes progress

### DIFF
--- a/.changeset/reset-divergence-budget-on-progress.md
+++ b/.changeset/reset-divergence-budget-on-progress.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Restart the replay divergence recovery budget once an invocation commits progress

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -2586,6 +2586,14 @@ describe('workflowEntrypoint inline-delta gate with open hooks', () => {
        * claim after an out-of-band event bumped the run's marker.
        */
       rejectClaimOnce?: { stepName: string; error: Error };
+      /** `replayDivergence` carried on the incoming queue message. */
+      replayDivergence?: { eventId: string; count: number };
+      /**
+       * Called after each event lands in the durable log, with a recorder for
+       * appending further events; simulates an out-of-band writer that lands
+       * between this invocation's write and its next replay.
+       */
+      afterRecord?: (event: Event, record: (data: any) => Event) => void;
     } = {}
   ) {
     const workflowRun: WorkflowRun = {
@@ -2600,7 +2608,7 @@ describe('workflowEntrypoint inline-delta gate with open hooks', () => {
     };
 
     const durableEvents: Event[] = [];
-    const recordEvent = (data: any): Event => {
+    const appendEvent = (data: any): Event => {
       // Slot-numbered event ids, so the runtime's snapshot (the highest slot
       // its loaded log occupies) is computable. This is the only kind of run
       // that reaches a fencing backend.
@@ -2611,6 +2619,11 @@ describe('workflowEntrypoint inline-delta gate with open hooks', () => {
         ...data,
       } as Event;
       durableEvents.push(created);
+      return created;
+    };
+    const recordEvent = (data: any): Event => {
+      const created = appendEvent(data);
+      opts.afterRecord?.(created, appendEvent);
       return created;
     };
 
@@ -2678,6 +2691,7 @@ describe('workflowEntrypoint inline-delta gate with open hooks', () => {
               {
                 runId,
                 requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+                replayDivergence: opts.replayDivergence,
               },
               {
                 requestId: 'req_delta_gate',
@@ -2816,6 +2830,79 @@ describe('workflowEntrypoint inline-delta gate with open hooks', () => {
     );
     expect(res.status).toBe(204);
     expect(deltaGateBodyRuns).toEqual(['B']);
+    expect(eventsCreate.mock.calls).not.toContainEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: 'run_failed' }),
+      ])
+    );
+  });
+
+  // One inline step, then a sleep. The step gives the recovery invocation a
+  // clean replay pass that commits progress; the sleep is where a later pass
+  // in the same invocation can be made to diverge.
+  const stepThenSleepWorkflow = `const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+    const a = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("deltaGateStep");
+    async function workflow() {
+      await a();
+      await sleep('5s');
+      return 'done';
+    };globalThis.__private_workflows = new Map();
+    globalThis.__private_workflows.set("workflow", workflow);`;
+
+  // Lands a wait_created with a foreign correlation id right after the inline
+  // step's terminal write, so the next replay pass (which reloads the log)
+  // finds it where its own sleep expects to be recorded and diverges.
+  const divergeAfterStepCompleted = (
+    event: Event,
+    record: (data: any) => Event
+  ) => {
+    if (event.eventType !== 'step_completed') return;
+    record({
+      eventType: 'wait_created',
+      specVersion: SPEC_VERSION_CURRENT,
+      correlationId: 'wait_01HK153X00VFKAJV9XFN9JXXRS',
+      eventData: { resumeAt: new Date('2024-01-01T00:00:05.000Z') },
+    });
+  };
+
+  it('restarts the divergence budget when a recovery invocation commits progress before a later pass diverges', async () => {
+    // The incoming message has already spent the whole budget. Without the
+    // reset, the divergence below would count as MAX + 1 and fail the run
+    // with CORRUPTED_EVENT_LOG, even though this invocation's first pass
+    // replayed cleanly and committed the step: proof the incoming episode was
+    // not reproducible against this log.
+    const { res, eventsCreate, queueMock } = await driveDeltaGate(
+      'wrun_divergence_budget_reset',
+      {
+        source: stepThenSleepWorkflow,
+        replayDivergence: {
+          eventId: 'prior-episode-event',
+          count: REPLAY_DIVERGENCE_MAX_RETRIES,
+        },
+        afterRecord: divergeAfterStepCompleted,
+      }
+    );
+    expect(res.status).toBe(204);
+
+    // The first pass recovered the incoming episode and said so on its first
+    // natural write, with the incoming count.
+    const stepStarted = eventsCreate.mock.calls.find(
+      (c) => (c[1] as any).eventType === 'step_started'
+    );
+    expect(stepStarted?.[2]).toEqual(
+      expect.objectContaining({
+        replayDivergenceCount: REPLAY_DIVERGENCE_MAX_RETRIES,
+      })
+    );
+
+    // The later divergence opens a new episode: a recovery replay at count 1,
+    // and no run_failed.
+    expect(queueMock).toHaveBeenCalledTimes(1);
+    expect(queueMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        replayDivergence: expect.objectContaining({ count: 1 }),
+      })
+    );
     expect(eventsCreate.mock.calls).not.toContainEqual(
       expect.arrayContaining([
         expect.objectContaining({ eventType: 'run_failed' }),

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4833,8 +4833,13 @@ export function workflowEntrypoint(
 
                         let replayDivergenceCountForFailure: number | undefined;
                         if (ReplayDivergenceError.is(err)) {
+                          // Continues the incoming episode's count unless this
+                          // invocation already committed a write after a clean
+                          // replay, which closed that episode; a divergence
+                          // after it starts a fresh budget rather than failing
+                          // the run on an unrelated earlier chain.
                           const divergenceCount =
-                            (replayDivergence?.count ?? 0) + 1;
+                            replayRecoveryReporter.nextDivergenceCount();
                           const maxRecoveryReplays =
                             getReplayDivergenceMaxRetries();
 

--- a/packages/core/src/runtime/replay-recovery-reporter.test.ts
+++ b/packages/core/src/runtime/replay-recovery-reporter.test.ts
@@ -42,6 +42,51 @@ describe('ReplayRecoveryReporter', () => {
     expect(create).toHaveBeenCalledWith({ replayDivergenceCount: 2 });
   });
 
+  describe('nextDivergenceCount()', () => {
+    it('continues the incoming episode until a natural write has reported', async () => {
+      const reporter = new ReplayRecoveryReporter(2);
+      expect(reporter.nextDivergenceCount()).toBe(3);
+
+      // A dormant write (no clean replay yet) does not end the episode.
+      await reporter.withEventCreate({}, async () => 'created');
+      expect(reporter.nextDivergenceCount()).toBe(3);
+
+      // Armed but not yet written: still the same episode.
+      reporter.activate();
+      expect(reporter.nextDivergenceCount()).toBe(3);
+    });
+
+    it('starts a new episode at 1 once a reported write succeeds', async () => {
+      const reporter = new ReplayRecoveryReporter(2);
+      reporter.activate();
+
+      await reporter.withEventCreate({}, async () => 'created');
+
+      expect(reporter.nextDivergenceCount()).toBe(1);
+    });
+
+    it('does not end the episode on a failed reported write', async () => {
+      const reporter = new ReplayRecoveryReporter(2);
+      reporter.activate();
+
+      await expect(
+        reporter.withEventCreate({}, async () => {
+          throw new Error('write failed');
+        })
+      ).rejects.toThrow('write failed');
+
+      expect(reporter.nextDivergenceCount()).toBe(3);
+    });
+
+    it('is 1 for an inert reporter, so a first divergence counts from zero', async () => {
+      const reporter = ReplayRecoveryReporter.inert();
+      reporter.activate();
+      await reporter.withEventCreate({}, async () => 'created');
+
+      expect(reporter.nextDivergenceCount()).toBe(1);
+    });
+  });
+
   describe('inert()', () => {
     it('cannot be armed, so it never stamps a count', async () => {
       const create = vi.fn(async (_params: CreateEventParams) => 'created');

--- a/packages/core/src/runtime/replay-recovery-reporter.ts
+++ b/packages/core/src/runtime/replay-recovery-reporter.ts
@@ -11,8 +11,24 @@ import type { CreateEventParams } from '@workflow/world';
 export class ReplayRecoveryReporter {
   private active = false;
   private reported = false;
+  private recovered = false;
 
   constructor(private readonly divergenceCount: number) {}
+
+  /**
+   * The count a divergence raised by this invocation belongs to.
+   *
+   * Until a natural write has carried the recovery telemetry, the invocation
+   * is still inside the episode it was enqueued to recover, so the count
+   * continues from the incoming one. A committed write after a clean replay
+   * proves that episode over (the divergence was not reproducible against
+   * this log), so a later divergence in the same invocation opens a new
+   * episode at 1 instead of spending the old one's budget. An inert reporter
+   * has no incoming episode and always answers 1.
+   */
+  nextDivergenceCount(): number {
+    return this.recovered ? 1 : this.divergenceCount + 1;
+  }
 
   /**
    * A reporter for an invocation that never diverged: `activate()` cannot arm
@@ -47,10 +63,12 @@ export class ReplayRecoveryReporter {
 
     this.reported = true;
     try {
-      return await create({
+      const result = await create({
         ...params,
         replayDivergenceCount: this.divergenceCount,
       });
+      this.recovered = true;
+      return result;
     } catch (error) {
       this.reported = false;
       throw error;


### PR DESCRIPTION
## Problem

A replay divergence enqueues a recovery replay carrying `replayDivergence: { eventId, count }`, and the run fails with `CORRUPTED_EVENT_LOG` once the count exceeds the recovery budget. The next invocation computed the count for *its* divergence as `incoming + 1` regardless of what happened in between.

Observed in production: a recovery invocation's first replay pass succeeded and committed events (a `wait_created`, then an inline step's `step_created` / `step_started` / `step_completed`), and a later pass in that same invocation diverged. That divergence was counted as `incoming + 1`, so a chain of unrelated, non-reproducible divergences reached the budget two hops later. An invocation that replayed cleanly against the log and committed new events is proof the incoming episode was over; a later divergence is a new one.

## Change

- `ReplayRecoveryReporter` (which already stamps `replayDivergenceCount` on the first successful natural write after a clean replay, the server's "episode recovered" signal) now tracks whether that write committed, and exposes `nextDivergenceCount()`: `incoming + 1` until then, `1` after. The inert reporter (an invocation that never diverged) keeps answering `1`.
- `runtime.ts` takes the divergence count from the reporter for both the recovery-replay `queueMessage` path and the `CorruptedEventLogError` path.

Telemetry is unchanged for the recovery write itself: the first natural write after a clean replay still carries the incoming count. What changes is the count on a *subsequent* divergence's queue message and, when the budget is spent, on `run_failed`'s `replayDivergenceCount`, which now describes the current episode rather than a running total across unrelated ones.

## Tests

- `replay-recovery-reporter.test.ts`: `nextDivergenceCount()` continues the incoming episode while dormant / armed-but-unwritten, resets to 1 after a successful reported write, does not reset after a failed one, and is 1 for the inert reporter.
- `runtime.test.ts`: a recovery invocation arriving with the budget already spent runs an inline step (first pass clean, `step_started` stamped with the incoming count), then an out-of-band `wait_created` lands and the next pass diverges. It enqueues a recovery replay at `count: 1` instead of writing `run_failed`. Fails on `main`, passes with the fix. The no-progress side (incoming count at the budget, first pass diverges, `run_failed` at `budget + 1`) is already covered by `redrives an initial replay divergence and fails after the recovery budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
