### PR TITLE
[core] Enforce the 8KiB attribute event-data limit before writes

### DIFF
--- a/.changeset/quiet-attributes-fit.md
+++ b/.changeset/quiet-attributes-fit.md
@@ -1,0 +1,7 @@
+---
+"@workflow/world": patch
+"@workflow/core": patch
+"@workflow/world-vercel": patch
+---
+
+Validate complete attribute event data against the World's 4KiB UTF-8 JSON limit before new writes, with catchable SDK errors and unchanged replay of persisted events.

--- a/.changeset/quiet-attributes-fit.md
+++ b/.changeset/quiet-attributes-fit.md
@@ -4,4 +4,4 @@
 "@workflow/world-vercel": patch
 ---
 
-Validate complete attribute event data against the World's 4KiB UTF-8 JSON limit before new writes, with catchable SDK errors and unchanged replay of persisted events.
+Validate complete attribute event data against the World's 8KiB UTF-8 JSON limit before new writes, with catchable SDK errors and unchanged replay of persisted events.

--- a/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
@@ -54,7 +54,7 @@ export async function cleanupAttributes() {
 
 Attribute keys must be 1-256 characters, values must be strings up to 256 bytes, and each run can have up to 64 attributes. Keys that start with `$` are reserved for framework and library code.
 
-Each call's complete `attr_set` event data must also fit in **4096 UTF-8 JSON bytes**. This includes the change keys and values, JSON escaping and structure, writer metadata (including the step ID and attempt for step calls), and the reserved-key option when enabled. It is not a limit on values alone. Split large updates into smaller calls; updates across multiple calls are not atomic and still share the 64-attribute per-run limit.
+Each call's complete `attr_set` event data must also fit in **8192 UTF-8 JSON bytes (8KiB)**. This includes the change keys and values, JSON escaping and structure, writer metadata (including the step ID and attempt for step calls), and the reserved-key option when enabled. It is not a limit on values alone. Split large updates into smaller calls; updates across multiple calls are not atomic and still share the 64-attribute per-run limit.
 
 Validation errors reject `setAttributes` with [`FatalError`](/docs/api-reference/workflow/fatal-error) before a new attribute write is attempted. Catch the error if the metadata is best-effort; an uncaught error fails the workflow or step. Previously persisted attribute events remain replayable.
 

--- a/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
+++ b/docs/content/docs/v5/api-reference/workflow/set-attributes.mdx
@@ -54,7 +54,9 @@ export async function cleanupAttributes() {
 
 Attribute keys must be 1-256 characters, values must be strings up to 256 bytes, and each run can have up to 64 attributes. Keys that start with `$` are reserved for framework and library code.
 
-Validation errors throw [`FatalError`](/docs/api-reference/workflow/fatal-error) and fail the run before an attribute write is attempted.
+Each call's complete `attr_set` event data must also fit in **4096 UTF-8 JSON bytes**. This includes the change keys and values, JSON escaping and structure, writer metadata (including the step ID and attempt for step calls), and the reserved-key option when enabled. It is not a limit on values alone. Split large updates into smaller calls; updates across multiple calls are not atomic and still share the 64-attribute per-run limit.
+
+Validation errors reject `setAttributes` with [`FatalError`](/docs/api-reference/workflow/fatal-error) before a new attribute write is attempted. Catch the error if the metadata is best-effort; an uncaught error fails the workflow or step. Previously persisted attribute events remain replayable.
 
 Calls from both workflow and step bodies append a native `attr_set` event, which the World materializes onto `run.attributes`. Workflow-originated events record a workflow writer; step-originated events record the originating step ID and attempt.
 

--- a/packages/core/src/attribute-changes.test.ts
+++ b/packages/core/src/attribute-changes.test.ts
@@ -27,9 +27,9 @@ describe('normalizeAttributeChanges', () => {
       options: {},
     },
   ])('counts $writer and $options only for attr_set', ({ writer, options }) => {
-    const changes = Array.from({ length: 15 }, (_, i) => ({
+    const changes = Array.from({ length: 30 }, (_, i) => ({
       key: `k${i}`.padEnd(240, 'k'),
-      value: '',
+      value: i === 1 ? 'x'.repeat(128) : '',
     }));
     const eventData = {
       changes,
@@ -39,7 +39,7 @@ describe('normalizeAttributeChanges', () => {
         : {}),
     };
     changes[0].value = 'x'.repeat(
-      4096 - Buffer.byteLength(JSON.stringify(eventData))
+      8192 - Buffer.byteLength(JSON.stringify(eventData))
     );
     const attrs = Object.fromEntries(
       changes.map(({ key, value }) => [key, value])
@@ -53,12 +53,12 @@ describe('normalizeAttributeChanges', () => {
       Buffer.byteLength(
         JSON.stringify({ ...eventData, changes: initialChanges })
       )
-    ).toBe(4097);
+    ).toBe(8193);
     expect(() => normalizeAttributeChanges(attrs, options, writer)).toThrow(
       FatalError
     );
     expect(() => normalizeAttributeChanges(attrs, options, writer)).toThrow(
-      /4096.*4097.*Split/
+      /8192.*8193.*Split/
     );
   });
 

--- a/packages/core/src/attribute-changes.test.ts
+++ b/packages/core/src/attribute-changes.test.ts
@@ -3,11 +3,65 @@ import {
   ATTRIBUTE_KEY_MAX_LENGTH,
   ATTRIBUTE_MAX_PER_RUN,
   ATTRIBUTE_VALUE_MAX_BYTES,
+  type EventOfType,
 } from '@workflow/world';
 import { describe, expect, it } from 'vitest';
 import { normalizeAttributeChanges } from './attribute-changes.js';
 
 describe('normalizeAttributeChanges', () => {
+  it.each<{
+    writer: EventOfType<'attr_set'>['eventData']['writer'];
+    options: { allowReservedAttributes?: boolean };
+  }>([
+    { writer: { type: 'workflow' }, options: {} },
+    {
+      writer: { type: 'workflow' },
+      options: { allowReservedAttributes: false },
+    },
+    {
+      writer: { type: 'workflow' },
+      options: { allowReservedAttributes: true },
+    },
+    {
+      writer: { type: 'step', stepId: 'step_actual_id', attempt: 12 },
+      options: {},
+    },
+  ])('counts $writer and $options only for attr_set', ({ writer, options }) => {
+    const changes = Array.from({ length: 15 }, (_, i) => ({
+      key: `k${i}`.padEnd(240, 'k'),
+      value: '',
+    }));
+    const eventData = {
+      changes,
+      writer,
+      ...(options.allowReservedAttributes
+        ? { allowReservedAttributes: true }
+        : {}),
+    };
+    changes[0].value = 'x'.repeat(
+      4096 - Buffer.byteLength(JSON.stringify(eventData))
+    );
+    const attrs = Object.fromEntries(
+      changes.map(({ key, value }) => [key, value])
+    );
+    expect(normalizeAttributeChanges(attrs, options, writer)).toEqual(changes);
+
+    attrs[changes[0].key] += 'x';
+    // Initial run attributes have no writer and retain only per-attribute limits.
+    const initialChanges = normalizeAttributeChanges(attrs, options);
+    expect(
+      Buffer.byteLength(
+        JSON.stringify({ ...eventData, changes: initialChanges })
+      )
+    ).toBe(4097);
+    expect(() => normalizeAttributeChanges(attrs, options, writer)).toThrow(
+      FatalError
+    );
+    expect(() => normalizeAttributeChanges(attrs, options, writer)).toThrow(
+      /4096.*4097.*Split/
+    );
+  });
+
   it('converts a record into ordered changes, mapping undefined to null', () => {
     expect(
       normalizeAttributeChanges({ phase: 'init', stale: undefined })

--- a/packages/core/src/attribute-changes.ts
+++ b/packages/core/src/attribute-changes.ts
@@ -1,13 +1,16 @@
 import { FatalError } from '@workflow/errors';
+import type { EventOfType } from '@workflow/world';
 import {
   type AttributeChange,
   AttributeValidationError,
   validateAttributeChanges,
+  validateAttributeEventDataSize,
 } from '@workflow/world/attributes-validation';
 
 export function normalizeAttributeChanges(
   attrs: Record<string, string | undefined>,
-  options: { allowReservedAttributes?: boolean } = {}
+  options: { allowReservedAttributes?: boolean } = {},
+  writer?: EventOfType<'attr_set'>['eventData']['writer']
 ): AttributeChange[] {
   if (attrs === null || typeof attrs !== 'object' || Array.isArray(attrs)) {
     throw new FatalError(
@@ -28,6 +31,14 @@ export function normalizeAttributeChanges(
   const allowReservedAttributes = options.allowReservedAttributes === true;
   try {
     validateAttributeChanges(changes, { allowReservedAttributes });
+    // Initial run attributes use this normalizer too, but are not attr_set.
+    if (writer) {
+      validateAttributeEventDataSize({
+        changes,
+        writer,
+        ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
+      });
+    }
   } catch (err) {
     if (err instanceof AttributeValidationError) {
       throw new FatalError(err.message);

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -441,7 +441,7 @@ describe('fresh attribute validation', () => {
         async function setAttributes(changes) { await dispatcher(changes); }
         async function workflow() {
           var pendingStep = step();
-          var changes = Array.from({ length: 16 }, function(_, i) {
+          var changes = Array.from({ length: 32 }, function(_, i) {
             return { key: "key" + i, value: "x".repeat(256) };
           });
           var attributePromise = ${asyncWrapper ? 'setAttributes' : 'dispatcher'}(changes);
@@ -493,17 +493,17 @@ describe('fresh attribute validation', () => {
     false,
     true,
   ])('checks the exact UTF-8 eventData boundary (reserved flag: %s)', async (allowReservedAttributes) => {
-    const changes = Array.from({ length: 15 }, (_, i) => ({
+    const changes = Array.from({ length: 29 }, (_, i) => ({
       key: `key${i}`,
-      value: i === 14 ? '' : '\u00e9'.repeat(128),
+      value: i === 28 ? '' : '\u00e9'.repeat(128),
     }));
     const eventData = {
       changes,
       writer: { type: 'workflow' },
       ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
     };
-    changes[14].value = 'x'.repeat(
-      4096 - new TextEncoder().encode(JSON.stringify(eventData)).length
+    changes[28].value = 'x'.repeat(
+      8192 - new TextEncoder().encode(JSON.stringify(eventData)).length
     );
     const run = makeRun();
     const options = {
@@ -532,7 +532,7 @@ describe('fresh attribute validation', () => {
       changes,
     });
 
-    changes[14].value += 'x';
+    changes[28].value += 'x';
     const rejected = await runQuickJSWorkflow({
       ...options,
       events: [runCreatedEvent(run, [changes])],
@@ -540,7 +540,7 @@ describe('fresh attribute validation', () => {
     assert(rejected.completed);
     expect(unwrapResult(rejected.completed.result)).toEqual({
       name: 'FatalError',
-      message: expect.stringContaining('received 4097 bytes'),
+      message: expect.stringContaining('received 8193 bytes'),
       isError: true,
     });
     expect(rejected.completed.drainOperations).toBeUndefined();
@@ -548,7 +548,7 @@ describe('fresh attribute validation', () => {
 
   it('preserves oversized history and IDs while rejecting fresh writes on replay and live continuation', async () => {
     const run = makeRun();
-    const oversized = Array.from({ length: 16 }, (_, i) => ({
+    const oversized = Array.from({ length: 32 }, (_, i) => ({
       key: `key${i}`,
       value: 'x'.repeat(256),
     }));

--- a/packages/core/src/runtime/quickjs-runtime.test.ts
+++ b/packages/core/src/runtime/quickjs-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   __peekBaselineEntryForTests,
   BASELINE_BUNDLE_FILENAME,
   runQuickJSWorkflow,
+  startQuickJSWorkflow,
 } from './quickjs-runtime.js';
 
 /** Helper to deserialize the format-prefixed result bytes */
@@ -424,6 +425,202 @@ describe('runQuickJSWorkflow', () => {
       ],
     });
     expect(unwrapResult(r2.completed!.result)).toBe('caught: boom');
+  });
+});
+
+describe('fresh attribute validation', () => {
+  it.each([
+    false,
+    true,
+  ])('keeps validation ahead of step results on replay (async wrapper: %s)', async (asyncWrapper) => {
+    const run = makeRun();
+    const options = {
+      workflowCode: `
+        var step = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("step//test//race");
+        var dispatcher = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+        async function setAttributes(changes) { await dispatcher(changes); }
+        async function workflow() {
+          var pendingStep = step();
+          var changes = Array.from({ length: 16 }, function(_, i) {
+            return { key: "key" + i, value: "x".repeat(256) };
+          });
+          var attributePromise = ${asyncWrapper ? 'setAttributes' : 'dispatcher'}(changes);
+          var winner;
+          try { winner = await Promise.race([pendingStep, attributePromise]); }
+          catch (error) { winner = { name: error.name, fatal: error.fatal }; }
+          await pendingStep;
+          return winner;
+        }
+        globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+      `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: run,
+    };
+    const input = runCreatedEvent(run);
+    const fresh = await startQuickJSWorkflow({ ...options, events: [input] });
+    try {
+      assert(fresh.result.suspended);
+      expect(fresh.result.suspended.pendingOperations).toHaveLength(1);
+      expect(fresh.result.suspended.pendingOperations[0].type).toBe('step');
+      const stepCompleted = {
+        eventId: 'evnt_race_step',
+        runId: run.runId,
+        eventType: 'step_completed' as const,
+        correlationId:
+          fresh.result.suspended.pendingOperations[0].correlationId,
+        eventData: { result: serialize('step won') },
+        createdAt: run.createdAt,
+      };
+      const continued = await fresh.continueWithEvents([stepCompleted]);
+      const replayed = await runQuickJSWorkflow({
+        ...options,
+        events: [input, stepCompleted],
+      });
+      for (const result of [continued, replayed]) {
+        assert(result.completed);
+        expect(unwrapResult(result.completed.result)).toEqual({
+          name: 'FatalError',
+          fatal: true,
+        });
+        expect(result.completed.drainOperations).toBeUndefined();
+      }
+    } finally {
+      fresh.dispose();
+    }
+  });
+
+  it.each([
+    false,
+    true,
+  ])('checks the exact UTF-8 eventData boundary (reserved flag: %s)', async (allowReservedAttributes) => {
+    const changes = Array.from({ length: 15 }, (_, i) => ({
+      key: `key${i}`,
+      value: i === 14 ? '' : '\u00e9'.repeat(128),
+    }));
+    const eventData = {
+      changes,
+      writer: { type: 'workflow' },
+      ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
+    };
+    changes[14].value = 'x'.repeat(
+      4096 - new TextEncoder().encode(JSON.stringify(eventData)).length
+    );
+    const run = makeRun();
+    const options = {
+      workflowCode: `
+          async function workflow(changes) {
+            try {
+              await globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")](changes, {
+                allowReservedAttributes: ${allowReservedAttributes},
+              });
+            } catch (error) {
+              return { name: error.name, message: error.message, isError: error instanceof Error };
+            }
+          }
+          globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+        `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: run,
+    };
+    const accepted = await runQuickJSWorkflow({
+      ...options,
+      events: [runCreatedEvent(run, [changes])],
+    });
+    expect(accepted.suspended?.pendingOperations).toHaveLength(1);
+    expect(accepted.suspended?.pendingOperations[0]).toMatchObject({
+      type: 'attribute',
+      changes,
+    });
+
+    changes[14].value += 'x';
+    const rejected = await runQuickJSWorkflow({
+      ...options,
+      events: [runCreatedEvent(run, [changes])],
+    });
+    assert(rejected.completed);
+    expect(unwrapResult(rejected.completed.result)).toEqual({
+      name: 'FatalError',
+      message: expect.stringContaining('received 4097 bytes'),
+      isError: true,
+    });
+    expect(rejected.completed.drainOperations).toBeUndefined();
+  });
+
+  it('preserves oversized history and IDs while rejecting fresh writes on replay and live continuation', async () => {
+    const run = makeRun();
+    const oversized = Array.from({ length: 16 }, (_, i) => ({
+      key: `key${i}`,
+      value: 'x'.repeat(256),
+    }));
+    const small = [{ key: 'status', value: 'ok' }];
+    const options = {
+      workflowCode: `
+        var setAttributes = globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")];
+        async function workflow(first, oversized) {
+          var caught = 0;
+          try { await setAttributes(first); } catch (error) { caught++; }
+          await setAttributes([{ key: 'status', value: 'ok' }]);
+          try { await setAttributes(oversized); } catch (error) { caught++; }
+          return caught;
+        }
+        globalThis.__private_workflows.set("workflow//test//workflow", workflow);
+      `,
+      workflowId: 'workflow//test//workflow',
+      workflowRun: run,
+    };
+    const control = await runQuickJSWorkflow({
+      ...options,
+      events: [runCreatedEvent(run, [small, oversized])],
+    });
+    assert(control.suspended);
+    const historical = {
+      eventId: 'evnt_old_attr',
+      runId: run.runId,
+      eventType: 'attr_set' as const,
+      correlationId: control.suspended.pendingOperations[0].correlationId,
+      eventData: { changes: oversized, writer: { type: 'workflow' as const } },
+      createdAt: run.createdAt,
+    };
+    const input = runCreatedEvent(run, [oversized, oversized]);
+    const replayed = await runQuickJSWorkflow({
+      ...options,
+      events: [input, historical],
+    });
+    const fresh = await startQuickJSWorkflow({ ...options, events: [input] });
+    try {
+      assert(fresh.result.suspended);
+      expect(fresh.result.suspended.pendingOperations).toHaveLength(1);
+      expect(fresh.result.suspended).toEqual(replayed.suspended);
+      const nextEvent = {
+        ...historical,
+        eventId: 'evnt_next_attr',
+        correlationId:
+          fresh.result.suspended.pendingOperations[0].correlationId,
+        eventData: { changes: small, writer: { type: 'workflow' as const } },
+      };
+      expect(nextEvent.correlationId).not.toBe(historical.correlationId);
+      const continued = await fresh.continueWithEvents([nextEvent]);
+      assert(continued.completed);
+      expect(unwrapResult(continued.completed.result)).toBe(2);
+      expect(continued.completed.drainOperations).toBeUndefined();
+
+      for (const history of [
+        [input, nextEvent],
+        [input, historical, nextEvent],
+      ]) {
+        const result = await runQuickJSWorkflow({
+          ...options,
+          events: history,
+        });
+        assert(result.completed);
+        expect(unwrapResult(result.completed.result)).toBe(
+          history.length === 2 ? 2 : 1
+        );
+        expect(result.completed.drainOperations).toBeUndefined();
+      }
+    } finally {
+      fresh.dispose();
+    }
   });
 });
 

--- a/packages/core/src/runtime/quickjs-runtime.ts
+++ b/packages/core/src/runtime/quickjs-runtime.ts
@@ -38,6 +38,11 @@ import {
   type WorkflowRun,
   type WorldCapabilities,
 } from '@workflow/world';
+import {
+  type AttributeChange,
+  AttributeValidationError,
+  validateAttributeEventDataSize,
+} from '@workflow/world/attributes-validation';
 import * as nanoid from 'nanoid';
 import {
   type ExtensionDescriptor,
@@ -160,7 +165,7 @@ export interface PendingAttribute {
   type: 'attribute';
   correlationId: string;
   /** Normalized attribute changes (plain JSON-able objects) */
-  changes: unknown[];
+  changes: AttributeChange[];
   allowReservedAttributes?: boolean;
   /** Whether an attr_set event already exists for this write */
   hasCreatedEvent: boolean;
@@ -814,18 +819,28 @@ globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")] = function(options) {
 };
 
 // setAttributes — attaches plaintext metadata to the current run.
-// Validation happens in library code (normalizeAttributeChanges) before
+// Per-change validation happens in library code (normalizeAttributeChanges) before
 // this dispatcher is invoked, so "changes" is already normalized. The
 // returned promise resolves when the matching attr_set event is
 // observed during event processing — mirroring the node:vm engine's
 // createSetAttributes (attribute-dispatcher.ts).
+// Baseline hydrate placeholder; module-scope calls draw a ULID and disable snapshots.
+globalThis.__validateAttributeWrite = function() {};
 globalThis[Symbol.for("WORKFLOW_SET_ATTRIBUTES")] = function(changes, options) {
   var correlationId = "attr_" + globalThis.__generateUlid();
+  var allowReservedAttributes = !!(options && options.allowReservedAttributes);
+  var validationError = globalThis.__validateAttributeWrite(correlationId, changes, allowReservedAttributes);
+  if (validationError !== undefined) {
+    var error = new Error(validationError);
+    error.name = "FatalError";
+    error.fatal = true;
+    return Promise.reject(error);
+  }
   globalThis.__pending.push({
     type: "attribute",
     correlationId: correlationId,
     changes: changes,
-    allowReservedAttributes: !!(options && options.allowReservedAttributes),
+    allowReservedAttributes: allowReservedAttributes,
     hasCreatedEvent: false,
   });
   return new Promise(function(resolve, reject) {
@@ -1556,6 +1571,39 @@ export async function startQuickJSWorkflow(
     // replays.
     serde.installProcessEnv(process.env);
 
+    // Validate before enqueueing so promise races observe the same rejection
+    // order on replay. Existing attr_set IDs retain their original semantics.
+    const historicalAttributeIds = new Set<string>();
+    for (const event of events) {
+      if (event.eventType === 'attr_set' && event.correlationId !== undefined) {
+        historicalAttributeIds.add(event.correlationId);
+      }
+    }
+    {
+      using validateAttributeWrite = vm.newFunction(
+        '__validateAttributeWrite',
+        (correlationId, changes, allowReservedAttributes) => {
+          if (historicalAttributeIds.has(correlationId.toString())) {
+            return vm.undefined;
+          }
+          try {
+            validateAttributeEventDataSize({
+              changes: vm.dump(changes) as AttributeChange[],
+              writer: { type: 'workflow' },
+              ...(allowReservedAttributes.toBoolean()
+                ? { allowReservedAttributes: true }
+                : {}),
+            });
+          } catch (err) {
+            if (!(err instanceof AttributeValidationError)) throw err;
+            return vm.newString(err.message);
+          }
+          return vm.undefined;
+        }
+      );
+      vm.setProp(vm.global, '__validateAttributeWrite', validateAttributeWrite);
+    }
+
     // Execute the workflow bundle: use the workflowId as the eval filename
     // so QuickJS stack traces reference the workflow name, enabling source map
     // remapping by remapErrorStack (which matches frames by filename).
@@ -1705,6 +1753,12 @@ export async function startQuickJSWorkflow(
       let maxIterations = 100;
       let madeProgress: boolean;
       do {
+        // Propagate local rejections through async wrappers before replay can
+        // resolve a competing promise from history.
+        let batch: number;
+        do {
+          batch = vm.executePendingJobs();
+        } while (batch > 0);
         madeProgress = await processEvents(
           vm,
           serde,
@@ -1712,7 +1766,6 @@ export async function startQuickJSWorkflow(
           advanceClock,
           options.encryptionKey
         );
-        let batch: number;
         do {
           batch = vm.executePendingJobs();
           if (batch > 0) madeProgress = true;
@@ -1739,6 +1792,7 @@ export async function startQuickJSWorkflow(
       serde,
       interruptBudget,
       advanceClock,
+      historicalAttributeIds,
       options.encryptionKey
     );
   }
@@ -1769,6 +1823,7 @@ function makeLiveSession(
   serde: QuickJSSerde,
   interruptBudget: InterruptBudget,
   advanceClock: (ms: number) => void,
+  historicalAttributeIds: Set<string>,
   encryptionKey?: DecryptionKey
 ): QuickJSWorkflowSession {
   const result = checkWorkflowState(vm, serde, { keepAliveOnSuspend: true });
@@ -1787,10 +1842,23 @@ function makeLiveSession(
       // Fresh execution burst: the interrupt budget bounds VM compute,
       // not wall time spent waiting on inline steps between bursts.
       interruptBudget.start = Date.now();
+      for (const event of newEvents) {
+        if (
+          event.eventType === 'attr_set' &&
+          event.correlationId !== undefined
+        ) {
+          historicalAttributeIds.add(event.correlationId);
+        }
+      }
 
       let maxIterations = 100;
       let madeProgress: boolean;
       do {
+        // Match initial replay: already-queued jobs precede event delivery.
+        let batch: number;
+        do {
+          batch = vm.executePendingJobs();
+        } while (batch > 0);
         madeProgress = await processEvents(
           vm,
           serde,
@@ -1798,7 +1866,6 @@ function makeLiveSession(
           advanceClock,
           encryptionKey
         );
-        let batch: number;
         do {
           batch = vm.executePendingJobs();
           if (batch > 0) madeProgress = true;

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -192,9 +192,9 @@ describe('setAttributes (host-side)', () => {
     const context = stepContext();
     context.stepMetadata.stepId = 'step_actual_id_longer_than_placeholder';
     context.stepMetadata.attempt = 12;
-    const changes = Array.from({ length: 15 }, (_, i) => ({
+    const changes = Array.from({ length: 30 }, (_, i) => ({
       key: `k${i}`.padEnd(240, 'k'),
-      value: '',
+      value: i === 1 ? 'x'.repeat(128) : '',
     }));
     const eventData = {
       changes,
@@ -206,7 +206,7 @@ describe('setAttributes (host-side)', () => {
       ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
     };
     changes[0].value = 'x'.repeat(
-      4096 - Buffer.byteLength(JSON.stringify(eventData))
+      8192 - Buffer.byteLength(JSON.stringify(eventData))
     );
     const attrs = Object.fromEntries(
       changes.map(({ key, value }) => [key, value])

--- a/packages/core/src/set-attributes.test.ts
+++ b/packages/core/src/set-attributes.test.ts
@@ -179,4 +179,53 @@ describe('setAttributes (host-side)', () => {
     ).rejects.toBeInstanceOf(FatalError);
     expect(create).not.toHaveBeenCalled();
   });
+
+  it.each([
+    false,
+    true,
+  ])('counts the actual step writer and reserved flag (%s) before create', async (allowReservedAttributes) => {
+    const create = vi.fn().mockResolvedValue({});
+    globals[WORLD_CACHE] = {
+      specVersion: SPEC_VERSION_CURRENT,
+      events: { create },
+    };
+    const context = stepContext();
+    context.stepMetadata.stepId = 'step_actual_id_longer_than_placeholder';
+    context.stepMetadata.attempt = 12;
+    const changes = Array.from({ length: 15 }, (_, i) => ({
+      key: `k${i}`.padEnd(240, 'k'),
+      value: '',
+    }));
+    const eventData = {
+      changes,
+      writer: {
+        type: 'step',
+        stepId: context.stepMetadata.stepId,
+        attempt: 12,
+      },
+      ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
+    };
+    changes[0].value = 'x'.repeat(
+      4096 - Buffer.byteLength(JSON.stringify(eventData))
+    );
+    const attrs = Object.fromEntries(
+      changes.map(({ key, value }) => [key, value])
+    );
+    await contextStorage.run(context, () =>
+      setAttributes(attrs, { allowReservedAttributes })
+    );
+    expect(create).toHaveBeenCalledWith(
+      'run_123',
+      expect.objectContaining({ eventData })
+    );
+    create.mockClear();
+
+    attrs[changes[0].key] += 'x';
+    await expect(
+      contextStorage.run(context, () =>
+        setAttributes(attrs, { allowReservedAttributes })
+      )
+    ).rejects.toThrow(FatalError);
+    expect(create).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/set-attributes.ts
+++ b/packages/core/src/set-attributes.ts
@@ -29,7 +29,12 @@ export async function setAttributes(
     );
   }
 
-  const changes = normalizeAttributeChanges(attrs, options);
+  const writer = {
+    type: 'step' as const,
+    stepId: store.stepMetadata.stepId,
+    attempt: store.stepMetadata.attempt,
+  };
+  const changes = normalizeAttributeChanges(attrs, options, writer);
   if (changes.length === 0) return;
 
   // Turbo optimistic start runs the step body before the backgrounded
@@ -56,11 +61,7 @@ export async function setAttributes(
     specVersion: SPEC_VERSION_CURRENT,
     eventData: {
       changes,
-      writer: {
-        type: 'step',
-        stepId: store.stepMetadata.stepId,
-        attempt: store.stepMetadata.attempt,
-      },
+      writer,
       ...(options.allowReservedAttributes === true
         ? { allowReservedAttributes: true }
         : {}),

--- a/packages/core/src/workflow/attribute-dispatcher.test.ts
+++ b/packages/core/src/workflow/attribute-dispatcher.test.ts
@@ -1,0 +1,143 @@
+import { FatalError } from '@workflow/errors';
+import type { Event, EventOfType } from '@workflow/world';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkflowSuspension } from '../global.js';
+import {
+  CORR_IDS,
+  runWithDiscontinuation,
+  setupWorkflowContext,
+} from '../test-support/orchestrator-context.js';
+import { createSetAttributes } from './attribute-dispatcher.js';
+import { createSleep } from './sleep.js';
+
+function attributeData(bytes: number, allowReservedAttributes: boolean) {
+  const eventData = {
+    changes: Array.from({ length: 15 }, (_, i) => ({
+      key: `k${i}`.padEnd(240, 'k'),
+      value: '',
+    })),
+    writer: { type: 'workflow' as const },
+    ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
+  };
+  eventData.changes[0].value = 'x'.repeat(
+    bytes - Buffer.byteLength(JSON.stringify(eventData))
+  );
+  return eventData;
+}
+
+describe.each([
+  false,
+  true,
+])('attribute dispatch (reserved flag %s)', (allowReservedAttributes) => {
+  const options = { allowReservedAttributes };
+
+  it('suspends to persist an event exactly at the byte limit', async () => {
+    const ctx = setupWorkflowContext([]);
+    const setAttributes = createSetAttributes(ctx);
+    const { error } = await runWithDiscontinuation(ctx, () =>
+      setAttributes(
+        attributeData(4096, allowReservedAttributes).changes,
+        options
+      )
+    );
+    expect(WorkflowSuspension.is(error)).toBe(true);
+    expect(ctx.invocationsQueue.size).toBe(1);
+  });
+
+  it('rejects an oversized new write catchably without leaving a pending event', async () => {
+    const ctx = setupWorkflowContext([]);
+    const setAttributes = createSetAttributes(ctx);
+    let caught: unknown;
+    const { result, error } = await runWithDiscontinuation(ctx, async () => {
+      try {
+        await setAttributes(
+          attributeData(4097, allowReservedAttributes).changes,
+          options
+        );
+      } catch (cause) {
+        caught = cause;
+      }
+      return 'continued';
+    });
+    expect(caught).toBeInstanceOf(FatalError);
+    expect((caught as Error).message).toMatch(/4096.*4097.*Split/);
+    expect(error).toBeUndefined();
+    expect(result).toBe('continued');
+    expect(ctx.invocationsQueue.size).toBe(0);
+  });
+
+  it('replays an oversized event persisted before write validation was added', async () => {
+    const eventData = attributeData(4097, allowReservedAttributes);
+    const event: EventOfType<'attr_set'> = {
+      eventType: 'attr_set',
+      eventId: 'evnt_0',
+      runId: 'wrun_test',
+      correlationId: `attr_${CORR_IDS[0]}`,
+      createdAt: new Date(),
+      eventData,
+    };
+    const ctx = setupWorkflowContext([event]);
+    const setAttributes = createSetAttributes(ctx);
+    const { error } = await runWithDiscontinuation(ctx, () =>
+      setAttributes(eventData.changes, options)
+    );
+    expect(error).toBeUndefined();
+    expect(ctx.invocationsQueue.size).toBe(0);
+    expect(ctx.eventsConsumer.strandedEvent).toBeUndefined();
+  });
+
+  it('replays a caught rejection before a recorded wait without diverging', async () => {
+    const resumeAt = new Date('2099-01-01T00:00:00.000Z');
+    const history = ['wait_created', 'wait_completed'].map((eventType, i) => ({
+      eventType,
+      eventId: `evnt_${i}`,
+      runId: 'wrun_test',
+      correlationId: `wait_${CORR_IDS[1]}`,
+      createdAt: new Date(),
+      eventData: { resumeAt },
+    })) as Event[];
+    const ctx = setupWorkflowContext(history);
+    const setAttributes = createSetAttributes(ctx);
+    const sleep = createSleep(ctx);
+    const { result, error } = await runWithDiscontinuation(ctx, async () => {
+      await setAttributes(
+        attributeData(4097, allowReservedAttributes).changes,
+        options
+      ).catch(() => {});
+      await sleep(resumeAt);
+      return 'continued';
+    });
+    expect(error).toBeUndefined();
+    expect(result).toBe('continued');
+    expect(ctx.eventsConsumer.strandedEvent).toBeUndefined();
+  });
+
+  it('does not consume a log slot when rejecting before a retained resume', async () => {
+    const ctx = setupWorkflowContext([]);
+    const setAttributes = createSetAttributes(ctx);
+    const changes = [{ key: 'phase', value: 'recovered' }];
+    let continued = false;
+    const { error } = await runWithDiscontinuation(ctx, async () => {
+      await setAttributes(
+        attributeData(4097, allowReservedAttributes).changes,
+        options
+      ).catch(() => {});
+      await setAttributes(changes);
+      continued = true;
+    });
+    expect(WorkflowSuspension.is(error)).toBe(true);
+    expect(ctx.eventsConsumer.eventIndex).toBe(0);
+    ctx.eventsConsumer.append([
+      {
+        eventType: 'attr_set',
+        eventId: 'evnt_0',
+        runId: 'wrun_test',
+        correlationId: `attr_${CORR_IDS[1]}`,
+        createdAt: new Date(),
+        eventData: { changes, writer: { type: 'workflow' } },
+      },
+    ]);
+    await vi.waitFor(() => expect(continued).toBe(true));
+    expect(ctx.invocationsQueue.size).toBe(0);
+  });
+});

--- a/packages/core/src/workflow/attribute-dispatcher.test.ts
+++ b/packages/core/src/workflow/attribute-dispatcher.test.ts
@@ -12,9 +12,9 @@ import { createSleep } from './sleep.js';
 
 function attributeData(bytes: number, allowReservedAttributes: boolean) {
   const eventData = {
-    changes: Array.from({ length: 15 }, (_, i) => ({
+    changes: Array.from({ length: 30 }, (_, i) => ({
       key: `k${i}`.padEnd(240, 'k'),
-      value: '',
+      value: i === 1 ? 'x'.repeat(128) : '',
     })),
     writer: { type: 'workflow' as const },
     ...(allowReservedAttributes ? { allowReservedAttributes: true } : {}),
@@ -36,7 +36,7 @@ describe.each([
     const setAttributes = createSetAttributes(ctx);
     const { error } = await runWithDiscontinuation(ctx, () =>
       setAttributes(
-        attributeData(4096, allowReservedAttributes).changes,
+        attributeData(8192, allowReservedAttributes).changes,
         options
       )
     );
@@ -51,7 +51,7 @@ describe.each([
     const { result, error } = await runWithDiscontinuation(ctx, async () => {
       try {
         await setAttributes(
-          attributeData(4097, allowReservedAttributes).changes,
+          attributeData(8193, allowReservedAttributes).changes,
           options
         );
       } catch (cause) {
@@ -60,14 +60,14 @@ describe.each([
       return 'continued';
     });
     expect(caught).toBeInstanceOf(FatalError);
-    expect((caught as Error).message).toMatch(/4096.*4097.*Split/);
+    expect((caught as Error).message).toMatch(/8192.*8193.*Split/);
     expect(error).toBeUndefined();
     expect(result).toBe('continued');
     expect(ctx.invocationsQueue.size).toBe(0);
   });
 
   it('replays an oversized event persisted before write validation was added', async () => {
-    const eventData = attributeData(4097, allowReservedAttributes);
+    const eventData = attributeData(8193, allowReservedAttributes);
     const event: EventOfType<'attr_set'> = {
       eventType: 'attr_set',
       eventId: 'evnt_0',
@@ -101,7 +101,7 @@ describe.each([
     const sleep = createSleep(ctx);
     const { result, error } = await runWithDiscontinuation(ctx, async () => {
       await setAttributes(
-        attributeData(4097, allowReservedAttributes).changes,
+        attributeData(8193, allowReservedAttributes).changes,
         options
       ).catch(() => {});
       await sleep(resumeAt);
@@ -119,7 +119,7 @@ describe.each([
     let continued = false;
     const { error } = await runWithDiscontinuation(ctx, async () => {
       await setAttributes(
-        attributeData(4097, allowReservedAttributes).changes,
+        attributeData(8193, allowReservedAttributes).changes,
         options
       ).catch(() => {});
       await setAttributes(changes);

--- a/packages/core/src/workflow/attribute-dispatcher.ts
+++ b/packages/core/src/workflow/attribute-dispatcher.ts
@@ -1,6 +1,10 @@
-import { ReplayDivergenceError } from '@workflow/errors';
+import { FatalError, ReplayDivergenceError } from '@workflow/errors';
 import { withResolvers } from '@workflow/utils';
 import type { AttributeChange } from '@workflow/world';
+import {
+  AttributeValidationError,
+  validateAttributeEventDataSize,
+} from '@workflow/world/attributes-validation';
 import { EventConsumerResult } from '../events-consumer.js';
 import type { AttributeInvocationQueueItem } from '../global.js';
 import {
@@ -15,6 +19,25 @@ export function createSetAttributes(ctx: WorkflowOrchestratorContext) {
   ): Promise<void> {
     const { promise, resolve } = withResolvers<void>();
     const correlationId = `attr_${ctx.generateUlid()}`;
+    try {
+      validateAttributeEventDataSize({
+        changes,
+        writer: { type: 'workflow' },
+        ...(options.allowReservedAttributes === true
+          ? { allowReservedAttributes: true }
+          : {}),
+      });
+    } catch (error) {
+      if (!(error instanceof AttributeValidationError)) throw error;
+      // Preserve old local-world histories, but reject new writes now so a
+      // catch path runs before unrelated replay events (including races).
+      const persisted = ctx.eventsConsumer.events.some(
+        (event) =>
+          event.eventType === 'attr_set' &&
+          event.correlationId === correlationId
+      );
+      if (!persisted) throw new FatalError(error.message);
+    }
     const queueItem: AttributeInvocationQueueItem = {
       type: 'attribute',
       correlationId,

--- a/packages/core/src/workflow/set-attributes.ts
+++ b/packages/core/src/workflow/set-attributes.ts
@@ -37,6 +37,10 @@ export interface SetAttributesOptions {
  * empty record is a no-op. `value: undefined` removes the key from the
  * run's attribute map.
  *
+ * Each call's complete eventData must fit in 4096 UTF-8 JSON bytes, including
+ * keys, escaped values, and writer metadata. Split larger updates into smaller
+ * calls; the per-value and per-run attribute limits still apply.
+ *
  * **Reserved namespace.** Keys starting with `$` are reserved for
  * framework/library code (telemetry, agent metadata, etc.). User code
  * trying to write a `$`-prefixed key throws `FatalError`. If you are a

--- a/packages/core/src/workflow/set-attributes.ts
+++ b/packages/core/src/workflow/set-attributes.ts
@@ -37,7 +37,7 @@ export interface SetAttributesOptions {
  * empty record is a no-op. `value: undefined` removes the key from the
  * run's attribute map.
  *
- * Each call's complete eventData must fit in 4096 UTF-8 JSON bytes, including
+ * Each call's complete eventData must fit in 8192 UTF-8 JSON bytes, including
  * keys, escaped values, and writer metadata. Split larger updates into smaller
  * calls; the per-value and per-run attribute limits still apply.
  *

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -796,7 +796,7 @@ describe('attr_set eventData size limit', () => {
     // Each value stays within 256 bytes; the aggregate JSON reaches the cap.
     const eventData = {
       changes: [
-        ...Array.from({ length: 14 }, (_, i) => ({
+        ...Array.from({ length: 28 }, (_, i) => ({
           key: `key${i}`,
           value: '\u00e9'.repeat(128),
         })),
@@ -816,21 +816,21 @@ describe('attr_set eventData size limit', () => {
     } satisfies AnyEventRequest;
   }
 
-  it('accepts exactly 4096 UTF-8 JSON bytes and rejects 4097 including writer metadata', () => {
-    const accepted = attributeEvent(4096);
-    expect(Buffer.byteLength(JSON.stringify(accepted.eventData))).toBe(4096);
+  it('accepts exactly 8192 UTF-8 JSON bytes and rejects 8193 including writer metadata', () => {
+    const accepted = attributeEvent(8192);
+    expect(Buffer.byteLength(JSON.stringify(accepted.eventData))).toBe(8192);
     expect(splitEventDataForV4(accepted)).toEqual({
       payload: undefined,
       meta: accepted.eventData,
     });
 
-    const rejected = attributeEvent(4097);
-    expect(Buffer.byteLength(JSON.stringify(rejected.eventData))).toBe(4097);
+    const rejected = attributeEvent(8193);
+    expect(Buffer.byteLength(JSON.stringify(rejected.eventData))).toBe(8193);
     expect(() => splitEventDataForV4(rejected)).toThrow(
       expect.objectContaining({
         name: 'WorkflowWorldError',
         status: 400,
-        message: expect.stringContaining('received 4097 bytes'),
+        message: expect.stringContaining('received 8193 bytes'),
       })
     );
   });
@@ -862,7 +862,7 @@ describe('attr_set eventData size limit', () => {
       expect(resolveWsTransport('wrun_1', config)?.transport).toBe(transport);
       const result = createWorkflowRunEvent(
         'wrun_1',
-        attributeEvent(4097),
+        attributeEvent(8193),
         undefined,
         config
       ).catch((error) => error);
@@ -872,7 +872,7 @@ describe('attr_set eventData size limit', () => {
       expect(error).toBeInstanceOf(WorkflowWorldError);
       expect(error).toMatchObject({
         status: 400,
-        message: expect.stringContaining('received 4097 bytes'),
+        message: expect.stringContaining('received 8193 bytes'),
       });
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(requestSpy).not.toHaveBeenCalled();
@@ -888,7 +888,7 @@ describe('attr_set eventData size limit', () => {
   });
 
   it('still parses persisted attr_set events larger than the write limit', () => {
-    const event = attributeEvent(4097);
+    const event = attributeEvent(8193);
     expect(
       EventSchema.parse({
         ...event,

--- a/packages/world-vercel/src/events.test.ts
+++ b/packages/world-vercel/src/events.test.ts
@@ -1,7 +1,11 @@
 import { Buffer } from 'node:buffer';
 import { gzipSync } from 'node:zlib';
 import { WorkflowWorldError } from '@workflow/errors';
-import type { AnyEventRequest, CreateEventParams } from '@workflow/world';
+import {
+  type AnyEventRequest,
+  type CreateEventParams,
+  EventSchema,
+} from '@workflow/world';
 import { decode, encode } from 'cbor-x';
 import { ulid } from 'ulid';
 import { MockAgent } from 'undici';
@@ -14,6 +18,11 @@ import {
 import { encodeFrame, V4_FRAME_CONTENT_TYPE } from './frames.js';
 import { encode as encodeRunId, REGION_IDS } from './run-id/index.js';
 import { WORKFLOW_SERVER_URL_OVERRIDE } from './utils.js';
+import {
+  getWsEventsTransport,
+  resolveWsTransport,
+  toEventsWsUrl,
+} from './ws-transport.js';
 
 const ORIGIN = WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
 const STARTED_AT = new Date('2026-06-10T00:00:00.000Z');
@@ -572,18 +581,20 @@ describe('splitEventDataForV4 attribute fields', () => {
   });
 
   it('carries initial run attributes on run_created', () => {
+    const input = new Uint8Array(8192);
     const { payload, meta } = splitEventDataForV4({
       eventType: 'run_created',
       specVersion: 4,
       eventData: {
         deploymentId: 'dpl_1',
         workflowName: 'wf',
-        input: new TextEncoder().encode('[]'),
+        input,
         attributes: { sourceAtStart: 'api' },
       },
     } as AnyEventRequest);
 
-    expect(payload).toBeInstanceOf(Uint8Array);
+    expect(payload).toBe(input);
+    expect(meta.input).toBeUndefined();
     expect(meta.attributes).toEqual({ sourceAtStart: 'api' });
     expect(meta.deploymentId).toBe('dpl_1');
     expect(meta.workflowName).toBe('wf');
@@ -609,6 +620,7 @@ describe('splitEventDataForV4 attribute fields', () => {
   it('lifts workflowName into the frame meta on outcome events (step_completed/step_created), keeping the payload in the body', () => {
     // The backend keys payload refs by workflow name; carrying it in the
     // frame meta lets the v4 POST handler skip the per-step run lookup.
+    const result = new Uint8Array(8192);
     const completed = splitEventDataForV4({
       eventType: 'step_completed',
       correlationId: 'step_1',
@@ -616,12 +628,12 @@ describe('splitEventDataForV4 attribute fields', () => {
       eventData: {
         stepName: 's',
         workflowName: 'wf',
-        result: new TextEncoder().encode('"ok"'),
+        result,
       },
     } as AnyEventRequest);
     expect(completed.meta.workflowName).toBe('wf');
     // The result still travels as the opaque body, not in meta.
-    expect(completed.payload).toBeInstanceOf(Uint8Array);
+    expect(completed.payload).toBe(result);
     expect(completed.meta.result).toBeUndefined();
 
     const created = splitEventDataForV4({
@@ -775,6 +787,116 @@ describe('splitEventDataForV4 attribute fields', () => {
     expect(malformed.meta.stepCount).toBeUndefined();
     expect(malformed.meta.eventCount).toBeUndefined();
     expect(malformed.meta.optimizations).toBeUndefined();
+  });
+});
+
+describe('attr_set eventData size limit', () => {
+  function attributeEvent(bytes: number) {
+    const padding = { key: 'padding', value: '' };
+    // Each value stays within 256 bytes; the aggregate JSON reaches the cap.
+    const eventData = {
+      changes: [
+        ...Array.from({ length: 14 }, (_, i) => ({
+          key: `key${i}`,
+          value: '\u00e9'.repeat(128),
+        })),
+        padding,
+      ],
+      writer: { type: 'step' as const, stepId: 'step_1', attempt: 2 },
+      allowReservedAttributes: true as const,
+    };
+    padding.value = 'x'.repeat(
+      bytes - Buffer.byteLength(JSON.stringify(eventData))
+    );
+    return {
+      eventType: 'attr_set' as const,
+      correlationId: 'attr_1',
+      specVersion: 4,
+      eventData,
+    } satisfies AnyEventRequest;
+  }
+
+  it('accepts exactly 4096 UTF-8 JSON bytes and rejects 4097 including writer metadata', () => {
+    const accepted = attributeEvent(4096);
+    expect(Buffer.byteLength(JSON.stringify(accepted.eventData))).toBe(4096);
+    expect(splitEventDataForV4(accepted)).toEqual({
+      payload: undefined,
+      meta: accepted.eventData,
+    });
+
+    const rejected = attributeEvent(4097);
+    expect(Buffer.byteLength(JSON.stringify(rejected.eventData))).toBe(4097);
+    expect(() => splitEventDataForV4(rejected)).toThrow(
+      expect.objectContaining({
+        name: 'WorkflowWorldError',
+        status: 400,
+        message: expect.stringContaining('received 4097 bytes'),
+      })
+    );
+  });
+
+  it.each([
+    'http',
+    'ws',
+  ])('rejects a direct oversized create before %s transport without retrying', async (transportKind) => {
+    vi.stubEnv('WORKFLOW_EVENTS_TRANSPORT', transportKind);
+    vi.useFakeTimers();
+    const retryTimer = vi.spyOn(globalThis, 'setTimeout');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response('Unexpected HTTP request', { status: 400 })
+      );
+    const config = { token: 'test-token' };
+    const transport = getWsEventsTransport(
+      toEventsWsUrl(`${ORIGIN}/api`, 'wrun_1'),
+      async () => ({ authorization: 'Bearer test-token' })
+    );
+    const requestSpy = vi
+      .spyOn(transport, 'request')
+      .mockRejectedValue(
+        new WorkflowWorldError('Unexpected WS request', { status: 400 })
+      );
+
+    try {
+      expect(resolveWsTransport('wrun_1', config)?.transport).toBe(transport);
+      const result = createWorkflowRunEvent(
+        'wrun_1',
+        attributeEvent(4097),
+        undefined,
+        config
+      ).catch((error) => error);
+      await vi.runAllTimersAsync();
+
+      const error = await result;
+      expect(error).toBeInstanceOf(WorkflowWorldError);
+      expect(error).toMatchObject({
+        status: 400,
+        message: expect.stringContaining('received 4097 bytes'),
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(requestSpy).not.toHaveBeenCalled();
+      expect(retryTimer).not.toHaveBeenCalled();
+    } finally {
+      transport.close('test cleanup');
+      requestSpy.mockRestore();
+      fetchSpy.mockRestore();
+      retryTimer.mockRestore();
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('still parses persisted attr_set events larger than the write limit', () => {
+    const event = attributeEvent(4097);
+    expect(
+      EventSchema.parse({
+        ...event,
+        eventId: 'evnt_1',
+        runId: 'wrun_1',
+        createdAt: STARTED_AT,
+      }).eventData
+    ).toEqual(event.eventData);
   });
 });
 

--- a/packages/world-vercel/src/events.ts
+++ b/packages/world-vercel/src/events.ts
@@ -53,6 +53,10 @@ import {
   validateUlidTimestamp,
   type WorkflowRun,
 } from '@workflow/world';
+import {
+  AttributeValidationError,
+  validateAttributeEventDataSize,
+} from '@workflow/world/attributes-validation';
 import { ReplayEventObserverError, withEventPostRetry } from './event-retry.js';
 import {
   createHookReceivedPreloadEventV4,
@@ -237,6 +241,14 @@ assertEventDataWireContractExhaustive<[Unhandled, Stale]>();
  * contract and must remain exhaustive with the @workflow/world event schemas.
  */
 export function splitEventDataForV4(data: AnyEventRequest): SplitEventData {
+  if (data.eventType === 'attr_set') {
+    try {
+      validateAttributeEventDataSize(data.eventData);
+    } catch (error) {
+      if (!(error instanceof AttributeValidationError)) throw error;
+      throw new WorkflowWorldError(error.message, { status: 400 });
+    }
+  }
   // Some event types in the AnyEventRequest discriminated union (e.g.
   // run_cancelled) have no eventData. Cast through unknown so this
   // helper can read it defensively without TS narrowing per branch.

--- a/packages/world/src/attributes-validation.ts
+++ b/packages/world/src/attributes-validation.ts
@@ -1,3 +1,5 @@
+import type { EventOfType } from './events.js';
+
 /** A single run-attribute change. `null` removes the key. */
 export interface AttributeChange {
   key: string;
@@ -113,6 +115,8 @@ export function purgesUserDataOnFinish(
 export const ATTRIBUTE_KEY_MAX_LENGTH = 256;
 export const ATTRIBUTE_VALUE_MAX_BYTES = 256;
 export const ATTRIBUTE_MAX_PER_RUN = 64;
+/** World limit for JSON-serialized inline eventData, not just attribute values. */
+export const ATTRIBUTE_EVENT_DATA_MAX_BYTES = 4096;
 
 const textEncoder = new TextEncoder();
 
@@ -121,6 +125,19 @@ export class AttributeValidationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AttributeValidationError';
+  }
+}
+
+/** Validate writes without applying a new constraint to persisted event schemas. */
+export function validateAttributeEventDataSize(
+  eventData: EventOfType<'attr_set'>['eventData']
+): void {
+  // attr_set has no RemoteRef payload fields: the entire eventData counts.
+  const bytes = textEncoder.encode(JSON.stringify(eventData)).length;
+  if (bytes > ATTRIBUTE_EVENT_DATA_MAX_BYTES) {
+    throw new AttributeValidationError(
+      `Attribute eventData exceeds limit ${ATTRIBUTE_EVENT_DATA_MAX_BYTES} UTF-8 JSON bytes (received ${bytes} bytes). Split the changes into smaller setAttributes() calls.`
+    );
   }
 }
 

--- a/packages/world/src/attributes-validation.ts
+++ b/packages/world/src/attributes-validation.ts
@@ -115,8 +115,8 @@ export function purgesUserDataOnFinish(
 export const ATTRIBUTE_KEY_MAX_LENGTH = 256;
 export const ATTRIBUTE_VALUE_MAX_BYTES = 256;
 export const ATTRIBUTE_MAX_PER_RUN = 64;
-/** World limit for JSON-serialized inline eventData, not just attribute values. */
-export const ATTRIBUTE_EVENT_DATA_MAX_BYTES = 4096;
+/** World attr_set limit for JSON-serialized eventData, not just attribute values. */
+export const ATTRIBUTE_EVENT_DATA_MAX_BYTES = 8192;
 
 const textEncoder = new TextEncoder();
 

--- a/packages/world/src/attributes.test.ts
+++ b/packages/world/src/attributes.test.ts
@@ -24,15 +24,15 @@ describe('validateAttributeEventDataSize', () => {
     ['UTF-8 values', 'key', '\u00e9'.repeat(64)],
     ['JSON escapes', '\n"\\', '\n"\\'.repeat(12)],
   ])('counts %s at the JSON byte boundary', (_label, key, value) => {
-    expect(ATTRIBUTE_EVENT_DATA_MAX_BYTES).toBe(4096);
+    expect(ATTRIBUTE_EVENT_DATA_MAX_BYTES).toBe(8192);
     const eventData = {
-      changes: Array.from({ length: 16 }, (_, i) => ({
+      changes: Array.from({ length: 32 }, (_, i) => ({
         key: `${i}${key}`,
         value,
       })),
       writer: { type: 'workflow' },
     } satisfies EventOfType<'attr_set'>['eventData'];
-    let remaining = 4096 - Buffer.byteLength(JSON.stringify(eventData));
+    let remaining = 8192 - Buffer.byteLength(JSON.stringify(eventData));
     for (const change of eventData.changes) {
       const padding = Math.min(
         remaining,
@@ -42,18 +42,18 @@ describe('validateAttributeEventDataSize', () => {
       remaining -= padding;
     }
     expect(remaining).toBe(0);
-    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(4096);
+    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(8192);
     expect(() => validateAttributeChanges(eventData.changes)).not.toThrow();
     expect(() => validateAttributeEventDataSize(eventData)).not.toThrow();
 
     eventData.changes[0].key += 'x';
-    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(4097);
+    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(8193);
     expect(() => validateAttributeChanges(eventData.changes)).not.toThrow();
     expect(() => validateAttributeEventDataSize(eventData)).toThrow(
       AttributeValidationError
     );
     expect(() => validateAttributeEventDataSize(eventData)).toThrow(
-      /4096.*4097.*Split/
+      /8192.*8193.*Split/
     );
   });
 });

--- a/packages/world/src/attributes.test.ts
+++ b/packages/world/src/attributes.test.ts
@@ -10,6 +10,53 @@ import {
   applyAttributeChanges,
   validateAttributeChanges,
 } from './attributes.js';
+import {
+  ATTRIBUTE_EVENT_DATA_MAX_BYTES,
+  type EventOfType,
+  validateAttributeEventDataSize,
+} from './index.js';
+
+describe('validateAttributeEventDataSize', () => {
+  it.each([
+    ['envelope', 'key', ''],
+    ['long keys', 'k'.repeat(180), ''],
+    ['UTF-8 keys', '\u00e9'.repeat(90), ''],
+    ['UTF-8 values', 'key', '\u00e9'.repeat(64)],
+    ['JSON escapes', '\n"\\', '\n"\\'.repeat(12)],
+  ])('counts %s at the JSON byte boundary', (_label, key, value) => {
+    expect(ATTRIBUTE_EVENT_DATA_MAX_BYTES).toBe(4096);
+    const eventData = {
+      changes: Array.from({ length: 16 }, (_, i) => ({
+        key: `${i}${key}`,
+        value,
+      })),
+      writer: { type: 'workflow' },
+    } satisfies EventOfType<'attr_set'>['eventData'];
+    let remaining = 4096 - Buffer.byteLength(JSON.stringify(eventData));
+    for (const change of eventData.changes) {
+      const padding = Math.min(
+        remaining,
+        256 - Buffer.byteLength(change.value)
+      );
+      change.value += 'x'.repeat(padding);
+      remaining -= padding;
+    }
+    expect(remaining).toBe(0);
+    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(4096);
+    expect(() => validateAttributeChanges(eventData.changes)).not.toThrow();
+    expect(() => validateAttributeEventDataSize(eventData)).not.toThrow();
+
+    eventData.changes[0].key += 'x';
+    expect(Buffer.byteLength(JSON.stringify(eventData))).toBe(4097);
+    expect(() => validateAttributeChanges(eventData.changes)).not.toThrow();
+    expect(() => validateAttributeEventDataSize(eventData)).toThrow(
+      AttributeValidationError
+    );
+    expect(() => validateAttributeEventDataSize(eventData)).toThrow(
+      /4096.*4097.*Split/
+    );
+  });
+});
 
 describe('attribute schemas', () => {
   it('accepts a normal key', () => {

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './analytics.js';
 export type * from './attributes.js';
 export {
+  ATTRIBUTE_EVENT_DATA_MAX_BYTES,
   ATTRIBUTE_KEY_MAX_LENGTH,
   ATTRIBUTE_MAX_PER_RUN,
   ATTRIBUTE_VALUE_MAX_BYTES,
@@ -33,6 +34,7 @@ export {
   type RunRetention,
   readRunRetention,
   validateAttributeChanges,
+  validateAttributeEventDataSize,
 } from './attributes.js';
 export {
   _resetEnvWarnCacheForTests,


### PR DESCRIPTION
- Allow **8192 bytes (8KiB)** for complete `attr_set.eventData`, measured as UTF-8 JSON including keys, escaping, writer metadata, and options.
  - Reject larger new writes catchably before persistence, with a defensive Vercel transport guard.
- Preserve historical replay in Node and QuickJS, including rejection ordering in promise races.
- Keep the 256-byte per-value and 64 stored-attribute limits unchanged. No automatic splitting or websocket-reconnect changes.
