### PR TITLE
[core] Budget queue redeliveries by message expiry instead of a fixed 48 attempts

### DIFF
--- a/.changeset/queue-delivery-budget-24h.md
+++ b/.changeset/queue-delivery-budget-24h.md
@@ -1,0 +1,7 @@
+---
+'@workflow/core': patch
+'@workflow/world': patch
+'@workflow/world-vercel': patch
+---
+
+Retry failed queue deliveries for the full message retention window (about 24 hours on Vercel) before failing the run with `MAX_DELIVERIES_EXCEEDED`, instead of giving up after 48 attempts.

--- a/docs/content/docs/v5/api-reference/workflow-runtime/world/queue.mdx
+++ b/docs/content/docs/v5/api-reference/workflow-runtime/world/queue.mdx
@@ -75,9 +75,11 @@ const handler = world.createQueueHandler(prefix, callback); // [!code highlight]
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `prefix` | `QueuePrefix` | Queue name prefix to match |
-| `callback` | `(message, meta) => Promise<void \| { timeoutSeconds: number }>` | Handler called for each message. `meta` contains `attempt`, `queueName`, `messageId`, `requestId`. |
+| `callback` | `(message, meta) => Promise<void \| { timeoutSeconds: number }>` | Handler called for each message. `meta` contains `attempt`, `queueName`, `messageId`, `requestId`, and `expiresAt` when the queue drops undelivered messages after a retention period. |
 
 **Returns:** `(req: Request) => Promise<Response>`
