### PR TITLE
docs: add synchronized language switcher

### DIFF
--- a/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
+++ b/docs/app/[lang]/v5/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { createDocsPage } from '@vercel/geistdocs/pages/docs';
 import { Card, type CardProps } from 'fumadocs-ui/components/card';
 import { permanentRedirect } from 'next/navigation';
 import type { ComponentProps, ComponentType } from 'react';
+import { PageLanguageSwitcher } from '@/components/custom/language-switcher';
 import { AutoCards } from '@/components/geistdocs/auto-cards';
 import { getMDXComponents } from '@/components/geistdocs/mdx-components';
 import { config } from '@/lib/geistdocs/config';
@@ -19,6 +20,10 @@ const DEFAULT_LANG = config.defaultLanguage ?? 'en';
 const getPageUrl = ({ page }: { page: { url: string } }) =>
   `${VERSION_PREFIX}${page.url}`;
 
+interface LanguageSwitcherFrontmatter {
+  languageSwitcher?: string[];
+}
+
 // Content links are authored against the raw `/docs/...` and `/worlds/...`
 // URL spaces; rewrite them into the v5 view so navigation doesn't escape to
 // the v4 route. Card renders its own Link (not the `a` component), so it
@@ -31,69 +36,88 @@ function V5Card(props: CardProps) {
   return <Card {...props} href={v5Href(props.href)} />;
 }
 
