### PR TITLE
[world-vercel] Backport post-header stream recovery to stable

### DIFF
--- a/.changeset/four-shrimps-recycle.md
+++ b/.changeset/four-shrimps-recycle.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Recycle the events HTTP/2 connection pool when a streamed response body fails after its headers arrive.

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -402,6 +402,7 @@ describe('v4 transport reports failures to the events recycler', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -427,6 +428,38 @@ describe('v4 transport reports failures to the events recycler', () => {
         getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
       ).rejects.toThrow();
       // Still the same pool until the threshold is reached.
+      if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
+        expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
+      }
+    }
+
+    expect(getEventsDispatcher({ token: 'test-token' })).not.toBe(before);
+  });
+
+  it('rebuilds the shared pool when the response body times out after headers', async () => {
+    const now = Date.now();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    // The preceding test intentionally rebuilt the process-global pool. Move
+    // beyond its anti-thrash cooldown so this test exercises its own threshold.
+    vi.setSystemTime(now + 60_000);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.error(wedgedSessionError());
+            },
+          }),
+          { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+        )
+    );
+
+    const before = getEventsDispatcher({ token: 'test-token' });
+
+    for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
+      await expect(
+        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
+      ).rejects.toThrow('fetch failed');
       if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
         expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
       }

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -64,7 +64,7 @@ async function fetchV4(
   opName: string
 ): Promise<Response> {
   const dispatcher = getEventsDispatcher(config);
-  return instrumentedFetch({
+  const response = await instrumentedFetch({
     method: init.method,
     url,
     headers: init.headers,
@@ -76,6 +76,7 @@ async function fetchV4(
     // until the compute instance is recycled — see noteEventsTransportOutcome.
     onTransportOutcome: (error) =>
       noteEventsTransportOutcome(dispatcher, error),
+    deferTransportSuccessUntilBody: true,
     timeoutMs: null,
     logLabel: opName,
     buildError: async (response) =>
@@ -86,6 +87,39 @@ async function fetchV4(
         opName,
         url
       ),
+  });
+
+  if (!response.body) {
+    noteEventsTransportOutcome(dispatcher);
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          noteEventsTransportOutcome(dispatcher);
+          controller.close();
+        } else {
+          controller.enqueue(chunk.value);
+        }
+      } catch (cause) {
+        noteEventsTransportOutcome(dispatcher, cause);
+        controller.error(cause);
+      }
+    },
+    cancel(reason) {
+      noteEventsTransportOutcome(dispatcher);
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
   });
 }
 

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -332,6 +332,13 @@ export interface InstrumentedFetchOptions {
    * connections stop delivering (see noteEventsTransportOutcome).
    */
   onTransportOutcome?: (error?: unknown) => void;
+  /**
+   * Delay the successful transport outcome until the caller consumes the body.
+   * Streamed responses can fail after their headers arrive, so treating
+   * `fetch()` resolution as success would hide those failures from a caller's
+   * connection-pool recycler.
+   */
+  deferTransportSuccessUntilBody?: boolean;
 }
 
 /**
@@ -362,6 +369,7 @@ export async function instrumentedFetch(
     logLabel,
     buildError,
     onTransportOutcome,
+    deferTransportSuccessUntilBody = false,
   } = opts;
   const label = logLabel ?? url;
 
@@ -447,7 +455,7 @@ export async function instrumentedFetch(
         throw error;
       }
       const ms = Date.now() - start;
-      onTransportOutcome?.();
+      if (!deferTransportSuccessUntilBody) onTransportOutcome?.();
 
       httpLog(method, label, response, ms);
       span?.setAttributes({ ...HttpResponseStatusCode(response.status) });
@@ -456,11 +464,21 @@ export async function instrumentedFetch(
         span?.setAttributes({ ...ErrorType(`HTTP ${response.status}`) });
         logCurlRepro(method, url, headers);
         if (buildError) {
-          const error = await buildError(response);
+          let error: Error;
+          try {
+            error = await buildError(response);
+          } catch (cause) {
+            if (deferTransportSuccessUntilBody) {
+              onTransportOutcome?.(cause);
+            }
+            throw cause;
+          }
+          if (deferTransportSuccessUntilBody) onTransportOutcome?.();
           span?.recordException?.(error);
           throw error;
         }
         const text = await response.text().catch(() => '');
+        if (deferTransportSuccessUntilBody) onTransportOutcome?.();
         const error = errorForResponse(
           response.status,
           `${method} ${label} -> HTTP ${response.status}: ${response.statusText}${


### PR DESCRIPTION
## Summary

- backport the post-header response-body accounting from #3850 to the 4.x stable line
- delay a successful transport outcome until the streamed body completes
- report post-header body failures to the shared dispatcher recycler so repeated HTTP/2 stream timeouts replace the wedged connection pool
- keep this deliberately scoped to the stable transport fix; the broader stream-error classification remains on beta/main

## Test plan

- `pnpm --filter @workflow/world-vercel typecheck`
- `pnpm --filter @workflow/world-vercel... build`
- `pnpm exec vitest run packages/world-vercel/src/events-v4.test.ts packages/world-vercel/src/http-core.test.ts` (29 tests)