+
+`meta.expiresAt` tells the runtime when the queue will drop the message. When a World provides it, the runtime keeps retrying a failing delivery until about an hour before that instant and then fails the run with `MAX_DELIVERIES_EXCEEDED`, so the failure is recorded rather than the message silently expiring. Without it, the runtime falls back to a fixed attempt count (see [`WORKFLOW_MAX_QUEUE_DELIVERIES`](/docs/configuration/runtime-tuning#workflow_max_queue_deliveries)).
 
 `meta.messageId` should be stable across redeliveries of the same message (one ID per enqueued message, reused on every delivery attempt). The runtime records it on inline `step_started` events as a liveness lease so that only a redelivery of the owning message re-executes a crashed inline step before the lease expires (see [Inline step message ownership](/docs/changelog/step-message-ownership)). A World whose queue mints a fresh ID per delivery degrades gracefully. Crashed inline steps recover via the delayed backstop instead of immediately on redelivery, but never wedge or duplicate.
 

--- a/docs/content/docs/v5/configuration/runtime-tuning.mdx
+++ b/docs/content/docs/v5/configuration/runtime-tuning.mdx
@@ -64,9 +64,10 @@ For example, a workflow can run a 10-minute inline step even with `WORKFLOW_REPL
 
 ### `WORKFLOW_MAX_QUEUE_DELIVERIES`
 
-- Default: `48`
-- Delivery attempts before a run or step is failed gracefully.
-- Can only be lowered. Workflow calibrates the default to record failure before the queue expires the message.
+- Default: `256` when the World reports message expiry (Vercel World), `48` otherwise (Local and Postgres Worlds)
+- Delivery attempts before a run is failed gracefully with `MAX_DELIVERIES_EXCEEDED`.
+- On the Vercel World the budget is time-based: a message that keeps failing is retried until about one hour before the queue's 24-hour message retention expires, then the run is failed. The attempt cap is a safety net above that. On Worlds without message expiry, the attempt cap is the whole budget.
+- Can only be lowered. Workflow calibrates the defaults to record failure before the queue expires the message.
 
 ### `WORKFLOW_MAX_EVENTS`
 

--- a/docs/content/docs/v5/foundations/errors-and-retries.mdx
+++ b/docs/content/docs/v5/foundations/errors-and-retries.mdx
@@ -192,7 +192,7 @@ try {
 | --- | --- |
 | `USER_ERROR` | An error thrown in your workflow or step code (including propagated step failures like `FatalError`) |
 | `MAX_EVENTS_EXCEEDED` | The run reached the World's per-run event ceiling (25,000 on the Local and Vercel Worlds). Split unbounded loops into [child workflows](/cookbook/advanced/child-workflows); see [Limits](/docs/configuration/runtime-tuning#limits) |
-| `MAX_DELIVERIES_EXCEEDED` | The run exceeded the maximum number of queue deliveries |
+| `MAX_DELIVERIES_EXCEEDED` | The run exhausted its queue redelivery budget: on the Vercel World, about 24 hours of failed deliveries (the message's retention); on other Worlds, the attempt cap in [`WORKFLOW_MAX_QUEUE_DELIVERIES`](/docs/configuration/runtime-tuning#workflow_max_queue_deliveries). Points at a persistent failure, such as a deployment whose function keeps crashing or timing out |
 | `REPLAY_TIMEOUT` | A workflow replay exceeded the maximum allowed duration |
 | `REPLAY_DIVERGENCE` | A replay could not consume the event log deterministically, usually because of non-deterministic workflow code. |
 | `CORRUPTED_EVENT_LOG` | The event log cannot be replayed: it contains orphaned or mismatched events, or one of its stored payloads is no longer readable from the World's storage. If you see this, please [file an issue](https://github.com/vercel/workflow/issues) |

--- a/docs/content/worlds/v5/building-a-world.mdx
+++ b/docs/content/worlds/v5/building-a-world.mdx
@@ -231,7 +231,7 @@ interface Queue {
 
   createQueueHandler(
     queueNamePrefix: QueuePrefix,
-    handler: (message: unknown, meta: { attempt: number; queueName: ValidQueueName; messageId: MessageId }) => Promise<void | { timeoutSeconds: number }>
+    handler: (message: unknown, meta: { attempt: number; queueName: ValidQueueName; messageId: MessageId; requestId?: string; expiresAt?: Date }) => Promise<void | { timeoutSeconds: number }>
   ): (req: Request) => Promise<Response>;
 }
 ```

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -17,6 +17,8 @@ import { runtimeLogger } from './logger.js';
 import { registerStepFunction } from './private.js';
 import {
   DEPLOYMENT_MISMATCH_MAX_RETRIES,
+  MAX_QUEUE_DELIVERIES,
+  QUEUE_DELIVERY_EXPIRY_MARGIN_MS,
   REPLAY_DIVERGENCE_MAX_RETRIES,
 } from './runtime/constants.js';
 import { setWorld } from './runtime/world.js';
@@ -67,6 +69,8 @@ async function runWorkflowHandlerWithEvents(
   events: Event[],
   options: {
     attempt?: number;
+    /** Message expiry reported by the queue, as world-vercel does. */
+    expiresAt?: Date;
     createdEvents?: unknown[];
     createdEventParams?: unknown[];
     queueCalls?: QueueCall[];
@@ -148,6 +152,7 @@ async function runWorkflowHandlerWithEvents(
               attempt: options.attempt ?? 1,
               queueName: '__wkf_workflow_workflow',
               messageId: 'msg_test',
+              expiresAt: options.expiresAt,
             }
           );
           return new Response(null, { status: 204 });
@@ -374,6 +379,83 @@ describe('workflowEntrypoint replay guards', () => {
     expect(createdEvents).not.toContainEqual(
       expect.objectContaining({ eventType: 'run_completed' })
     );
+  });
+
+  describe('delivery budget', () => {
+    const HOUR_MS = 60 * 60 * 1000;
+
+    it('fails the run with MAX_DELIVERIES_EXCEEDED once the fixed attempt cap is exceeded on a queue without message expiry', async () => {
+      const workflowRun = await misroutedRun();
+      const createdEvents = await runWorkflowHandlerWithEvents(
+        mustNotRun,
+        workflowRun,
+        [],
+        { attempt: MAX_QUEUE_DELIVERIES + 1 }
+      );
+
+      const failedEvent = createdEvents.find(
+        (event: any) => event.eventType === 'run_failed'
+      ) as any;
+      expect(failedEvent).toBeDefined();
+      expect(failedEvent.eventData.errorCode).toBe(
+        RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED
+      );
+    });
+
+    it('keeps retrying past the fixed attempt cap while the message has time before it expires', async () => {
+      // A message on a queue with retention is budgeted by time, so a long
+      // backend outage does not fail the run at the attempt count that
+      // bounds queues without expiry. This delivery is a misrouted one so
+      // the handler takes a known non-failing path (re-route) after the
+      // budget check passes.
+      const workflowRun = await misroutedRun();
+      const queueCalls: QueueCall[] = [];
+      const createdEvents = await runWorkflowHandlerWithEvents(
+        mustNotRun,
+        workflowRun,
+        [],
+        {
+          attempt: MAX_QUEUE_DELIVERIES + 1,
+          expiresAt: new Date(Date.now() + 12 * HOUR_MS),
+          currentDeploymentId: 'dpl_current',
+          queueCalls,
+        }
+      );
+
+      expect(createdEvents).not.toContainEqual(
+        expect.objectContaining({ eventType: 'run_failed' })
+      );
+      expect(queueCalls).toHaveLength(1);
+    });
+
+    it('fails the run with MAX_DELIVERIES_EXCEEDED once the message is about to expire', async () => {
+      const workflowRun = await misroutedRun();
+      const createdEvents = await runWorkflowHandlerWithEvents(
+        mustNotRun,
+        workflowRun,
+        [],
+        {
+          attempt: 20,
+          expiresAt: new Date(
+            Date.now() + QUEUE_DELIVERY_EXPIRY_MARGIN_MS - 60_000
+          ),
+        }
+      );
+
+      const failedEvent = createdEvents.find(
+        (event: any) => event.eventType === 'run_failed'
+      ) as any;
+      expect(failedEvent).toBeDefined();
+      expect(failedEvent.eventData.errorCode).toBe(
+        RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED
+      );
+      const error = await hydrateRunError(
+        failedEvent.eventData.error,
+        workflowRun.runId,
+        undefined
+      );
+      expect(String(error.message)).toContain('message expires in');
+    });
   });
 
   it('records run_failed when run_started response schema validation fails', async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -52,8 +52,8 @@ import { getStepFunction } from './private.js';
 import { ReplayPayloadCache } from './replay-payload-cache.js';
 import { COMPUTE_INSTANCE_ID } from './runtime/compute-instance.js';
 import {
+  getExhaustedDeliveryBudget,
   getMaxEventsOverride,
-  getMaxQueueDeliveries,
   getPreconditionMaxInProcessRestarts,
   getPreconditionMaxReinvocations,
   getPreconditionReinvokeDelaySeconds,
@@ -794,23 +794,28 @@ export function workflowEntrypoint(
         const { requestId } = metadata;
         const workflowName = metadata.queueName.slice(workflowPrefix.length);
 
-        // --- Max delivery check ---
-        // Enforce max delivery limit before any infrastructure calls.
-        // This prevents runaway workflows from consuming infinite queue deliveries.
+        // --- Delivery budget check ---
+        // Enforce the redelivery budget before any infrastructure calls, so a
+        // runaway workflow cannot consume queue deliveries until the message
+        // expires. The budget is the time left before the queue drops the
+        // message when the World reports it, and a fixed attempt count
+        // otherwise (see `getExhaustedDeliveryBudget`).
         // Scoped logger for this run: attaches runId/workflowName to every
         // log line and child loggers below, so callers don't repeat it.
         const runLogger = runtimeLogger.forRun(runId, workflowName);
 
-        const maxQueueDeliveries = getMaxQueueDeliveries();
-        if (metadata.attempt > maxQueueDeliveries) {
+        const exhaustedBudget = getExhaustedDeliveryBudget(metadata);
+        if (exhaustedBudget) {
           const maxDeliveriesDescription = describeError(
             undefined,
             RUN_ERROR_CODES.MAX_DELIVERIES_EXCEEDED
           );
           runLogger.error(
-            `Workflow handler exceeded max deliveries (${metadata.attempt}/${maxQueueDeliveries})`,
+            `Workflow handler exceeded ${exhaustedBudget.reason}`,
             {
               attempt: metadata.attempt,
+              maxQueueDeliveries: exhaustedBudget.maxQueueDeliveries,
+              expiresAt: metadata.expiresAt?.toISOString(),
               errorCode: maxDeliveriesDescription.errorCode,
               errorAttribution: maxDeliveriesDescription.attribution,
             }
@@ -819,7 +824,7 @@ export function workflowEntrypoint(
             const world = await getWorld();
             const getEncryptionKey = memoizeEncryptionKey(world, runId);
             const err = new FatalError(
-              `Workflow exceeded maximum queue deliveries (${metadata.attempt}/${maxQueueDeliveries})`
+              `Workflow exceeded ${exhaustedBudget.reason}`
             );
             await world.events.create(
               runId,

--- a/packages/core/src/runtime/constants.test.ts
+++ b/packages/core/src/runtime/constants.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runtimeLogger } from '../logger.js';
 import {
   _resetReplayTimeoutWarnCacheForTests,
+  getExhaustedDeliveryBudget,
   getInlineOwnershipLeaseSeconds,
   getMaxInlineSteps,
   getMaxQueueDeliveries,
@@ -16,9 +17,11 @@ import {
   MAX_INLINE_STEPS,
   MAX_MAX_INLINE_STEPS,
   MAX_QUEUE_DELIVERIES,
+  MAX_QUEUE_DELIVERIES_WITH_EXPIRY,
   MAX_REPLAY_TIMEOUT_MS,
   MIN_MAX_INLINE_STEPS,
   MIN_REPLAY_TIMEOUT_MS,
+  QUEUE_DELIVERY_EXPIRY_MARGIN_MS,
   REPLAY_TIMEOUT_MS,
 } from './constants.js';
 
@@ -316,6 +319,121 @@ describe('getMaxQueueDeliveries', () => {
     // may only lower it, never raise it.
     process.env[ENV] = String(MAX_QUEUE_DELIVERIES + 100);
     expect(getMaxQueueDeliveries()).toBe(MAX_QUEUE_DELIVERIES);
+  });
+
+  it('uses the larger safety-net cap when the queue reports message expiry', () => {
+    expect(getMaxQueueDeliveries(true)).toBe(MAX_QUEUE_DELIVERIES_WITH_EXPIRY);
+    expect(MAX_QUEUE_DELIVERIES_WITH_EXPIRY).toBeGreaterThan(
+      MAX_QUEUE_DELIVERIES
+    );
+  });
+
+  it('clamps an override against the cap that applies to the queue', () => {
+    process.env[ENV] = String(MAX_QUEUE_DELIVERIES + 100);
+    expect(getMaxQueueDeliveries(true)).toBe(MAX_QUEUE_DELIVERIES + 100);
+    process.env[ENV] = String(MAX_QUEUE_DELIVERIES_WITH_EXPIRY + 100);
+    expect(getMaxQueueDeliveries(true)).toBe(MAX_QUEUE_DELIVERIES_WITH_EXPIRY);
+  });
+});
+
+describe('getExhaustedDeliveryBudget', () => {
+  const ENV = 'WORKFLOW_MAX_QUEUE_DELIVERIES';
+  const now = Date.UTC(2026, 0, 1);
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  afterEach(() => {
+    delete process.env[ENV];
+  });
+
+  describe('without message expiry', () => {
+    it('allows deliveries up to the fixed cap', () => {
+      expect(
+        getExhaustedDeliveryBudget({ attempt: MAX_QUEUE_DELIVERIES }, now)
+      ).toBeUndefined();
+    });
+
+    it('is exhausted once the fixed cap is exceeded', () => {
+      const exhausted = getExhaustedDeliveryBudget(
+        { attempt: MAX_QUEUE_DELIVERIES + 1 },
+        now
+      );
+      expect(exhausted?.maxQueueDeliveries).toBe(MAX_QUEUE_DELIVERIES);
+      expect(exhausted?.reason).toContain(
+        `${MAX_QUEUE_DELIVERIES + 1}/${MAX_QUEUE_DELIVERIES}`
+      );
+    });
+  });
+
+  describe('with message expiry', () => {
+    it('keeps retrying past the fixed cap while the message has time left', () => {
+      // The whole point of the time-based budget: a backend outage that lasts
+      // longer than 48 deliveries' worth of backoff does not fail the run as
+      // long as the queue still holds the message.
+      expect(
+        getExhaustedDeliveryBudget(
+          {
+            attempt: MAX_QUEUE_DELIVERIES + 1,
+            expiresAt: new Date(now + DAY_MS / 2),
+          },
+          now
+        )
+      ).toBeUndefined();
+    });
+
+    it('is exhausted once the message is within the expiry margin', () => {
+      const exhausted = getExhaustedDeliveryBudget(
+        {
+          attempt: 30,
+          expiresAt: new Date(now + QUEUE_DELIVERY_EXPIRY_MARGIN_MS - 1),
+        },
+        now
+      );
+      expect(exhausted?.reason).toContain('message expires in');
+      expect(exhausted?.reason).toContain('30 deliveries');
+    });
+
+    it('is not exhausted exactly at the margin', () => {
+      expect(
+        getExhaustedDeliveryBudget(
+          {
+            attempt: 30,
+            expiresAt: new Date(now + QUEUE_DELIVERY_EXPIRY_MARGIN_MS),
+          },
+          now
+        )
+      ).toBeUndefined();
+    });
+
+    it('reports a non-negative remaining time for an already-expired message', () => {
+      const exhausted = getExhaustedDeliveryBudget(
+        { attempt: 5, expiresAt: new Date(now - 1000) },
+        now
+      );
+      expect(exhausted?.reason).toContain('expires in 0s');
+    });
+
+    it('still enforces the safety-net attempt cap', () => {
+      const exhausted = getExhaustedDeliveryBudget(
+        {
+          attempt: MAX_QUEUE_DELIVERIES_WITH_EXPIRY + 1,
+          expiresAt: new Date(now + DAY_MS),
+        },
+        now
+      );
+      expect(exhausted?.maxQueueDeliveries).toBe(
+        MAX_QUEUE_DELIVERIES_WITH_EXPIRY
+      );
+    });
+
+    it('honors a lowered override ahead of the time budget', () => {
+      process.env[ENV] = '5';
+      expect(
+        getExhaustedDeliveryBudget(
+          { attempt: 6, expiresAt: new Date(now + DAY_MS) },
+          now
+        )?.maxQueueDeliveries
+      ).toBe(5);
+    });
   });
 });
 

--- a/packages/core/src/runtime/constants.ts
+++ b/packages/core/src/runtime/constants.ts
@@ -2,40 +2,92 @@ import { globalSingleton } from '@workflow/utils';
 import { envNumber } from '@workflow/world';
 import { runtimeLogger } from '../logger.js';
 
-// Maximum number of queue delivery attempts before the handler gives up and
-// gracefully fails the run/step. This must be bounded under the VQS message
-// max visibility window (24 hours) so that our handler-side failure path
-// reliably executes before VQS expires the message.
+// The handler's redelivery budget: how long a message that keeps failing is
+// retried before the handler gives up and records `run_failed`. The failure
+// path must run while the queue still holds the message, so the budget is
+// bounded by the message's retention (24 hours on the Vercel queue).
 //
-// The effective wall-clock survival depends on the per-redelivery backoff: the
-// `retry-after` the handler returns (see world-vercel
-// `getHandlerErrorRetryAfterSeconds`) fed through VQS `calculateBackoffDelay`.
-// VQS uses our value for the first 32 attempts (clamped to [5s, 900s]) then
-// applies its own exponential growth, every hop hard-capped at the SQS limit
-// of 900s. With the backoff ramping toward that 900s ceiling (reached by
-// ~delivery 11), 48 attempts span roughly 9–10 hours of wall-clock (~35,000s),
-// comfortably under the 24-hour message-visibility limit so the failure path
-// runs before the message expires. (A flatter, low-capped backoff exhausts the
-// budget in only a few hours, failing otherwise-healthy runs during a transient
-// backend outage; conversely, spanning the full 24h window would require a
-// substantially higher cap here, not a higher per-hop ceiling, since VQS
-// clamps every hop at 900s.)
+// When the queue reports the message's expiry (`meta.expiresAt`), the budget
+// is time-based: the handler keeps retrying until the message is within
+// `QUEUE_DELIVERY_EXPIRY_MARGIN_MS` of expiring, then fails the run. This
+// spans the retention window regardless of how long each attempt takes or
+// how the per-redelivery backoff is shaped. Before this, the budget was a
+// fixed 48 attempts, which under the backoff in world-vercel
+// (`getHandlerErrorRetryAfterSeconds`, ramping to VQS's 900s per-hop cap by
+// about delivery 11) gave up after roughly 9-10 hours of a backend outage,
+// well short of the 24 hours the message would otherwise have survived.
+//
+// The margin has to cover one more redelivery hop plus the handler's own
+// startup: the check runs at the top of each delivery, so the last attempt to
+// see "not yet exhausted" is followed by at most one backoff (VQS caps every
+// hop at 900s) before the attempt that records the failure.
+export const QUEUE_DELIVERY_EXPIRY_MARGIN_MS = 60 * 60 * 1000;
+
+// Attempt cap that applies alongside the time-based budget. It is a safety
+// net against a queue that ignores the requested backoff, not the budget
+// itself: 23 hours of 900s hops is about 100 deliveries, and the jittered
+// backoff can fit at most ~135, so a healthy message never reaches this.
+export const MAX_QUEUE_DELIVERIES_WITH_EXPIRY = 256;
+
+// Attempt cap for queues that report no message expiry (world-local,
+// world-postgres, custom worlds). With no retention to run against, the
+// count is the whole budget, and it stays at the value calibrated for the
+// Vercel queue's retention so a bad deployment on such a world is bounded
+// the same way it was before the time-based budget existed.
 export const MAX_QUEUE_DELIVERIES = 48;
 
 /**
  * Effective max queue deliveries. Override via `WORKFLOW_MAX_QUEUE_DELIVERIES`.
+ *
+ * `hasExpiry` selects the default: the safety-net cap when the queue reports
+ * a message expiry (the time-based budget is the binding bound then), the
+ * fixed budget otherwise.
  */
-export function getMaxQueueDeliveries(): number {
+export function getMaxQueueDeliveries(hasExpiry = false): number {
+  const defaultMax = hasExpiry
+    ? MAX_QUEUE_DELIVERIES_WITH_EXPIRY
+    : MAX_QUEUE_DELIVERIES;
   // Only ever lower the delivery budget. The default is calibrated so the
   // handler-side failure path runs before VQS message-retention expiry (see
-  // MAX_QUEUE_DELIVERIES above); a higher value would bypass that invariant and
-  // let a bad deployment redeliver until queue expiry instead of recording
-  // run_fail. `max` clamps a too-high override back down to the safe default.
-  return envNumber('WORKFLOW_MAX_QUEUE_DELIVERIES', MAX_QUEUE_DELIVERIES, {
+  // above); a higher value would bypass that invariant and let a bad
+  // deployment redeliver until queue expiry instead of recording run_failed.
+  // `max` clamps a too-high override back down to the safe default.
+  return envNumber('WORKFLOW_MAX_QUEUE_DELIVERIES', defaultMax, {
     integer: true,
     min: 1,
-    max: MAX_QUEUE_DELIVERIES,
+    max: defaultMax,
   });
+}
+
+/**
+ * Decides whether a delivery has exhausted its redelivery budget. Returns a
+ * description of the exhausted bound for the failure message, or `undefined`
+ * while the message may still be retried.
+ */
+export function getExhaustedDeliveryBudget(
+  meta: { attempt: number; expiresAt?: Date },
+  now: number = Date.now()
+): { reason: string; maxQueueDeliveries: number } | undefined {
+  const maxQueueDeliveries = getMaxQueueDeliveries(
+    meta.expiresAt !== undefined
+  );
+  if (meta.attempt > maxQueueDeliveries) {
+    return {
+      reason: `maximum queue deliveries (${meta.attempt}/${maxQueueDeliveries})`,
+      maxQueueDeliveries,
+    };
+  }
+  if (meta.expiresAt !== undefined) {
+    const remainingMs = meta.expiresAt.getTime() - now;
+    if (remainingMs < QUEUE_DELIVERY_EXPIRY_MARGIN_MS) {
+      const remainingSeconds = Math.max(0, Math.round(remainingMs / 1000));
+      return {
+        reason: `queue delivery budget (message expires in ${remainingSeconds}s after ${meta.attempt} deliveries)`,
+        maxQueueDeliveries,
+      };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -747,6 +747,55 @@ describe('createQueue', () => {
       }
     });
 
+    it('forwards the message expiry to the handler so the runtime can budget redeliveries by time', async () => {
+      let capturedHandler: (
+        message: unknown,
+        metadata: unknown
+      ) => Promise<void>;
+      mockHandleCallback.mockImplementation((handler) => {
+        capturedHandler = handler;
+        return async () => new Response('ok');
+      });
+
+      const originalEnv = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+
+      try {
+        const queue = createQueue();
+        const handler = vi.fn(async () => undefined);
+        queue.createQueueHandler('__wkf_workflow_', handler);
+
+        const expiresAt = new Date('2026-01-02T00:00:00.000Z');
+        await capturedHandler!(
+          {
+            payload: { runId: 'run-123' },
+            queueName: '__wkf_workflow_test',
+            deploymentId: 'dpl_original',
+          },
+          {
+            messageId: 'msg-123',
+            deliveryCount: 7,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            expiresAt,
+            topicName: '__wkf_workflow_test',
+            consumerGroup: 'test',
+          }
+        );
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler.mock.calls[0][1]).toMatchObject({
+          attempt: 7,
+          expiresAt,
+        });
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
+        } else {
+          delete process.env.VERCEL_DEPLOYMENT_ID;
+        }
+      }
+    });
+
     it('should send new message with delaySeconds when handler returns timeoutSeconds', async () => {
       mockSend.mockResolvedValue({ messageId: 'new-msg-123' });
 
@@ -787,6 +836,9 @@ describe('createQueue', () => {
         // send(topicName, payload, options)
         const sendOpts = mockSend.mock.calls[0][2];
         expect(sendOpts.delaySeconds).toBe(300);
+        // A delayed message keeps the full default retention (24h) of retry
+        // budget after it fires, so its retention is the delay on top of it.
+        expect(sendOpts.retentionSeconds).toBe(300 + 86400);
       } finally {
         if (originalEnv !== undefined) {
           process.env.VERCEL_DEPLOYMENT_ID = originalEnv;
@@ -885,6 +937,7 @@ describe('createQueue', () => {
         // send(topicName, payload, options)
         const sendOpts = mockSend.mock.calls[0][2];
         expect(sendOpts.delaySeconds).toBeUndefined();
+        expect(sendOpts.retentionSeconds).toBeUndefined();
       } finally {
         if (originalEnv !== undefined) {
           process.env.VERCEL_DEPLOYMENT_ID = originalEnv;

--- a/packages/world-vercel/src/queue.ts
+++ b/packages/world-vercel/src/queue.ts
@@ -143,18 +143,26 @@ const MAX_DELAY_SECONDS = Number(
   process.env.VERCEL_QUEUE_MAX_DELAY_SECONDS || 82800 // 23 hours - leave 1h buffer before the default 24h message TTL
 );
 
+// The queue's default message retention. A message is dropped this long after
+// it was sent, whether or not it has been delivered; the runtime's redelivery
+// budget (`getExhaustedDeliveryBudget` in @workflow/core) runs against the
+// `expiresAt` the queue stamps on each delivery. A delayed message spends most
+// of that window waiting, so it is sent with the delay added on top: every
+// message then has the full window of retries from its first delivery, and a
+// sleep continuation that fires with an hour left does not read as an
+// exhausted budget.
+const DEFAULT_MESSAGE_RETENTION_SECONDS = 86400;
+
 const HANDLER_ERROR_RETRY_AFTER_SECONDS = 1;
 // Ceiling for the per-redelivery backoff. This value is the `retry-after` we
 // hand to VQS, which clamps it into [5s, MAX_SQS_DELAY_SECONDS=900s] for the
 // first 32 deliveries and then applies its own exponential growth (also capped
-// at 900s); see vqs-server `calculateBackoffDelay`. Capping our base at 60s
-// (the old value) wasted that headroom: a run stuck behind a sustained backend
-// outage exhausted its delivery budget in ~3.7h. Ramping to the 900s ceiling
-// instead stretches survival to ~9–10h (across `MAX_QUEUE_DELIVERIES` = 48
-// attempts), so transient outages don't fail otherwise-healthy runs. Spanning
-// the full ~24h message-visibility window would require a higher delivery cap,
-// not a higher ceiling: VQS clamps every hop at 900s, so going above it here
-// is pointless.
+// at 900s); see vqs-server `calculateBackoffDelay`. Ramping to that ceiling
+// (reached by about delivery 11) keeps a run stuck behind a sustained backend
+// outage from burning its redelivery budget in a tight loop. How long the
+// run survives is decided by the runtime's time-based budget against the
+// message's `expiresAt`, so the retention window (24h) is what bounds it, and
+// going above 900s here is pointless since VQS clamps every hop there.
 const HANDLER_ERROR_MAX_RETRY_AFTER_SECONDS = 900;
 const HANDLER_ERROR_RETRY_JITTER_RATIO = 0.25;
 
@@ -496,6 +504,9 @@ export function createQueue(config?: APIConfig): Queue {
     const { messageId } = await client.send(sanitizedQueueName, wrapper, {
       idempotencyKey: opts?.idempotencyKey,
       delaySeconds: opts?.delaySeconds,
+      retentionSeconds: opts?.delaySeconds
+        ? opts.delaySeconds + DEFAULT_MESSAGE_RETENTION_SECONDS
+        : undefined,
       headers: {
         ...getHeadersFromPayload(payload),
         ...opts?.headers,
@@ -541,6 +552,7 @@ export function createQueue(config?: APIConfig): Queue {
             messageId: MessageId.parse(metadata.messageId),
             attempt: metadata.deliveryCount,
             requestId,
+            expiresAt: metadata.expiresAt,
           });
 
           if (typeof result?.timeoutSeconds === 'number') {

--- a/packages/world/src/queue.ts
+++ b/packages/world/src/queue.ts
@@ -463,6 +463,13 @@ export interface Queue {
    * whose queue mints a fresh ID per delivery degrades gracefully: owner
    * redeliveries fall back to the delayed-backstop path instead of executing
    * immediately, adding recovery latency but never wedging or duplicating.
+   *
+   * `meta.expiresAt` is the instant the queue will drop this message without
+   * further delivery attempts (its retention / TTL). When present, the
+   * runtime's redelivery budget is time-based: it stops retrying and fails
+   * the run shortly before this instant so the failure is recorded rather
+   * than the message vanishing mid-retry. A queue with no message expiry
+   * omits it, and the runtime falls back to a fixed attempt count.
    */
   createQueueHandler(
     queueNamePrefix: QueuePrefix,
@@ -473,6 +480,7 @@ export interface Queue {
         queueName: ValidQueueName;
         messageId: MessageId;
         requestId?: string;
+        expiresAt?: Date;
       }
       // biome-ignore lint/suspicious/noConfusingVoidType: it is what it is
     ) => Promise<void | { timeoutSeconds: number }>


### PR DESCRIPTION
## Why

A run whose deliveries keep failing (backend outage, a deployment whose function crashes or times out) was retried for at most 48 queue deliveries. Under `world-vercel`'s backoff, which ramps to the queue's 900s per-hop cap by about delivery 11, that is roughly 9-10 hours, well short of the 24 hours the queue holds the message. The intent has always been to keep retrying for about the retention window and then record a failure, rather than to give up early or let the message silently expire.

## What

- `@workflow/world`: `createQueueHandler` meta gains optional `expiresAt`, the instant the queue drops the message.
- `@workflow/world-vercel`: forwards the queue's `expiresAt` to the handler. Delayed messages (sleep continuations) are sent with `retentionSeconds = delay + 24h`, so a message that fires after a 23h sleep still has a full window of retries instead of one hour. Before this, such a message had no attempt-cap failure path that could run before expiry, so a failing continuation stranded the run instead of failing it.
- `@workflow/core`: the budget check at the top of the handler is now `getExhaustedDeliveryBudget(meta)`. With `expiresAt`, it keeps retrying until the message is within one hour of expiring (the margin covers one more 900s hop plus handler startup), then fails the run with `MAX_DELIVERIES_EXCEEDED`. The attempt cap stays as a safety net against a queue that ignores the requested backoff (256 with expiry). Worlds that report no expiry (local, postgres, custom) keep the fixed 48-attempt budget unchanged. `WORKFLOW_MAX_QUEUE_DELIVERIES` still only lowers the cap.
- Docs: `runtime-tuning`, `errors-and-retries`, the World queue API reference, and `building-a-world` describe the time-based budget and the new meta field.

## Tests

- `constants.test.ts`: budget decisions for both queue kinds, the margin boundary, the safety-net cap, and the env override.
- `runtime.test.ts`: the handler keeps going past 48 attempts with 12h left, and records `run_failed` / `MAX_DELIVERIES_EXCEEDED` once the message is inside the margin.
- `world-vercel/queue.test.ts`: `expiresAt` reaches the handler; delayed sends carry the extended retention, undelayed sends do not.

## Notes for review

- Retention is only raised for delayed messages, so undelayed messages keep the queue default and there is no storage change for the common path.
- If the queue ever omitted the expiry header, `@vercel/queue` synthesizes `createdAt + 24h` per delivery, which would make the time budget never exhaust; the 256-attempt safety net bounds that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)