-const docsPage = createDocsPage({
-  config: {
-    ...config,
-    github: config.github && {
-      ...config.github,
-      editPath: 'docs/content/docs/v5/{path}',
+function createV5DocsPage(languageSwitcher?: string[]) {
+  return createDocsPage({
+    config: {
+      ...config,
+      github: config.github && {
+        ...config.github,
+        editPath: 'docs/content/docs/v5/{path}',
+      },
     },
-  },
-  source: v5GeistdocsSource,
-  getPageUrl,
-  mdx: ({ link, page }) =>
-    getMDXComponents({
-      a: link,
-      Card: V5Card,
-      // Cards render in the v5 URL space (`/v5/docs/...`), matching the
-      // sidebar tree so hrefs don't escape to the v4 route.
-      AutoCards: () => (
-        <AutoCards
-          items={resolveSectionChildren(
-            getDocsTreeForVersion(DEFAULT_LANG, PRE_RELEASE_VERSION),
-            `${VERSION_PREFIX}${page.url}`
-          )}
-        />
-      ),
-    }),
-  resolveLink: ({ link }) => {
-    const Link = link as ComponentType<ComponentProps<'a'>>;
-    const V5Link = (props: ComponentProps<'a'>) => (
-      <Link {...props} href={v5Href(props.href)} />
-    );
+    source: v5GeistdocsSource,
+    getPageUrl,
+    mdx: ({ link, page }) =>
+      getMDXComponents({
+        a: link,
+        Card: V5Card,
+        // Cards render in the v5 URL space (`/v5/docs/...`), matching the
+        // sidebar tree so hrefs don't escape to the v4 route.
+        AutoCards: () => (
+          <AutoCards
+            items={resolveSectionChildren(
+              getDocsTreeForVersion(DEFAULT_LANG, PRE_RELEASE_VERSION),
+              `${VERSION_PREFIX}${page.url}`
+            )}
+          />
+        ),
+      }),
+    resolveLink: ({ link }) => {
+      const Link = link as ComponentType<ComponentProps<'a'>>;
+      const V5Link = (props: ComponentProps<'a'>) => (
+        <Link {...props} href={v5Href(props.href)} />
+      );
 
-    return V5Link;
-  },
-  openGraph: {
-    images: true,
-  },
-  tableOfContentPopover: {
-    enabled: false,
-  },
-  renderTop: ({ data }) => <MobileDocsBar toc={data.toc} />,
-  metadata: ({ metadata, page, params }) => {
-    const pageUrl = getPageUrl({ page });
+      return V5Link;
+    },
+    openGraph: {
+      images: true,
+    },
+    tableOfContentPopover: {
+      enabled: false,
+    },
+    tableOfContent: languageSwitcher
+      ? {
+          header: <PageLanguageSwitcher languages={languageSwitcher} />,
+        }
+      : undefined,
+    renderTop: ({ data }) => (
+      <>
+        <MobileDocsBar toc={data.toc} />
+        {languageSwitcher ? (
+          <PageLanguageSwitcher
+            className="max-w-56 xl:hidden"
+            languages={languageSwitcher}
+          />
+        ) : null}
+      </>
+    ),
+    metadata: ({ metadata, page, params }) => {
+      const pageUrl = getPageUrl({ page });
 
-    return {
-      ...metadata,
-      title: `${page.data.title} · Pre-release`,
-      alternates: {
-        ...metadata.alternates,
-        canonical: source.getPage(params.slug, params.lang)
-          ? page.url
-          : pageUrl,
-        types: {
-          ...metadata.alternates?.types,
-          'text/markdown': `${pageUrl}.md`,
+      return {
+        ...metadata,
+        title: `${page.data.title} · Pre-release`,
+        alternates: {
+          ...metadata.alternates,
+          canonical: source.getPage(params.slug, params.lang)
+            ? page.url
+            : pageUrl,
+          types: {
+            ...metadata.alternates?.types,
+            'text/markdown': `${pageUrl}.md`,
+          },
         },
-      },
-      robots: {
-        index: false,
-        follow: true,
-      },
-    };
-  },
-});
+        robots: {
+          index: false,
+          follow: true,
+        },
+      };
+    },
+  });
+}
+
+const docsPage = createV5DocsPage();
 
 const Page = async (props: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
   const { slug, lang } = await props.params;
@@ -106,7 +130,10 @@ const Page = async (props: PageProps<'/[lang]/v5/docs/[[...slug]]'>) => {
     permanentRedirect(`/${lang}${rewriteCookbookUrl(legacyPath)}`);
   }
 
-  return docsPage.Page(props);
+  const page = v5GeistdocsSource.source.getPage(slug, lang);
+  const pageData = page?.data as LanguageSwitcherFrontmatter | undefined;
+
+  return createV5DocsPage(pageData?.languageSwitcher).Page(props);
 };
 
 export default Page;

--- a/docs/components/custom/language-switcher.tsx
+++ b/docs/components/custom/language-switcher.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  Children,
+  isValidElement,
+  type JSX,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useEffect,
+  useSyncExternalStore,
+} from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+const QUERY_PARAM = 'language';
+
+const listeners = new Set<() => void>();
+let currentLanguage: string | null = null;
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): string | null {
+  return currentLanguage;
+}
+
+function getServerSnapshot(): string | null {
+  return null;
+}
+
+function setLanguage(value: string): void {
+  currentLanguage = value;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+const DEFAULT_TITLES: Record<string, string> = {
+  js: 'JavaScript',
+  javascript: 'JavaScript',
+  py: 'Python',
+  python: 'Python',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+};
+
+function getDefaultTitle(value: string): string {
+  return DEFAULT_TITLES[value] ?? value;
+}
+
+interface LanguageSwitcherTabProps {
+  value: string;
+  title?: ReactNode;
+  icon?: ReactNode;
+  disabled?: boolean;
+  tooltip?: string;
+  children?: ReactNode;
+}
+
+interface LanguageSwitcherProps {
+  defaultValue?: string;
+  /**
+   * Render only the selected panel so the switcher matches its height. By
+   * default, panels share the height of the tallest option to avoid layout
+   * shift when the language changes.
+   */
+  compactHeight?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+function useLanguageStore(
+  defaultValue: string,
+  availableValues: string[]
+): [string, (value: string) => void] {
+  const router = useRouter();
+  const pathname = usePathname();
+  const sharedValue = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  const fallbackValue = availableValues.includes(defaultValue)
+    ? defaultValue
+    : (availableValues[0] ?? '');
+  const selected =
+    sharedValue && availableValues.includes(sharedValue)
+      ? sharedValue
+      : fallbackValue;
+
+  const updateSelected = useCallback(
+    (value: string) => {
+      setLanguage(value);
+
+      const params = new URLSearchParams(window.location.search);
+      params.set(QUERY_PARAM, value);
+      const query = params.toString();
+      router.replace(
+        `${pathname}${query ? `?${query}` : ''}${window.location.hash}`,
+        { scroll: false }
+      );
+    },
+    [pathname, router]
+  );
+
+  return [selected, updateSelected];
+}
+
+function LanguageUrlSyncer(): null {
+  const searchParams = useSearchParams();
+  const urlLanguage = searchParams.get(QUERY_PARAM);
+
+  useEffect(() => {
+    if (urlLanguage && urlLanguage !== currentLanguage) {
+      setLanguage(urlLanguage);
+    }
+  }, [urlLanguage]);
+
+  return null;
+}
+
+/**
+ * Defines one language panel inside a {@link LanguageSwitcher}.
+ */
+export function LanguageSwitcherTab(
+  _props: LanguageSwitcherTabProps
+): JSX.Element | null {
+  return null;
+}
+
+function getTabChildren(children: ReactNode) {
+  return Children.toArray(children).filter(
+    (child): child is ReactElement<LanguageSwitcherTabProps> =>
+      isValidElement<LanguageSwitcherTabProps>(child) &&
+      typeof child.props.value === 'string'
+  );
+}
+
+function LanguagePanels({
+  compactHeight,
+  selected,
+  tabs,
+}: {
+  compactHeight: boolean;
+  selected: string;
+  tabs: ReactElement<LanguageSwitcherTabProps>[];
+}): JSX.Element | null {
+  if (compactHeight) {
+    const selectedTab =
+      tabs.find((tab) => tab.props.value === selected) ?? tabs[0];
+
+    return selectedTab ? (
+      <TabsContent className="pt-4" value={selectedTab.props.value}>
+        {selectedTab.props.children}
+      </TabsContent>
+    ) : null;
+  }
+
+  return (
+    <div className="grid">
+      {tabs.map((tab) => {
+        const isSelected = tab.props.value === selected;
+
+        return (
+          <TabsContent
+            aria-hidden={!isSelected}
+            className={cn(
+              'col-start-1 row-start-1 min-w-0 pt-4',
+              isSelected ? 'visible' : 'invisible pointer-events-none'
+            )}
+            forceMount
+            key={tab.props.value}
+            tabIndex={isSelected ? 0 : -1}
+            value={tab.props.value}
+          >
+            {tab.props.children}
+          </TabsContent>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Renders language-specific MDX content. Every switcher on the page shares the
+ * selected language, and the selection is reflected in the `language` query
+ * parameter so links can open with the intended language selected.
+ */
+export function LanguageSwitcher({
+  children,
+  className,
+  compactHeight = false,
+  defaultValue = 'ts',
+}: LanguageSwitcherProps): JSX.Element | null {
+  const tabs = getTabChildren(children);
+  const enabledValues = tabs
+    .filter((tab) => !tab.props.disabled)
+    .map((tab) => tab.props.value);
+  const availableValues =
+    enabledValues.length > 0
+      ? enabledValues
+      : tabs.map((tab) => tab.props.value);
+  const [selected, setSelected] = useLanguageStore(
+    defaultValue,
+    availableValues
+  );
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <LanguageUrlSyncer />
+      </Suspense>
+      <Tabs
+        className={cn('my-4 gap-0', className)}
+        onValueChange={setSelected}
+        value={selected}
+        variant="underline"
+      >
+        {tabs.length > 1 ? (
+          <TabsList
+            aria-label="Programming language"
+            className="w-full justify-start overflow-x-auto"
+          >
+            {tabs.map((tab) => (
+              <TabsTrigger
+                disabled={tab.props.disabled}
+                key={tab.props.value}
+                title={tab.props.tooltip}
+                value={tab.props.value}
+              >
+                {tab.props.icon}
+                {tab.props.title ?? getDefaultTitle(tab.props.value)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        ) : null}
+        <LanguagePanels
+          compactHeight={compactHeight}
+          selected={selected}
+          tabs={tabs}
+        />
+      </Tabs>
+    </>
+  );
+}

--- a/docs/components/custom/language-switcher.tsx
+++ b/docs/components/custom/language-switcher.tsx
@@ -12,6 +12,13 @@ import {
   useEffect,
   useSyncExternalStore,
 } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 
@@ -43,8 +50,8 @@ function setLanguage(value: string): void {
 const DEFAULT_TITLES: Record<string, string> = {
   js: 'JavaScript',
   javascript: 'JavaScript',
-  py: 'Python',
-  python: 'Python',
+  py: 'Python (beta)',
+  python: 'Python (beta)',
   ts: 'TypeScript',
   typescript: 'TypeScript',
 };
@@ -74,17 +81,31 @@ interface LanguageSwitcherProps {
   children: ReactNode;
 }
 
+interface LanguageContentProps {
+  as?: keyof JSX.IntrinsicElements;
+  value: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+type LanguageTextProps = Record<string, ReactNode>;
+
+interface PageLanguageSwitcherProps {
+  languages: readonly string[];
+  className?: string;
+}
+
+function useSharedLanguage(): string | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
 function useLanguageStore(
   defaultValue: string,
   availableValues: string[]
 ): [string, (value: string) => void] {
   const router = useRouter();
   const pathname = usePathname();
-  const sharedValue = useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    getServerSnapshot
-  );
+  const sharedValue = useSharedLanguage();
 
   const fallbackValue = availableValues.includes(defaultValue)
     ? defaultValue
@@ -252,4 +273,82 @@ export function LanguageSwitcher({
       </Tabs>
     </>
   );
+}
+
+function PageLanguageSwitcherImpl({
+  className,
+  languages,
+}: PageLanguageSwitcherProps): JSX.Element | null {
+  const [selected, setSelected] = useLanguageStore(languages[0] ?? 'ts', [
+    ...languages,
+  ]);
+
+  if (languages.length < 2) {
+    return null;
+  }
+
+  return (
+    <div className={cn('mb-6', className)} data-page-language-switcher>
+      <Suspense fallback={null}>
+        <LanguageUrlSyncer />
+      </Suspense>
+      <Select onValueChange={setSelected} value={selected}>
+        <SelectTrigger
+          aria-label="Programming language"
+          className="w-full bg-background-100"
+          size="sm"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="start">
+          {languages.map((language) => (
+            <SelectItem key={language} value={language}>
+              {getDefaultTitle(language)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+/** Renders the language selector only for pages that opt in via frontmatter. */
+export function PageLanguageSwitcher(
+  props: PageLanguageSwitcherProps
+): JSX.Element {
+  return (
+    <Suspense fallback={null}>
+      <PageLanguageSwitcherImpl {...props} />
+    </Suspense>
+  );
+}
+
+/**
+ * Shows block content when its language is selected for the current page.
+ */
+export function LanguageContent({
+  as,
+  children,
+  className,
+  value,
+}: LanguageContentProps): JSX.Element {
+  const selected = useSharedLanguage() ?? 'ts';
+  const Component = as ?? 'div';
+
+  return (
+    <Component
+      className={className}
+      data-language={value}
+      hidden={selected !== value}
+    >
+      {children}
+    </Component>
+  );
+}
+
+/** Selects one inline value, provided as a prop named after each language. */
+export function LanguageText(values: LanguageTextProps): JSX.Element {
+  const selected = useSharedLanguage() ?? 'ts';
+
+  return <>{values[selected]}</>;
 }

--- a/docs/components/geistdocs/mdx-components.tsx
+++ b/docs/components/geistdocs/mdx-components.tsx
@@ -6,8 +6,10 @@ import type { MDXComponents } from 'mdx/types';
 import { AgentTraces } from '@/components/custom/agent-traces';
 import { FluidComputeCallout } from '@/components/custom/fluid-compute-callout';
 import {
+  LanguageContent,
   LanguageSwitcher,
   LanguageSwitcherTab,
+  LanguageText,
 } from '@/components/custom/language-switcher';
 import { PreviewInstallServer } from '@/components/preview-install-server';
 import * as AccordionComponents from '@/components/ui/accordion';
@@ -56,8 +58,10 @@ export const getMDXComponents = (components?: MDXComponents): MDXComponents =>
   createMdxComponents({
     AgentTraces,
     FluidComputeCallout,
+    LanguageContent,
     LanguageSwitcher,
     LanguageSwitcherTab,
+    LanguageText,
     Badge,
     TSDoc,
     Step,

--- a/docs/components/geistdocs/mdx-components.tsx
+++ b/docs/components/geistdocs/mdx-components.tsx
@@ -5,6 +5,10 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import type { MDXComponents } from 'mdx/types';
 import { AgentTraces } from '@/components/custom/agent-traces';
 import { FluidComputeCallout } from '@/components/custom/fluid-compute-callout';
+import {
+  LanguageSwitcher,
+  LanguageSwitcherTab,
+} from '@/components/custom/language-switcher';
 import { PreviewInstallServer } from '@/components/preview-install-server';
 import * as AccordionComponents from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
@@ -52,6 +56,8 @@ export const getMDXComponents = (components?: MDXComponents): MDXComponents =>
   createMdxComponents({
     AgentTraces,
     FluidComputeCallout,
+    LanguageSwitcher,
+    LanguageSwitcherTab,
     Badge,
     TSDoc,
     Step,

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -9,6 +9,8 @@ import { z } from 'zod';
 // You can customise Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
 const docsSchema = geistdocsFrontmatterSchema.extend({
+  // Opt a page into the shared language selector; the first option is default.
+  languageSwitcher: z.array(z.string().min(1)).min(2).optional(),
   // Opt a section landing page out of the card↔nav completeness lint when its
   // `<Cards>` grid is intentionally curated (e.g. links outside the section or
   // deliberately omits children). Exhaustive list pages should use `<AutoCards />`


### PR DESCRIPTION
### Description

Adds reusable TypeScript/Python language tabs for MDX documentation.

- Synchronizes the selected language across every switcher on the page.
- Persists the selection in the `language` query parameter while preserving existing query parameters and hashes.
- Keeps all panels mounted by default to avoid layout shifts, with an opt-in compact-height mode.
- Registers both components globally for MDX pages.

This establishes the shared UI needed to add Python content across the documentation.

### How did you test your changes?

- [x] `pnpm exec biome check docs/components/custom/language-switcher.tsx docs/components/geistdocs/mdx-components.tsx`
- [x] `pnpm --filter docs build`
- [x] `node docs/scripts/check-docs-smoke.mjs`

### PR Checklist - Required to merge

- [ ] 📦 `pnpm changeset --empty` was run for this documentation change
- [ ] 🔒 DCO sign-off passes
- [ ] 📝 Ping `@vercel/workflow` in a comment once the PR is ready and the checklist is complete