### PR TITLE
[docs] Document WORKFLOW_NODE_HTTP in the v4 World docs

### DIFF
--- a/.changeset/document-node-http-v4.md
+++ b/.changeset/document-node-http-v4.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document `WORKFLOW_NODE_HTTP` in the v4 World docs.

--- a/docs/content/worlds/v4/local.mdx
+++ b/docs/content/worlds/v4/local.mdx
@@ -58,6 +58,12 @@ Port resolution priority: `baseUrl` > `port` > `PORT` > auto-detected
 
 Maximum number of concurrent queue workers. Default: `100`
 
+### `WORKFLOW_NODE_HTTP`
+
+Whether queue deliveries go out through Node's built-in `node:http` and `node:https` modules instead of the HTTP client library this World normally uses. Default: disabled. Set to `1` to switch to Node's modules. Socket pooling, keep-alive, and the request deadlines apply either way.
+
+This variable covers both HTTP-backed Worlds. See [the Vercel World's entry](/worlds/vercel#workflow_node_http) for when to reach for it and what it costs.
+
 ### Programmatic configuration
 
 {/* @skip-typecheck: incomplete code sample */}

--- a/docs/content/worlds/v4/vercel.mdx
+++ b/docs/content/worlds/v4/vercel.mdx
@@ -132,6 +132,32 @@ When enabled, each run is given its own queue topic and the flow route is config
 
 Because it routes each run's flow invocations through a dedicated `maxConcurrency: 1` queue topic, enabling this might lead to higher queue performance overhead.
 
+### `WORKFLOW_NODE_HTTP`
+
+Set `WORKFLOW_NODE_HTTP=1` to make the Vercel World issue its HTTP requests through Node's built-in `node:http` and `node:https` modules instead of the HTTP client library (undici) it normally uses. Off by default.
+
+This exists for deployments where that library is not usable, rather than as a tuning knob. Reach for it when:
+
+- your bundler mangles the library's internals, so requests through it fail or never settle;
+- your build pairs a bundled copy of the library with a different copy inside the runtime, which can produce errors like `Cannot read private member #… from an object whose class did not declare it`;
+- you want to rule the transport out while diagnosing event-delivery or queue problems.
+
+The symptom that most often leads here is a workflow whose steps all complete while the invocation itself never returns, and whose queue messages are delivered repeatedly and never acknowledged. A killed invocation cannot acknowledge its message, so the queue redelivers it to the same deployment and each redelivery holds a function for the full `maxDuration`. Check your project's Queues view for a topic with a high received count and a delete count near zero.
+
+Requests reached through `fetch()` are covered too, so a runtime whose `fetch()` is built on the same library still benefits.
+
+<Callout type="warn">
+  Node's modules do less than the client they replace, so enabling this drops per-call-site tuning and costs throughput on every deployment. That is why it is opt-in.
+
+  - Event-log requests lose HTTP/2, so concurrent reads and writes no longer share one connection and the enlarged HTTP/2 receive windows no longer apply. This is the largest difference and it slows replays that read a large event log.
+  - Requests lose their transport-level retry. Nothing is silently dropped, because the layers above still retry event writes and redeliver queue messages, but a failure a same-connection retry would have hidden now costs a full redelivery.
+  - Stream close loses its retry of retriable server errors, so a transient failure at close can leave a stream marked closing until the run expires.
+
+  Connection pooling, keep-alive, and the request, header, and body deadlines are preserved.
+</Callout>
+
+A `dispatcher` passed to `createVercelWorld()` still wins over this variable: supplying one is an instruction to use the library. The variable only chooses which transport the World builds when you have not supplied one.
+
 ### Programmatic configuration
 
 {/*@skip-typecheck: incomplete code sample*/}


### PR DESCRIPTION
## What

Adds a `WORKFLOW_NODE_HTTP` entry to `docs/content/worlds/v4/vercel.mdx`, and a pointer to it from `docs/content/worlds/v4/local.mdx`.

## Why

The flag ships in `@workflow/world-vercel@4.7.0` (2026-08-19) and is documented only in the v5 docs (`docs/content/docs/v5/configuration/runtime-tuning.mdx` and `worlds/v5/local.mdx`). A 4.x user has no way to find it short of reading package source, and the v4 Vercel World page opens with "requires no configuration when deployed to Vercel".

That is not hypothetical. It is how the flag was actually found in the field, partway through a nine-day outage on a Pro project whose cause the flag addresses: a Next 16 Turbopack build in which the bundled HTTP client library was unusable, so workflows hung before journaling their first step. Same failure class as #3373.

## Where it went

v4 has no consolidated environment-variable page (v5's `configuration/runtime-tuning.mdx` has no v4 counterpart), so the World pages are the only sensible home. The Vercel page carries the full entry and the Local page gets a short entry plus a link, mirroring how v5 splits the same content.

The entry covers:

- what it does and that it is opt-in;
- when to reach for it (a bundler that mangles the library, a build pairing a bundled copy with a different one in the runtime, or ruling the transport out while diagnosing);
- **the symptom that leads here**, which is the part that was missing: steps all complete while the invocation never returns, and queue messages are delivered repeatedly and never acknowledged. Readers are pointed at the Queues view for a topic with a high received count and a delete count near zero.
- what the swap costs (no HTTP/2 on event-log requests, no transport-level retry, no stream-close retry), in a warning callout, since it is a throughput regression on every deployment.
- that a `dispatcher` passed to `createVercelWorld()` still wins.

## Notes

Changeset is empty: docs only, no published package changed. Internal links use the unprefixed `/worlds/vercel` form the surrounding v4 pages already use.

## Docs Preview

| Page | Link |
|---|---|
| v4 Vercel World | [`/v4/worlds/vercel#workflow_node_http`](https://workflow-docs-git-peter-nodehttp-docs.vercel.sh/v4/worlds/vercel#workflow_node_http) |
| v4 Local World | [`/v4/worlds/local#workflow_node_http`](https://workflow-docs-git-peter-nodehttp-docs.vercel.sh/v4/worlds/local#workflow_node_http) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)