### PR TITLE
fix(world-local): retry JSON reads on Windows

### DIFF
--- a/.changeset/world-local-retry-json-read.md
+++ b/.changeset/world-local-retry-json-read.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-local': patch
+---
+
+Retry transient Windows file-lock failures while reading JSON files.

--- a/packages/world-local/src/fs.test.ts
+++ b/packages/world-local/src/fs.test.ts
@@ -180,6 +180,40 @@ describe('fs utilities', () => {
     });
   });
 
+  describe('readJSON', () => {
+    it('retries transient EPERM read failures on Windows', async () => {
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      vi.resetModules();
+      try {
+        const freshFsModule = await import('./fs.js');
+        const filePath = path.join(testDir, 'locked.json');
+        await fs.writeFile(filePath, JSON.stringify({ id: 'locked' }));
+
+        const eperm = Object.assign(
+          new Error('EPERM: operation not permitted, readFile'),
+          { code: 'EPERM' }
+        );
+        const readFile = fs.readFile;
+        const readFileSpy = vi
+          .spyOn(fs, 'readFile')
+          .mockRejectedValueOnce(eperm)
+          .mockRejectedValueOnce(eperm)
+          .mockImplementation(readFile);
+
+        await expect(
+          freshFsModule.readJSON(filePath, z.object({ id: z.string() }))
+        ).resolves.toEqual({ id: 'locked' });
+        expect(readFileSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform);
+        }
+        vi.resetModules();
+      }
+    });
+  });
+
   describe('ensureDir', () => {
     it('does not repeat mkdir for a directory created by this process', async () => {
       clearCreatedFilesCache();

--- a/packages/world-local/src/fs.ts
+++ b/packages/world-local/src/fs.ts
@@ -441,7 +441,9 @@ export async function readJSON<T>(
   decoder: z.ZodType<T>
 ): Promise<T | null> {
   try {
-    const content = await fs.readFile(filePath, 'utf-8');
+    const content = await withWindowsRetry(() =>
+      fs.readFile(filePath, 'utf-8')
+    );
     return decoder.parse(JSON.parse(content, jsonReviver));
   } catch (error) {
     if ((error as any).code === 'ENOENT') return null;


### PR DESCRIPTION
## Summary
- retry transient Windows file-lock failures when reading JSON files
- cover the retry behavior with a Windows-specific regression test

## Tests
- pnpm --filter @workflow/world-local test
- pnpm --filter @workflow/world-local typecheck