### PR TITLE
test(streams): defer WebSocket connect for benchmark

### DIFF
--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -286,7 +286,8 @@ export function createStreamer(config?: APIConfig): Streamer {
                     config,
                     attributes
                   ),
-                () => closeStreamSessionOverHttp(runId, name, config)
+                () => closeStreamSessionOverHttp(runId, name, config),
+                true
               );
             },
           }

--- a/packages/world-vercel/src/ws-stream-session.test.ts
+++ b/packages/world-vercel/src/ws-stream-session.test.ts
@@ -131,7 +131,8 @@ afterEach(() => {
 });
 
 function makeSession(
-  config: { token?: string } | undefined = { token: 'token' }
+  config: { token?: string } | undefined = { token: 'token' },
+  deferInitialConnect = false
 ) {
   const writeHttp = vi.fn().mockResolvedValue(undefined);
   const closeHttp = vi.fn().mockResolvedValue(undefined);
@@ -141,7 +142,8 @@ function makeSession(
     writerId,
     config,
     writeHttp,
-    closeHttp
+    closeHttp,
+    deferInitialConnect
   );
   activeSessions.push(session);
   return { session, writeHttp, closeHttp };
@@ -156,6 +158,66 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     expect(sockets).toHaveLength(0);
     expect(writeHttp).toHaveBeenCalledWith(['one']);
     expect(closeHttp).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers the diagnostic socket until the first HTTP group settles', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    let releaseHttp: (() => void) | undefined;
+    const httpPending = new Promise<void>((resolve) => {
+      releaseHttp = resolve;
+    });
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+    writeHttp.mockImplementationOnce(async () => httpPending);
+
+    const first = session.write(0, ['one']);
+    await vi.waitFor(() => expect(writeHttp).toHaveBeenCalledTimes(1));
+    expect(writeHttp).toHaveBeenCalledWith(
+      ['one'],
+      expect.objectContaining({
+        'workflow.stream.ws.session_first_write': true,
+        'workflow.stream.ws.connecting_at_write': false,
+        'workflow.stream.ws.connect_deferred_at_write': true,
+        'workflow.stream.ws.connection_attempt': 0,
+      })
+    );
+    expect(sockets).toHaveLength(0);
+
+    const second = session.write(1, ['two']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sockets).toHaveLength(0);
+    releaseHttp?.();
+    await first;
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].open();
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    expect((await decodeOne(sockets[0].sent[0])).meta).toMatchObject({
+      type: 'write',
+      chunkSeq: 1,
+    });
+    sockets[0].reply(
+      encodeFrame({ type: 'write_ack', reqId: 1 }, new Uint8Array())
+    );
+    await second;
+  });
+
+  it('does not start a diagnostic socket after an ambiguous first HTTP outcome', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const error = new Error('HTTP outcome unknown');
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+    writeHttp.mockRejectedValueOnce(error);
+
+    await expect(session.write(0, ['one'])).rejects.toBe(error);
+    await expect(session.write(1, ['two'])).rejects.toBe(error);
+    expect(sockets).toHaveLength(0);
+  });
+
+  it('closes over HTTP without starting a deferred diagnostic socket', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const { session, closeHttp } = makeSession({ token: 'token' }, true);
+
+    await session.close();
+    expect(closeHttp).toHaveBeenCalledTimes(1);
+    expect(sockets).toHaveLength(0);
   });
 
   it('sends immediately over HTTP while the initial socket connects, then switches to WS', async () => {
@@ -766,15 +828,16 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     expect(sockets).toHaveLength(0);
   });
 
