### PR TITLE
[core] Fix the python e2e conformance suite after the retention merge

### DIFF
--- a/.changeset/plain-pears-listen.md
+++ b/.changeset/plain-pears-listen.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the python e2e conformance suite failing on a stale unsupported-test entry.

--- a/docs/content/docs/v5/errors/run-expired.mdx
+++ b/docs/content/docs/v5/errors/run-expired.mdx
@@ -42,8 +42,8 @@ Two ways to reach it:
 
 ## How to respond
 
-`RunExpiredError` is terminal. Retrying will not bring the data back, so catch
-Catch the error and use the run's metadata to decide what you want to do.
+`RunExpiredError` is terminal. Retrying will not bring the data back. Catch it
+and use the run's metadata to decide what you want to do.
 
 ```typescript lineNumbers
 import { getRun } from "workflow/api"
@@ -73,10 +73,10 @@ them.
 ### If you need the result of a zero-retention run
 
 Do not read it back off the run. Send it somewhere you control while the run
-is still executing — a step that writes it to your own store. That is the intended pattern
-for `experimental_retention: 0`: the point of the option is that the platform
-does not keep your data, so the platform cannot also be where you fetch it
-from afterwards.
+is still executing — a step that writes it to your own store. That is the
+intended pattern for `experimental_retention: 0`: the point of the option is
+that the platform does not keep your data, so the platform cannot also be where
+you fetch it from afterwards.
 
 ## Related
 

--- a/docs/content/docs/v5/observability/retention.mdx
+++ b/docs/content/docs/v5/observability/retention.mdx
@@ -72,7 +72,8 @@ only in how the absence is labelled.
   [`RunExpiredError`](/docs/errors/run-expired) instead of resolving.
 
   This is a known limitation. If you need the result, send it somewhere you
-  control, e.g. a step that writes it to your own store, rather than reading it back off the run.
+  control, e.g. a step that writes it to your own store, rather than reading
+  it back off the run.
 </Callout>
 
 `RunExpiredError` is not specific to `experimental_retention: 0`. Any run read
@@ -86,8 +87,9 @@ missing and you get `WorkflowRunNotFoundError` instead.
 
 The SDK records your preference; it does not enforce it. `start()` writes the
 value onto the run as the reserved `$retention` attribute, and the World
-decides what to do when the run ends.
-A World that does not implement retention
-**keeps the data**. If you need certainty that a specific World deletes your data,
-confirm it against that World's own documentation rather than the presence of this
-option.
+decides what to do when the run ends. Attributes are a spec version 4 feature,
+so `experimental_retention: 0` throws against an older World rather than being
+recorded and ignored. A World that does implement spec version 4 but not
+retention **keeps the data**. If you need certainty that a specific World
+deletes your data, confirm it against that World's own documentation rather
+than the presence of this option.

--- a/packages/core/e2e/e2e.test.ts
+++ b/packages/core/e2e/e2e.test.ts
@@ -4822,83 +4822,95 @@ describe.concurrent('e2e', () => {
    * also true for the Postgres lane. The Local and Postgres Worlds implement
    * retention too, but their coverage lives in their own package tests where
    * the storage can be inspected directly.
+   *
+   * Also gated on `isJsApp()`: the padding below deliberately crosses the JS
+   * client's compression threshold, and the Python SDK cannot read the `zstd`
+   * payload that produces, so the run fails deserializing its own input. The
+   * gate belongs here rather than in an app's `unsupported` map, because a
+   * `describe` skipped at collection time never reaches `requireSupported`
+   * and the entry would read as stale to `assertUnsupportedTestsExist`.
    */
-  describe.skipIf(!process.env.WORKFLOW_VERCEL_ENV)('retention', () => {
-    test(
-      'experimental_retention: 0 purges the run payloads once the run finishes',
-      { timeout: 240_000 },
-      async () => {
-        // Padded past the ~422-byte inline-ref cutoff on purpose. Below it a
-        // payload lives inside the database row and is scrubbed in place;
-        // above it the World writes a blob and has to delete the object. A
-        // small payload exercises only the first path, and this feature's
-        // whole claim is about the second. `metadataFromHelperWorkflow`
-        // echoes its label, so one big argument puts a blob behind the run's
-        // input, its output, and the step's on both sides.
-        const label = `retention-purge-${'x'.repeat(2048)}`;
-        const run = await start(
-          await e2e('metadataFromHelperWorkflow'),
-          [label],
-          {
-            experimental_retention: 0,
+  describe.skipIf(!process.env.WORKFLOW_VERCEL_ENV || !isJsApp())(
+    'retention',
+    () => {
+      test(
+        'experimental_retention: 0 purges the run payloads once the run finishes',
+        { timeout: 240_000 },
+        async () => {
+          // Padded past the ~422-byte inline-ref cutoff on purpose. Below it a
+          // payload lives inside the database row and is scrubbed in place;
+          // above it the World writes a blob and has to delete the object. A
+          // small payload exercises only the first path, and this feature's
+          // whole claim is about the second. `metadataFromHelperWorkflow`
+          // echoes its label, so one big argument puts a blob behind the run's
+          // input, its output, and the step's on both sides.
+          const label = `retention-purge-${'x'.repeat(2048)}`;
+          const run = await start(
+            await e2e('metadataFromHelperWorkflow'),
+            [label],
+            {
+              experimental_retention: 0,
+            }
+          );
+
+          // The purge races the caller's own read of the result and generally
+          // wins, so `returnValue` resolves after the data is already gone.
+          // What it must NOT do is hand back the expired-data placeholder as
+          // though the workflow had returned it — that is indistinguishable
+          // from a real result. It throws instead, carrying whatever metadata
+          // outlived the payloads so a caller can still tell success from
+          // failure.
+          //
+          // Accepting either outcome would make this assertion worthless, so it
+          // insists on the throw. If the client ever starts winning the race
+          // this test fails loudly, which is the right way to find out.
+          await expect(run.returnValue).rejects.toMatchObject({
+            name: 'RunExpiredError',
+            runId: run.runId,
+            runStatus: 'completed',
+          });
+
+          // That same race is why nothing is asserted about the payloads
+          // *before* the purge: there is no reliable window in which to read
+          // them.
+          const afterPurge = await cliInspectJsonUntil(
+            `runs ${run.runId} --withData`,
+            (json) => json?.output === EXPIRED_DATA_JSON,
+            { timeoutMs: 180_000, intervalMs: 5_000 }
+          );
+          expect(afterPurge).toMatchObject({
+            runId: run.runId,
+            input: EXPIRED_DATA_JSON,
+            output: EXPIRED_DATA_JSON,
+            // Only user data goes. The run itself survives on the World's
+            // default retention so it stays listable in observability.
+            status: 'completed',
+          });
+
+          // Step payloads go with it, not just the run's own input/output.
+          const steps = await cliInspectJsonUntil(
+            `steps --runId ${run.runId} --withData`,
+            (json) =>
+              Array.isArray(json) &&
+              json.length > 0 &&
+              json.every((step: any) => step.output === EXPIRED_DATA_JSON),
+            { timeoutMs: 60_000, intervalMs: 5_000 }
+          );
+          expect(steps.length).toBeGreaterThan(0);
+          for (const step of steps) {
+            expect(step.output).toBe(EXPIRED_DATA_JSON);
           }
-        );
 
-        // The purge races the caller's own read of the result and generally
-        // wins, so `returnValue` resolves after the data is already gone.
-        // What it must NOT do is hand back the expired-data placeholder as
-        // though the workflow had returned it — that is indistinguishable
-        // from a real result. It throws instead, carrying whatever metadata
-        // outlived the payloads so a caller can still tell success from
-        // failure.
-        //
-        // Accepting either outcome would make this assertion worthless, so it
-        // insists on the throw. If the client ever starts winning the race
-        // this test fails loudly, which is the right way to find out.
-        await expect(run.returnValue).rejects.toMatchObject({
-          name: 'RunExpiredError',
-          runId: run.runId,
-          runStatus: 'completed',
-        });
-
-        // That same race is why nothing is asserted about the payloads
-        // *before* the purge: there is no reliable window in which to read
-        // them.
-        const afterPurge = await cliInspectJsonUntil(
-          `runs ${run.runId} --withData`,
-          (json) => json?.output === EXPIRED_DATA_JSON,
-          { timeoutMs: 180_000, intervalMs: 5_000 }
-        );
-        expect(afterPurge).toMatchObject({
-          runId: run.runId,
-          input: EXPIRED_DATA_JSON,
-          output: EXPIRED_DATA_JSON,
-          // Only user data goes. The run itself survives on the World's
-          // default retention so it stays listable in observability.
-          status: 'completed',
-        });
-
-        // Step payloads go with it, not just the run's own input/output.
-        const steps = await cliInspectJsonUntil(
-          `steps --runId ${run.runId} --withData`,
-          (json) =>
-            Array.isArray(json) &&
-            json.length > 0 &&
-            json.every((step: any) => step.output === EXPIRED_DATA_JSON),
-          { timeoutMs: 60_000, intervalMs: 5_000 }
-        );
-        expect(steps.length).toBeGreaterThan(0);
-        for (const step of steps) {
-          expect(step.output).toBe(EXPIRED_DATA_JSON);
+          // And the run carries the marker the CLI and web UI gate their
+          // "<data expired>" rendering on: an `expiredAt` in the past.
+          const world = await getWorld();
+          const persisted = await world.runs.get(run.runId);
+          expect(persisted.expiredAt).toBeInstanceOf(Date);
+          expect(persisted.expiredAt?.getTime()).toBeLessThanOrEqual(
+            Date.now()
+          );
         }
-
-        // And the run carries the marker the CLI and web UI gate their
-        // "<data expired>" rendering on: an `expiredAt` in the past.
-        const world = await getWorld();
-        const persisted = await world.runs.get(run.runId);
-        expect(persisted.expiredAt).toBeInstanceOf(Date);
-        expect(persisted.expiredAt?.getTime()).toBeLessThanOrEqual(Date.now());
-      }
-    );
-  });
+      );
+    }
+  );
 });

--- a/workbench/python/e2e-conformance.json
+++ b/workbench/python/e2e-conformance.json
@@ -63,7 +63,6 @@
     "writableForwardedFromWorkflowWorkflow"
   ],
   "unsupported": {
-    "experimental_retention: 0 purges the run payloads once the run finishes": "The test pads its input past the inline-ref cutoff on purpose, so the World writes a real blob for the purge to delete. Any payload that large also crosses the JS client's compression threshold, and the Python SDK cannot read the resulting `zstd` payload, so the run fails during input deserialization instead of completing.",
     "fire-and-forget: void setAttributes lands without awaiting": "`set_attributes()` is now an `async def`: scheduling it can reproduce the unawaited writes before a later suspension, but the final scheduled coroutine does not start before the workflow body returns, so there is no final `attr_set` to drain. The run completes with `phase: mid` instead of `phase: done`.",
     "validation DX: invalid writes throw catchable FatalErrors naming rule and limit": "The new `set_attributes()` validator still raises a catchable `FatalError` for a reserved key, but its message ends at `starts with reserved prefix '$'` and no longer names the `allow_reserved_attributes=True` escape hatch that this test requires. The other six validation cases and the valid write afterwards pass."
   }


### PR DESCRIPTION
`E2E Python Conformance` is red on `main`. #3787 was squash-merged from a commit
that added an `unsupported` entry for the retention e2e, without the later
commit that replaced that entry with a language gate. The python conformance
job now fails at collection time:

```
Error: e2e-conformance.json lists "unsupported" tests that do not exist in this
suite (renamed or removed?): "experimental_retention: 0 purges the run payloads
once the run finishes"
```

`requireSupported()` records a test name only when the test actually runs, and
`assertUnsupportedTestsExist()` treats an unrecorded key as stale. The retention
`describe` is skipped at collection time, so its name never gets recorded and
its `unsupported` entry can never be anything but stale. The two mechanisms are
mutually exclusive.

## Changes

- Gate the retention `describe` on `isJsApp()` alongside `WORKFLOW_VERCEL_ENV`,
  and drop the `unsupported` entry from `workbench/python/e2e-conformance.json`.
  The test pads its input past the inline-ref cutoff on purpose, which also
  crosses the JS client's compression threshold, and the Python SDK cannot read
  the resulting `zstd` payload. That also fixes
  `E2E Vercel Prod Tests (python - node)`, where the run failed deserializing
  its own input.
- Repair two docs regressions from review suggestions applied through the
  GitHub UI: a sentence in `run-expired.mdx` left half-rewritten, and the
  spec-version-4 requirement for `experimental_retention: 0`, which was dropped
  from `retention.mdx` along with the per-World table. `start()` still throws
  naming it.

Most of the `e2e.test.ts` diff is Biome reindenting the `describe` body after
the gate went multi-line.

## Docs Preview

| Page | Preview |
|------|---------|
| `docs/content/docs/v5/errors/run-expired.mdx` | https://workflow-docs-git-peter-retention-e2e-conformance-fix.vercel.sh/docs/errors/run-expired |
| `docs/content/docs/v5/observability/retention.mdx` | https://workflow-docs-git-peter-retention-e2e-conformance-fix.vercel.sh/docs/observability/retention |
