### PR TITLE
[world-vercel] Backport retryable run creation stream failures

### DIFF
--- a/.changeset/tidy-pumas-start.md
+++ b/.changeset/tidy-pumas-start.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Classify HTTP/2 response stream timeouts as retryable transport failures so `start()` can return the queued run through resilient start.

--- a/packages/core/src/runtime/start.test.ts
+++ b/packages/core/src/runtime/start.test.ts
@@ -517,6 +517,29 @@ describe('start', () => {
       );
     });
 
+    it('should succeed when events.create throws a transport error (queue still dispatched)', async () => {
+      const mockQueue = vi.fn().mockResolvedValue({ messageId: null });
+      const transportError = new WorkflowWorldError(
+        'response stream transport failure (UND_ERR_INFO)',
+        {
+          code: 'TRANSPORT',
+          cause: new TypeError('fetch failed'),
+        }
+      );
+      const mockEventsCreate = vi.fn().mockRejectedValue(transportError);
+
+      vi.mocked(getWorld).mockReturnValue({
+        specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+        getDeploymentId: vi.fn().mockResolvedValue('deploy_123'),
+        events: { create: mockEventsCreate },
+        queue: mockQueue,
+      } as any);
+
+      const run = await start(validWorkflow, [42]);
+      expect(run.runId).toMatch(/^wrun_/);
+      expect(mockQueue).toHaveBeenCalledTimes(1);
+    });
+
     it('should throw when queue fails even if events.create succeeds', async () => {
       const mockEventsCreate = vi.fn().mockResolvedValue({
         run: { runId: 'wrun_test', status: 'pending' },

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -426,7 +426,10 @@ describe('v4 transport reports failures to the events recycler', () => {
     for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
       await expect(
         getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: 'TRANSPORT',
+      });
       // Still the same pool until the threshold is reached.
       if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
         expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
@@ -450,7 +453,14 @@ describe('v4 transport reports failures to the events recycler', () => {
               controller.error(wedgedSessionError());
             },
           }),
-          { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+          {
+            headers: {
+              'content-type': V4_FRAME_CONTENT_TYPE,
+              'x-wf-event-id': 'evnt_1',
+              'x-wf-run-id': 'wrun_1',
+              'x-wf-created-at': new Date().toISOString(),
+            },
+          }
         )
     );
 
@@ -458,8 +468,19 @@ describe('v4 transport reports failures to the events recycler', () => {
 
     for (let i = 0; i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES; i++) {
       await expect(
-        getWorkflowRunEventsV4('wrun_1', {}, { token: 'test-token' })
-      ).rejects.toThrow('fetch failed');
+        createWorkflowRunEventV4(
+          {
+            runId: 'wrun_1',
+            eventType: 'run_created',
+            specVersion: 3,
+          },
+          { token: 'test-token' }
+        )
+      ).rejects.toMatchObject({
+        name: 'WorkflowWorldError',
+        code: 'TRANSPORT',
+        cause: expect.objectContaining({ message: 'fetch failed' }),
+      });
       if (i < EVENTS_RECYCLE_AFTER_CONSECUTIVE_FAILURES - 1) {
         expect(getEventsDispatcher({ token: 'test-token' })).toBe(before);
       }

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -21,6 +21,7 @@
  * bytes — this module stays at the wire-bytes layer.
  */
 
+import { WorkflowWorldError } from '@workflow/errors';
 import { decode } from 'cbor-x';
 import { decodeFrames, encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import {
@@ -29,6 +30,7 @@ import {
 } from './http-client.js';
 import {
   errorForResponse,
+  getTransientTransportCode,
   instrumentedFetch,
   parseRetryAfter,
 } from './http-core.js';
@@ -107,7 +109,15 @@ async function fetchV4(
         }
       } catch (cause) {
         noteEventsTransportOutcome(dispatcher, cause);
-        controller.error(cause);
+        const transportCode = getTransientTransportCode(cause);
+        controller.error(
+          transportCode
+            ? new WorkflowWorldError(
+                `v4 ${opName}: response stream transport failure (${transportCode})`,
+                { url, code: 'TRANSPORT', cause }
+              )
+            : cause
+        );
       }
     },
     cancel(reason) {

--- a/packages/world-vercel/src/http-core.test.ts
+++ b/packages/world-vercel/src/http-core.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   errorForResponse,
   formatVercelDiagnostics,
+  getTransientTransportCode,
   getVercelDiagnostics,
   parseRetryAfter,
   resolveVercelApiToken,
@@ -57,6 +58,22 @@ describe('errorForResponse', () => {
     const err = errorForResponse(503, 'unavailable');
     expect(err).toBeInstanceOf(WorkflowWorldError);
     expect((err as WorkflowWorldError).status).toBe(503);
+  });
+});
+
+describe('getTransientTransportCode', () => {
+  it('finds an HTTP/2 stream timeout in a fetch cause chain', () => {
+    const cause = Object.assign(
+      new Error('HTTP/2: "stream timeout after 300000"'),
+      { code: 'UND_ERR_INFO' }
+    );
+    const error = new TypeError('fetch failed', { cause });
+
+    expect(getTransientTransportCode(error)).toBe('UND_ERR_INFO');
+  });
+
+  it('ignores non-transport errors', () => {
+    expect(getTransientTransportCode(new Error('bad payload'))).toBeUndefined();
   });
 });
 

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -61,6 +61,47 @@ import {
 export const REQUEST_TIMEOUT_MS = 60_000;
 
 /**
+ * Transport failures that are safe to classify as transient infrastructure
+ * errors. `fetch()` usually wraps the undici error in `TypeError: fetch
+ * failed`, so callers must inspect the cause chain rather than only the
+ * top-level error.
+ */
+const TRANSIENT_TRANSPORT_ERROR_CODES = new Set([
+  'UND_ERR_INFO',
+  'UND_ERR_REQ_RETRY',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CLOSED',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'ETIMEDOUT',
+]);
+
+/** Walk a bounded cause chain looking for a transient transport error code. */
+export function getTransientTransportCode(error: unknown): string | undefined {
+  let current = error;
+  for (let depth = 0; current != null && depth < 8; depth++) {
+    if (typeof current === 'object' && 'code' in current) {
+      const code = (current as { code?: unknown }).code;
+      if (
+        typeof code === 'string' &&
+        TRANSIENT_TRANSPORT_ERROR_CODES.has(code)
+      ) {
+        return code;
+      }
+    }
+    current = (current as { cause?: unknown })?.cause;
+  }
+  return undefined;
+}
+
+/**
  * Lightweight debug logger toggle for HTTP requests. Activated when the DEBUG
  * env var contains "workflow:" or is "*".
  *
@@ -446,11 +487,21 @@ export async function instrumentedFetch(
         ) {
           const timeoutError = new WorkflowWorldError(
             `${method} ${label} timed out after ${elapsed}ms`,
-            { url, cause: error }
+            { url, code: 'TIMEOUT', cause: error }
           );
           span?.setAttributes({ ...ErrorType('TIMEOUT') });
           span?.recordException?.(timeoutError);
           throw timeoutError;
+        }
+        const transportCode = getTransientTransportCode(error);
+        if (transportCode) {
+          const transportError = new WorkflowWorldError(
+            `${method} ${label} transport failure after ${elapsed}ms (${transportCode})`,
+            { url, code: 'TRANSPORT', cause: error }
+          );
+          span?.setAttributes({ ...ErrorType('TRANSPORT') });
+          span?.recordException?.(transportError);
+          throw transportError;
         }
         throw error;
       }
@@ -468,6 +519,19 @@ export async function instrumentedFetch(
           try {
             error = await buildError(response);
           } catch (cause) {
+            const transportCode = getTransientTransportCode(cause);
+            if (transportCode) {
+              if (deferTransportSuccessUntilBody) {
+                onTransportOutcome?.(cause);
+              }
+              const transportError = new WorkflowWorldError(
+                `${method} ${label} response body transport failure (${transportCode})`,
+                { url, code: 'TRANSPORT', cause }
+              );
+              span?.setAttributes({ ...ErrorType('TRANSPORT') });
+              span?.recordException?.(transportError);
+              throw transportError;
+            }
             if (deferTransportSuccessUntilBody) {
               onTransportOutcome?.(cause);
             }

--- a/packages/world-vercel/src/utils.ts
+++ b/packages/world-vercel/src/utils.ts
@@ -14,6 +14,7 @@ import {
 import {
   errorForResponse,
   formatVercelDiagnostics,
+  getTransientTransportCode,
   HTTP_DEBUG_ENABLED,
   httpClientSpanAttributes,
   httpLog,
@@ -63,76 +64,6 @@ export const MAX_BODY_PARSE_RETRIES = 2;
 
 /** Base delay for the exponential backoff between body-parse retries. */
 const BODY_PARSE_RETRY_BASE_MS = 100;
-
-/**
- * Transient transport failure codes. When a request to workflow-server cannot
- * complete, the request throws rather than returning a response, and the code
- * it carries depends on which transport issued it.
- *
- * Over undici (`fetch` plus the shared dispatcher): the `RetryAgent` exhausted
- * its retries (`UND_ERR_REQ_RETRY`, e.g. the firewall in front of
- * workflow-server shedding load with sustained 429/503, which the RetryAgent
- * retries internally and never surfaces to us), the socket dropped, or
- * connect/DNS failed.
- *
- * Over `node:http` / `node:https` (`WORKFLOW_NODE_HTTP`): there is no undici in
- * the path, so no `UND_ERR_*` code ever appears. Node's own socket and DNS
- * codes are raised instead, plus `ETIMEDOUT` from the client's own header and
- * body deadlines, which stand in for `UND_ERR_HEADERS_TIMEOUT` /
- * `UND_ERR_BODY_TIMEOUT`.
- *
- * Either way these are retryable infrastructure failures, not contract or user
- * errors, so we map them to a typed `WorkflowWorldError` (`code: 'TRANSPORT'`)
- * that the runtime recognizes as retryable and bubbles to the queue for a fast
- * redrive, instead of crashing the invocation or failing the run.
- *
- * The set is consulted on both paths, so adding `ETIMEDOUT` for the node:http
- * deadlines also classifies it on the undici path — where it is near
- * unreachable, since undici's 10s `connectTimeout` fires long before the OS
- * raises `ETIMEDOUT` on a connect, and its own stalls surface as `UND_ERR_*`.
- * Deliberate either way: a socket that timed out is transient under any client.
- */
-const TRANSIENT_TRANSPORT_ERROR_CODES = new Set([
-  'UND_ERR_REQ_RETRY',
-  'UND_ERR_SOCKET',
-  'UND_ERR_CONNECT',
-  'UND_ERR_CONNECT_TIMEOUT',
-  'UND_ERR_HEADERS_TIMEOUT',
-  'UND_ERR_BODY_TIMEOUT',
-  'UND_ERR_CLOSED',
-  'ECONNRESET',
-  'ECONNREFUSED',
-  'ENOTFOUND',
-  'EAI_AGAIN',
-  'EPIPE',
-  'ETIMEDOUT',
-]);
-
-/**
- * Walks the `cause` chain of a thrown value looking for a transient transport
- * error code. `fetch()` wraps the underlying undici error in a
- * `TypeError: fetch failed` whose `cause` carries the real `.code`, so the
- * code we care about is usually one level down (sometimes two). The
- * `node:http` client throws the socket error itself, so there the code is on
- * the top-level value. Bounded depth guards against pathological or cyclic
- * `cause` chains.
- */
-function getTransientTransportCode(error: unknown): string | undefined {
-  let current: unknown = error;
-  for (let depth = 0; current != null && depth < 5; depth++) {
-    if (typeof current === 'object' && 'code' in current) {
-      const code = (current as { code?: unknown }).code;
-      if (
-        typeof code === 'string' &&
-        TRANSIENT_TRANSPORT_ERROR_CODES.has(code)
-      ) {
-        return code;
-      }
-    }
-    current = (current as { cause?: unknown })?.cause;
-  }
-  return undefined;
-}
 
 /**
  * Effective workflow-server URL override. The inline constant wins when


### PR DESCRIPTION
## Summary

- complete the stable portion of #3850 for run-creation response streams that was not included in #4041
- classify transient undici/socket failures, including HTTP/2 `UND_ERR_INFO` stream timeouts, as the existing 4.x `WorkflowWorldError` transport type before and after response headers
- let resilient `start()` return the queued run when VQS accepted it and only the committed `run_created` response body failed, without replaying the non-idempotent POST
- keep the existing events-pool recycling behavior and share one transient-error classifier across the v3 and v4 clients

This deliberately uses the stable 4.x error model instead of backporting the beta `StreamError` class and its cross-runtime serialization surface.

## LocalStack reproduction

A deterministic integration test commits `run_created`, replaces its response body with the Phonic failure (`TypeError: fetch failed`, cause `UND_ERR_INFO: HTTP/2: "stream timeout after 300000"`), and then delivers the VQS message.

| SDK / world | `start()` result | Delivered run |
| --- | --- | --- |
| 4.8.5 / 4.7.1 | throws raw `TypeError` | `running` |
| 4.8.6 / 4.7.2 | throws raw `TypeError` | `running` |
| 4.8.6 / this patch | returns the queued run ID | `running` |
| 5.0.0-beta.48 / 5.0.0-beta.44 | returns the queued run ID | `running` |

## Tests

- `pnpm --filter @workflow/world-vercel test` (278 passed)
- focused core `start` and error-classification tests (47 passed)
- builds for `@workflow/world-vercel`, `@workflow/core`, and their required workspace dependencies
- focused workflow-server LocalStack matrix above (4 passed)

The complete core suite also ran: 46 files passed and 1 skipped; one unrelated VM/base64 test file has 14 pre-existing cross-realm constructor-identity assertion failures under local Node 24.

Related: #3850, #4041