-  it('forwards streamer-wrapper disposal after session materialization', async () => {
+  it('keeps streamer-wrapper disposal socket-free before its first write', async () => {
     process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
     const { createStreamer } = await import('./streamer.js');
     const session = createStreamer({
       token: 'token',
     }).streams.createWriteSession?.('wrun_1', 'stream/1', { writerId });
-    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sockets).toHaveLength(0);
     await session?.dispose?.();
-    expect(sockets[0].closed).toContainEqual([1000, 'stream writer disposed']);
+    expect(sockets).toHaveLength(0);
   });
 
   it('disposes transport without sending protocol close', async () => {

--- a/packages/world-vercel/src/ws-stream-session.ts
+++ b/packages/world-vercel/src/ws-stream-session.ts
@@ -26,7 +26,14 @@ import {
 } from './ws-stream-connect.js';
 import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
 
-type Mode = 'connecting' | 'draining' | 'ws' | 'http' | 'closed' | 'poisoned';
+type Mode =
+  | 'deferred'
+  | 'connecting'
+  | 'draining'
+  | 'ws'
+  | 'http'
+  | 'closed'
+  | 'poisoned';
 type WriteTiming = {
   startedAt: number;
   sessionFirstWrite: boolean;
@@ -181,8 +188,8 @@ function asBytes(raw: unknown): Uint8Array {
 class VercelStreamWriteSession implements StreamWriteSession {
   private mode: Mode = 'connecting';
   private socket: WebSocket | undefined;
-  private connect: Promise<void>;
-  private transportDecision: Promise<void>;
+  private connect = Promise.resolve();
+  private transportDecision = Promise.resolve();
   private tail = Promise.resolve();
   private inbound = Promise.resolve();
   private nextReqId = 1;
@@ -209,10 +216,14 @@ class VercelStreamWriteSession implements StreamWriteSession {
       chunks: (string | Uint8Array)[],
       attributes?: Attributes
     ) => Promise<void>,
-    private readonly closeHttp: () => Promise<void>
+    private readonly closeHttp: () => Promise<void>,
+    private readonly deferInitialConnect: boolean
   ) {
-    this.connect = this.startConnect();
-    this.transportDecision = this.makeTransportDecision();
+    if (deferInitialConnect) {
+      this.mode = 'deferred';
+    } else {
+      this.startInitialConnect();
+    }
   }
 
   write(chunkSeq: number, chunks: (string | Uint8Array)[]): Promise<void> {
@@ -230,23 +241,12 @@ class VercelStreamWriteSession implements StreamWriteSession {
     timing: WriteTiming
   ): Promise<void> {
     this.assertUsable();
-    if (this.mode === 'connecting' && this.connectionAttempt === 1) {
-      // Assign complete groups to HTTP while the initial socket opens in the
-      // background. The serial operation chain prevents later WS work from
-      // overtaking this request, and a failed HTTP request poisons the writer:
-      // its outcome may be unknown, so it must never be replayed over WS.
-      try {
-        await this.writeHttp(chunks, {
-          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
-          'workflow.stream.ws.connection_attempt': this.connectionAttempt,
-          'workflow.stream.ws.connecting_at_write': true,
-          'workflow.stream.ws.session_to_write_ms':
-            timing.startedAt - this.sessionCreatedAt,
-        });
-      } catch (error) {
-        this.failUnknown(error);
-        throw this.poisonError;
-      }
+    if (this.mode === 'deferred') {
+      await this.writeBeforeInitialConnect(chunks, timing);
+      return;
+    }
+    if (this.shouldWriteHttpWhileConnecting()) {
+      await this.writeWhileInitialConnectRuns(chunks, timing);
       return;
     }
     await this.transportDecision;
@@ -296,6 +296,58 @@ class VercelStreamWriteSession implements StreamWriteSession {
     }
   }
 
+  private shouldWriteHttpWhileConnecting(): boolean {
+    return (
+      !this.deferInitialConnect &&
+      this.mode === 'connecting' &&
+      this.connectionAttempt === 1
+    );
+  }
+
+  private async writeWhileInitialConnectRuns(
+    chunks: (string | Uint8Array)[],
+    timing: WriteTiming
+  ): Promise<void> {
+    // Assign complete groups to HTTP while the initial socket opens in the
+    // background. The serial operation chain prevents later WS work from
+    // overtaking this request, and a failed HTTP request poisons the writer:
+    // its outcome may be unknown, so it must never be replayed over WS.
+    try {
+      await this.writeHttp(chunks, {
+        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+        'workflow.stream.ws.connection_attempt': this.connectionAttempt,
+        'workflow.stream.ws.connecting_at_write': true,
+        'workflow.stream.ws.session_to_write_ms':
+          timing.startedAt - this.sessionCreatedAt,
+      });
+    } catch (error) {
+      this.failUnknown(error);
+      throw this.poisonError;
+    }
+  }
+
+  private async writeBeforeInitialConnect(
+    chunks: (string | Uint8Array)[],
+    timing: WriteTiming
+  ): Promise<void> {
+    // Diagnostic variant: delay all socket setup until the first HTTP group
+    // settles, isolating concurrent WS initialization from first-chunk CTT.
+    try {
+      await this.writeHttp(chunks, {
+        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+        'workflow.stream.ws.connection_attempt': 0,
+        'workflow.stream.ws.connecting_at_write': false,
+        'workflow.stream.ws.connect_deferred_at_write': true,
+        'workflow.stream.ws.session_to_write_ms':
+          timing.startedAt - this.sessionCreatedAt,
+      });
+    } catch (error) {
+      this.failUnknown(error);
+      throw this.poisonError;
+    }
+    if (this.mode === 'deferred') this.startInitialConnect();
+  }
+
   dispose(): void {
     if (this.mode === 'closed') return;
     this.mode = 'closed';
@@ -312,6 +364,11 @@ class VercelStreamWriteSession implements StreamWriteSession {
   close(): Promise<void> {
     return this.enqueue(async () => {
       this.assertUsable();
+      if (this.mode === 'deferred') {
+        await this.closeHttp();
+        this.mode = 'closed';
+        return;
+      }
       await this.transportDecision;
       this.assertUsable();
       if (this.mode === 'http') {
@@ -350,6 +407,12 @@ class VercelStreamWriteSession implements StreamWriteSession {
   private assertUsable(): void {
     if (this.mode === 'poisoned') throw this.poisonError;
     if (this.mode === 'closed') throw new Error('stream writer is closed');
+  }
+
+  private startInitialConnect(): void {
+    this.mode = 'connecting';
+    this.connect = this.startConnect();
+    this.transportDecision = this.makeTransportDecision();
   }
 
   /** One shared bounded decision for all operations queued while connecting. */
@@ -797,7 +860,8 @@ export function createStreamWriteSession(
     chunks: (string | Uint8Array)[],
     attributes?: Attributes
   ) => Promise<void>,
-  closeHttp: () => Promise<void>
+  closeHttp: () => Promise<void>,
+  deferInitialConnect = false
 ): StreamWriteSession {
   return new VercelStreamWriteSession(
     runId,
@@ -805,6 +869,7 @@ export function createStreamWriteSession(
     StreamWriterIdSchema.parse(writerId),
     config,
     writeHttp,
-    closeHttp
+    closeHttp,
+    deferInitialConnect
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Temporary benchmark arm: the write session can hold off all socket setup until the first HTTP group settles, so first-chunk latency can be measured without concurrent WebSocket initialization competing with it. A session that only ever closes never opens a socket at all.

## Test Plan

Unit tests cover the deferred path (first write, poisoned first write, close-without-write); world-vercel suite, typecheck, and Biome all pass locally.
