### PR TITLE
[core] Backport #3700 (log-order correlation-id draws) to stable, and fail on a mismatched duplicate step_created

### DIFF
--- a/.changeset/log-order-draws.md
+++ b/.changeset/log-order-draws.md
@@ -1,0 +1,6 @@
+---
+'workflow': minor
+'@workflow/core': minor
+---
+
+Pin correlation-ID draw order to event-log order (Node.js VM engine), so two concurrent replays of the same run assign the same IDs even when one loaded a shorter event-log prefix. Set `WORKFLOW_LOG_ORDER_DRAWS=0` to opt back into arrival-order delivery resolution.

--- a/.changeset/log-order-draws.md
+++ b/.changeset/log-order-draws.md
@@ -1,6 +1,6 @@
 ---
-'workflow': minor
-'@workflow/core': minor
+'workflow': patch
+'@workflow/core': patch
 ---
 
 Pin correlation-ID draw order to event-log order (Node.js VM engine), so two concurrent replays of the same run assign the same IDs even when one loaded a shorter event-log prefix. Set `WORKFLOW_LOG_ORDER_DRAWS=0` to opt back into arrival-order delivery resolution.

--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fix replay divergence when a step result overtook an earlier sleep or hook delivery that was parked behind an unread hook's payload

--- a/.changeset/step-created-conflict-guard.md
+++ b/.changeset/step-created-conflict-guard.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fail a run as `CORRUPTED_EVENT_LOG` when a concurrent replay already created a step under the same correlation id but with a different step name or different arguments, instead of continuing and delivering that step's result to the wrong call.

--- a/packages/core/src/delivery-barrier-coverage.test.ts
+++ b/packages/core/src/delivery-barrier-coverage.test.ts
@@ -78,6 +78,10 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
   });
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
+  // Real-session parity: the log-order-draws quiescence fixpoint keys its
+  // progress metric on `mintCount`; without it the loop degrades to a single
+  // turn and this suite would only exercise a degraded variant.
+  let mintCount = 0;
   const promiseQueueHolder = { current: Promise.resolve() };
   const ctxRef: { current?: WorkflowOrchestratorContext } = {};
   const ctx: WorkflowOrchestratorContext = {
@@ -94,7 +98,13 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
       getPromiseQueue: () => promiseQueueHolder.current,
     }),
     invocationsQueue: new Map(),
-    generateUlid: () => ulid(workflowStartedAt),
+    generateUlid: () => {
+      mintCount += 1;
+      return ulid(workflowStartedAt);
+    },
+    get mintCount() {
+      return mintCount;
+    },
     generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
     ),
@@ -739,5 +749,90 @@ describe('suspension timing against parked step deliveries', () => {
     });
 
     expectSuspensionSnapshotSteps(error, ['followUp']);
+  });
+});
+
+// ─── step result above a wait parked behind an unclaimed payload ────────────
+//
+// The log-order-draws turnstile (`quiesceEarlierCascades`) refuses to resolve
+// a delivery while a LOWER-index ARMED barrier is still registered. An armed
+// wait can itself be parked behind an unclaimed buffered hook payload — a
+// chain only the idle-gated safety net can move (lowest-first retirement).
+// This test pins the termination argument for that shape: the spinning step
+// delivery must not count as a parked committed delivery (`resolvesOnItsOwn`
+// excludes it — it gates on the parked wait), so `canRetireAbandonedBarriers`
+// stays reachable, the net retires the payload, the wait delivers, and the
+// turnstile opens. A regression that makes the turnstile wait on parked
+// chains directly, or counts the spinner as self-resolving, deadlocks this
+// replay instead of suspending it.
+describe('log-order draws turnstile above a parked chain', () => {
+  const scenario = async () => {
+    const resumeAt = new Date(FIXED_TIMESTAMP + 5_000);
+    const ops: Promise<unknown>[] = [];
+    const [payload, stepAResult] = await Promise.all([
+      dehydrateStepReturnValue({ poke: 1 }, 'wrun_test', undefined, ops),
+      dehydrateStepReturnValue('a', 'wrun_test', undefined, ops),
+    ]);
+
+    const events: Event[] = [
+      event('evnt_0', 'hook_created', `hook_${ULIDS[0]}`, {
+        token: 'parked-token',
+        isWebhook: false,
+      }),
+      event('evnt_1', 'wait_created', `wait_${ULIDS[1]}`, { resumeAt }),
+      event('evnt_2', 'step_created', `step_${ULIDS[2]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_3', 'step_started', `step_${ULIDS[2]}`, {
+        stepName: 'stepA',
+      }),
+      event('evnt_4', 'hook_received', `hook_${ULIDS[0]}`, { payload }),
+      event('evnt_5', 'wait_completed', `wait_${ULIDS[1]}`, { resumeAt }),
+      event('evnt_6', 'step_completed', `step_${ULIDS[2]}`, {
+        stepName: 'stepA',
+        result: stepAResult,
+      }),
+      event('evnt_7', 'step_created', `step_${ULIDS[3]}`, {
+        stepName: 'afterBoth',
+      }),
+    ];
+
+    const ctx = setupWorkflowContext(events);
+    const useStep = createUseStep(ctx);
+    const sleep = createSleep(ctx);
+    const createHook = createCreateHook(ctx);
+
+    const error = await replay(ctx, async () => {
+      const stepA = useStep('stepA');
+      const afterBoth = useStep('afterBoth');
+      // Fire-and-forget hook: its payload (evnt_4) is consumed but never
+      // claimed, so its barrier stays unarmed and parks the wait behind it.
+      createHook({ token: 'parked-token' });
+      await Promise.all([sleep('5s'), stepA()]);
+      await afterBoth();
+    });
+
+    expectSuspendedWithPendingSteps(ctx, error, ['afterBoth']);
+  };
+
+  it('terminates and suspends with log-order draws on', async () => {
+    // Pin the flag rather than inherit the ambient environment: a suite-wide
+    // WORKFLOW_LOG_ORDER_DRAWS=0 sweep would otherwise silently run the off
+    // path twice and this test would prove nothing about the turnstile.
+    vi.stubEnv('WORKFLOW_LOG_ORDER_DRAWS', '1');
+    try {
+      await scenario();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('terminates and suspends with log-order draws off', async () => {
+    vi.stubEnv('WORKFLOW_LOG_ORDER_DRAWS', '0');
+    try {
+      await scenario();
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/packages/core/src/delivery-barrier-coverage.test.ts
+++ b/packages/core/src/delivery-barrier-coverage.test.ts
@@ -32,6 +32,12 @@
  * ULIDs in the order the committed log recorded. A regression surfaces as the
  * production `ReplayDivergenceError`.
  *
+ * Section 3 asserts the registry's other job directly, over a registry built
+ * by hand rather than by a replay: which entries an idle check may ignore. Get
+ * that wrong in one direction and a chain parked on an unclaimed hook payload
+ * deadlocks; wrong in the other and a suspension preempts a batch of parked
+ * step results.
+ *
  * The final section covers the SUSPENSION side of the registry
  * (vercel/workflow#3183): an idle check must not observe idle — and raise a
  * `WorkflowSuspension` — while a delivery that is committed to reaching the
@@ -53,6 +59,7 @@ import { WorkflowSuspension } from './global.js';
 import {
   awaitEarlierDeliveries,
   registerDeliveryBarrier,
+  scheduleWhenIdle,
   type WorkflowOrchestratorContext,
 } from './private.js';
 import { dehydrateStepReturnValue } from './serialization.js';
@@ -466,41 +473,121 @@ describe('hook payload delivery ordering against an earlier hook payload', () =>
   });
 });
 
-// ─── 4. registry scan cost ─────────────────────────────────────────────────
+// ─── 4. idle reachability over the barrier registry ────────────────────────
 //
-// `resolvesOnItsOwn` walks the registry recursively: an armed hook re-checks
-// every earlier wait and step, an armed wait every earlier hook and step, and
-// so on. Unmemoized that is T(n) = Σ T(j) — exponential — and the registry is
-// not small by construction: `EventsConsumer` drains consecutively consumable
-// events synchronously while barriers only retire on microtask-driven
-// deliveries, so a fan-out of `Promise.race([hook, sleep(watchdog)])` branches
-// accumulates one barrier per branch per kind (measured: 49 live barriers for
-// 24 branches).
+// `hasParkedCommittedDelivery` decides whether an idle check may observe idle,
+// and it is the only remaining caller of the recursive `resolvesOnItsOwn`
+// walk. Two opposite answers are load-bearing, and neither is covered by the
+// replay sections above, which exercise the walk only through whichever shape
+// their fixture happens to build:
 //
-// The scan runs synchronously, before `awaitEarlierDeliveries` first awaits,
-// so timing the call alone measures it. Unmemoized, 40 alternating armed
-// hook/wait barriers is ~10^8 recursive calls — minutes. Memoized it is
-// linear. The bound is deliberately loose; this is an order-of-magnitude
-// guard, not a benchmark.
-describe('delivery-barrier registry scan cost', () => {
-  it('stays linear in registry size for a step delivery', () => {
-    const ctx = {
+//  - A PARKED CHAIN must not be counted. An unclaimed buffered hook payload is
+//    retired by the idle safety net in `registerDeliveryBarrier`, so counting
+//    it would gate its own retirement — and that extends to the wait parked
+//    behind it and the step gated on that wait. If any link were counted, idle
+//    would be unreachable, no net could fire, and the chain would never
+//    deliver: a deadlock, not a divergence.
+//  - An ALL-ARMED BATCH must be counted (vercel/workflow#3183). Parallel step
+//    results parked between their queue slots and their detached `resolve()`
+//    are invisible to `pendingDeliveries`, and an idle check that observed idle
+//    there would raise a `WorkflowSuspension` carrying none of the follow-up
+//    work the batch was about to create.
+//
+// Asserted through `scheduleWhenIdle`, which is the coupling that matters, and
+// which makes both cases unambiguous: nothing in these registries ever
+// delivers, so the callback can only fire if the registry was excluded from
+// the idle count AND the barriers' own nets then retired it.
+//
+// This replaces a timing guard that no longer measured anything. It timed
+// `awaitEarlierDeliveries(ctx, 40, 'step')` against 40 alternating armed
+// hook/wait barriers to catch an unmemoized exponential walk (4.3e8 recursive
+// calls, 84s). That call site is gone: a step now tests `armed` directly, so
+// the call is a flat loop. The surviving caller cannot reach an exponential
+// shape at all — it returns at the first self-resolving entry, so it only
+// advances past entries that short-circuit on their first false child
+// (measured: 98 recursive calls unmemoized for the worst 40-barrier shape).
+// Timing it would assert nothing; see the memo note on `resolvesOnItsOwn`.
+describe('delivery-barrier idle reachability', () => {
+  function emptyCtx(): WorkflowOrchestratorContext {
+    return {
       pendingDeliveries: 0,
       promiseQueue: Promise.resolve(),
       pendingDeliveryBarriers: new Map(),
     } as unknown as WorkflowOrchestratorContext;
+  }
 
-    const BARRIERS = 40;
-    for (let index = 0; index < BARRIERS; index++) {
-      registerDeliveryBarrier(ctx, index, index % 2 ? 'hook' : 'wait');
+  /** Whether `scheduleWhenIdle` observes idle within `rounds` timer ticks. */
+  async function reachesIdle(
+    ctx: WorkflowOrchestratorContext,
+    rounds = 10
+  ): Promise<boolean> {
+    let idle = false;
+    scheduleWhenIdle(ctx, () => {
+      idle = true;
+    });
+    for (let round = 0; round < rounds && !idle; round++) {
+      await ctx.promiseQueue;
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    expect(ctx.pendingDeliveryBarriers?.size).toBe(BARRIERS);
+    return idle;
+  }
 
-    const startedAt = performance.now();
-    // The floating promise never settles (nothing delivers these barriers);
-    // only the synchronous scan inside the call is under test.
-    void awaitEarlierDeliveries(ctx, BARRIERS, 'step');
-    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  it('unwinds a step parked behind a wait parked on an unclaimed payload, in log order', async () => {
+    const ctx = emptyCtx();
+    const order: string[] = [];
+    let payloadRetiredBeforeWait: boolean | undefined;
+
+    // The shape `step-delivery-ordering.test.ts` replays, as a registry: an
+    // unread hook's payload at index 0, a wait behind it, a step gated on that
+    // wait. Only the payload lacks a delivery chain — nothing in the workflow
+    // ever claims it, so the idle safety net is the only thing that can retire
+    // it. The wait and the step get the unconditional chain their real call
+    // sites attach at event-consumption time, as the INVARIANT on
+    // `registerDeliveryBarrier` requires of any armed barrier.
+    registerDeliveryBarrier(ctx, 0, 'hook', { armed: false });
+    const wait = registerDeliveryBarrier(ctx, 1, 'wait');
+    const step = registerDeliveryBarrier(ctx, 2, 'step');
+    const chains = [
+      awaitEarlierDeliveries(ctx, 1, 'wait').then(() => {
+        order.push('wait');
+        payloadRetiredBeforeWait = !ctx.pendingDeliveryBarriers?.has(0);
+        wait.markDelivered();
+      }),
+      awaitEarlierDeliveries(ctx, 2, 'step').then(() => {
+        order.push('step');
+        step.markDelivered();
+      }),
+    ];
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(3);
+
+    // Neither chain can run yet: the wait gates on the unclaimed payload, and
+    // the step gates on the wait (it skips the payload directly, but the skip
+    // is not transitive through the armed wait).
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    // Idle must stay reachable for the payload's net to fire at all. If any
+    // link of the chain were counted against idle, this would hang.
+    expect(await reachesIdle(ctx)).toBe(true);
+    await Promise.all(chains);
+
+    expect(payloadRetiredBeforeWait).toBe(true);
+    expect(order).toEqual(['wait', 'step']);
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(0);
+  });
+
+  it('is blocked by an all-armed batch of step results', async () => {
+    const ctx = emptyCtx();
+    // Armed and undelivered is exactly the window #3183 is about: the batch's
+    // queue slots have released `pendingDeliveries` and their detached
+    // `resolve()` calls have not run yet.
+    for (let index = 0; index < 3; index++) {
+      registerDeliveryBarrier(ctx, index, 'step');
+    }
+
+    expect(await reachesIdle(ctx)).toBe(false);
+    // The nets are idle-gated too, so nothing retires behind our back.
+    expect(ctx.pendingDeliveryBarriers?.size).toBe(3);
   });
 });
 

--- a/packages/core/src/delivery-barrier-dispenser.test.ts
+++ b/packages/core/src/delivery-barrier-dispenser.test.ts
@@ -50,6 +50,10 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
   });
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
+  // Real-session parity: the log-order-draws quiescence fixpoint keys its
+  // progress metric on `mintCount`; without it the loop degrades to a single
+  // turn and this suite would only exercise a degraded variant.
+  let mintCount = 0;
   const promiseQueueHolder = { current: Promise.resolve() };
   const ctxRef: { current?: WorkflowOrchestratorContext } = {};
   const ctx: WorkflowOrchestratorContext = {
@@ -70,7 +74,13 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
       getPromiseQueue: () => promiseQueueHolder.current,
     }),
     invocationsQueue: new Map(),
-    generateUlid: () => ulid(workflowStartedAt),
+    generateUlid: () => {
+      mintCount += 1;
+      return ulid(workflowStartedAt);
+    },
+    get mintCount() {
+      return mintCount;
+    },
     generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
     ),

--- a/packages/core/src/log-order-draws.test.ts
+++ b/packages/core/src/log-order-draws.test.ts
@@ -1,0 +1,319 @@
+import type { Event, WorkflowRun } from '@workflow/world';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WorkflowSuspension } from './global.js';
+import {
+  dehydrateStepReturnValue,
+  dehydrateWorkflowArguments,
+} from './serialization.js';
+import { runWorkflow } from './workflow.js';
+
+/**
+ * Offline regression coverage for `WORKFLOW_LOG_ORDER_DRAWS=1`: correlation-id
+ * draw order pinned to event-log order, so draw bindings are stable under
+ * dense-prefix extension and concurrent replays of different-length prefixes
+ * mint compatible ids.
+ *
+ * The shape is the 2026-08-20 production corruption (five runs on
+ * 5.0.0-beta.43): a fan-out where each branch launches a step, then races a
+ * hook against a watchdog sleep. A replay whose dense prefix ends just before
+ * a sibling branch's launch completion sees that branch parked at its `await`
+ * minting nothing, so the woken branch's finalize takes the ordinal a fresher
+ * replay gives the sibling's wait. With draws pinned to log order, the
+ * finalize is minted inside the cascade of the delivery that enabled it, and
+ * extending the log can only append draws, never renumber them.
+ */
+
+const RUN_ID = 'wrun_log_order_draws';
+
+async function makeRun(): Promise<WorkflowRun> {
+  const ops: Promise<unknown>[] = [];
+  const input = await dehydrateWorkflowArguments([], RUN_ID, undefined, ops);
+  await Promise.all(ops);
+  return {
+    runId: RUN_ID,
+    workflowName: 'workflow',
+    status: 'running',
+    input,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deploymentId: 'test-deployment',
+  };
+}
+
+const TRANSFORM = `;globalThis.__private_workflows = new Map();
+  globalThis.__private_workflows.set("workflow", workflow);`;
+
+/**
+ * The 2026-08-20 production shape (five corrupted runs on 5.0.0-beta.43): a
+ * fan-out where each branch launches a step, then races a hook against a
+ * watchdog sleep, and finalizes when the hook wins. A replay whose dense
+ * prefix ends just before a sibling branch's launch completion sees that
+ * branch parked at its `await` — the branch mints nothing, not even its
+ * watchdog wait — so the woken branch's `finalizeTask` draws the ordinal a
+ * fresher replay gives the sibling's wait. One correlation id then names both
+ * a step and a wait, and every later replay fails with an unconsumable
+ * `step_created` (CORRUPTED_EVENT_LOG).
+ *
+ * The two branches' pre-race hops differ on purpose: the woken branch reaches
+ * its mint through the `Promise.race` resolution (two hops after delivery)
+ * while the unblocked sibling mints its wait one hop after its own delivery,
+ * which is how the sibling overtakes it on the shared counter.
+ */
+const BLOCKED_BRANCH_CODE = `
+  const useStep = globalThis[Symbol.for("WORKFLOW_USE_STEP")];
+  const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+  const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+  const launchTask = useStep("launchTask");
+  const finalizeTask = useStep("finalizeTask");
+  const WATCHDOG = "watchdog";
+  async function workflow() {
+    await Promise.all([0, 1, 2].map(async (task) => {
+      const hook = createHook({ token: "task-done-" + task });
+      await launchTask(task);
+      const winner = await Promise.race([
+        hook,
+        sleep("1h").then(() => WATCHDOG),
+      ]);
+      if (winner !== WATCHDOG) {
+        await finalizeTask(task);
+      }
+    }));
+  }${TRANSFORM}`;
+
+/** Replays the blocked-branch workflow and returns every pending entity. */
+async function blockedBranchEntities(
+  events: Event[]
+): Promise<{ type: string; correlationId: string; stepName?: string }[]> {
+  const run = await makeRun();
+  try {
+    await runWorkflow(BLOCKED_BRANCH_CODE, run, events, undefined);
+  } catch (error) {
+    const suspension = error as WorkflowSuspension;
+    if (suspension.name !== 'WorkflowSuspension') {
+      throw error;
+    }
+    return suspension.steps.map((item) => ({
+      type: item.type,
+      correlationId: item.correlationId,
+      stepName: (item as { stepName?: string }).stepName,
+    }));
+  }
+  throw new Error('expected the replay to suspend');
+}
+
+/**
+ * Builds the two dense prefixes of the production log. The shorter one ends
+ * before the second branch's launch completion; the longer one appends it.
+ */
+async function blockedBranchPrefixes(): Promise<{
+  shorter: Event[];
+  longer: Event[];
+}> {
+  const initial = await blockedBranchEntities([]);
+  const hooks = initial.filter((item) => item.type === 'hook');
+  const launches = initial.filter((item) => item.stepName === 'launchTask');
+  expect(hooks).toHaveLength(3);
+  expect(launches).toHaveLength(3);
+
+  let at = 0;
+  const stamp = () => new Date(Date.parse('2024-01-01T00:00:00.000Z') + ++at);
+  const event = (
+    eventType: Event['eventType'],
+    correlationId: string,
+    eventData: object
+  ): Event => ({
+    eventId: `event-${at + 1}`,
+    runId: RUN_ID,
+    eventType,
+    correlationId,
+    eventData: eventData as Event['eventData'],
+    createdAt: stamp(),
+  });
+
+  const ops: Promise<unknown>[] = [];
+  const launchResult = await dehydrateStepReturnValue(
+    'launched',
+    RUN_ID,
+    undefined,
+    ops
+  );
+  const hookPayload = await dehydrateStepReturnValue(
+    { done: true },
+    RUN_ID,
+    undefined,
+    ops
+  );
+  await Promise.all(ops);
+
+  // Mirrors the production slot order: every branch's hook and launch created,
+  // the first two launches completed, both of their hooks received, and the
+  // third branch's launch completion as the extension event.
+  const shorter: Event[] = [
+    ...hooks.map((hook, task) =>
+      event('hook_created', hook.correlationId, {
+        token: `task-done-${task}`,
+        isWebhook: false,
+      })
+    ),
+    ...launches.map((launch) =>
+      event('step_created', launch.correlationId, { stepName: 'launchTask' })
+    ),
+    event('step_completed', launches[0]!.correlationId, {
+      stepName: 'launchTask',
+      result: launchResult,
+    }),
+    event('step_completed', launches[1]!.correlationId, {
+      stepName: 'launchTask',
+      result: launchResult,
+    }),
+    event('hook_received', hooks[0]!.correlationId, {
+      payload: hookPayload,
+    }),
+    event('hook_received', hooks[1]!.correlationId, {
+      payload: hookPayload,
+    }),
+  ];
+  const longer: Event[] = [
+    ...shorter,
+    event('step_completed', launches[2]!.correlationId, {
+      stepName: 'launchTask',
+      result: launchResult,
+    }),
+  ];
+  return { shorter, longer };
+}
+
+function suspensionBindings(
+  items: { type: string; correlationId: string; stepName?: string }[]
+) {
+  return items
+    .map((item) => `${item.correlationId}=${item.type}:${item.stepName ?? ''}`)
+    .sort();
+}
+
+describe('arrival-order draws (opt-out, WORKFLOW_LOG_ORDER_DRAWS=0)', () => {
+  const original = process.env.WORKFLOW_LOG_ORDER_DRAWS;
+
+  beforeEach(() => {
+    process.env.WORKFLOW_LOG_ORDER_DRAWS = '0';
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.WORKFLOW_LOG_ORDER_DRAWS;
+    } else {
+      process.env.WORKFLOW_LOG_ORDER_DRAWS = original;
+    }
+  });
+
+  // Deliberate CONTROL: asserts the arrival-order BUG still reproduces with
+  // the flag off. If this stops failing-to-bind (i.e. `rebound` comes back
+  // empty), the control is obsolete, not broken — most likely because
+  // positional rebinding was fixed independently of draw scheduling, e.g.
+  // call-site-addressed correlation ids (vercel/workflow#3179) landing, which
+  // removes the rebinding in BOTH modes. Delete this block then; do not chase
+  // it as a regression.
+  it('rebinds an ordinal from a step to a wait under extension (the control)', async () => {
+    const { shorter, longer } = await blockedBranchPrefixes();
+    const stale = await blockedBranchEntities(shorter);
+    const fresh = await blockedBranchEntities(longer);
+    const staleFinalizes = stale
+      .filter((item) => item.stepName === 'finalizeTask')
+      .map((item) => item.correlationId);
+    const freshIds = new Set(fresh.map((item) => item.correlationId));
+    const rebound = staleFinalizes.filter((id) => !freshIds.has(id));
+    expect(rebound.length).toBeGreaterThan(0);
+  });
+});
+
+describe('log-order draws (the default)', () => {
+  const original = process.env.WORKFLOW_LOG_ORDER_DRAWS;
+
+  beforeEach(() => {
+    delete process.env.WORKFLOW_LOG_ORDER_DRAWS;
+  });
+
+  afterEach(() => {
+    if (original !== undefined) {
+      process.env.WORKFLOW_LOG_ORDER_DRAWS = original;
+    }
+  });
+
+  it('keeps every binding of the shorter prefix under extension', async () => {
+    const { shorter, longer } = await blockedBranchPrefixes();
+    const stale = await blockedBranchEntities(shorter);
+    const fresh = await blockedBranchEntities(longer);
+    // Every entity the shorter replay would create must exist, under the SAME
+    // correlation id and kind, in the longer replay: extension appends draws,
+    // never renumbers them.
+    // The corruption signature is one correlation id bound to two different
+    // entities across the two replays. Compare bindings on shared ids: an id
+    // present in both pending sets must name the same entity. Ids only in the
+    // shorter set are entities the extension consumed (the sibling's launch);
+    // ids only in the longer set are the extension's appended draws.
+    const byId = (
+      items: { type: string; correlationId: string; stepName?: string }[]
+    ) =>
+      new Map(
+        items.map((item) => [
+          item.correlationId,
+          `${item.type}:${item.stepName ?? ''}`,
+        ])
+      );
+    const staleById = byId(stale);
+    const freshById = byId(fresh);
+    const rebound: string[] = [];
+    for (const [id, binding] of staleById) {
+      const extended = freshById.get(id);
+      if (extended !== undefined && extended !== binding) {
+        rebound.push(`${id}: ${binding} -> ${extended}`);
+      }
+    }
+    expect(rebound).toEqual([]);
+    // And specifically: the woken branches' finalize steps keep their ids.
+    const staleFinalizes = stale
+      .filter((item) => item.stepName === 'finalizeTask')
+      .map((item) => item.correlationId)
+      .sort();
+    const freshFinalizes = fresh
+      .filter((item) => item.stepName === 'finalizeTask')
+      .map((item) => item.correlationId)
+      .sort();
+    expect(freshFinalizes).toEqual(staleFinalizes);
+  });
+
+  it('is stable across every dense prefix of the log', async () => {
+    // The pairwise test above targets the production window; this sweeps all
+    // of them: no shared correlation id may change entity between any two
+    // consecutive dense prefixes.
+    const { longer } = await blockedBranchPrefixes();
+    let previous: Map<string, string> | undefined;
+    for (let length = 1; length <= longer.length; length++) {
+      const entities = await blockedBranchEntities(longer.slice(0, length));
+      const current = new Map(
+        entities.map((item) => [
+          item.correlationId,
+          `${item.type}:${item.stepName ?? ''}`,
+        ])
+      );
+      if (previous) {
+        for (const [id, binding] of previous) {
+          const extended = current.get(id);
+          expect(
+            extended === undefined || extended === binding,
+            `prefix ${length}: ${id} rebound ${binding} -> ${extended}`
+          ).toBe(true);
+        }
+      }
+      previous = current;
+    }
+  });
+
+  it('is deterministic per prefix', async () => {
+    const { longer } = await blockedBranchPrefixes();
+    const a = suspensionBindings(await blockedBranchEntities(longer));
+    const b = suspensionBindings(await blockedBranchEntities(longer));
+    expect(b).toEqual(a);
+  });
+});

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -271,23 +271,68 @@ const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
 };
 
 /**
- * Whether `entry` will resolve on its own — it is armed, and every earlier
- * delivery it defers behind will likewise resolve on its own.
+ * Whether a delivery of `kind` at log index `index` gates on the earlier
+ * registry entry `other` (at `otherIndex`).
  *
- * A step delivery is always self-resolving: it skips uncommitted deliveries
- * (see {@link awaitEarlierDeliveries}), and the earlier steps it does defer
- * behind are self-resolving by the same argument, inducting down on index.
+ * Single source of truth for that question, called by both
+ * {@link awaitEarlierDeliveries} (which awaits what it gates on) and
+ * {@link computeResolvesOnItsOwn} (which recurses into what it gates on).
+ * Those two MUST agree exactly, and the doc block on
+ * {@link awaitEarlierDeliveries} stakes deadlock-freedom on it, so the
+ * condition lives here rather than being spelled out twice.
+ */
+function gatesOn(
+  kind: DeliveryKind,
+  index: number,
+  otherIndex: number,
+  other: DeliveryBarrierEntry
+): boolean {
+  if (otherIndex >= index || !DEFER_BEHIND[kind].includes(other.kind)) {
+    return false;
+  }
+  // A step skips an UNARMED earlier entry (an unclaimed buffered hook
+  // payload) — see the asymmetry described on `awaitEarlierDeliveries`. The
+  // skip is direct, never transitive: armed entries are still gated on, even
+  // when they are themselves parked behind such a payload.
+  return !(kind === 'step' && !other.armed);
+}
+
+/**
+ * Whether `entry` will resolve on its own — it is armed, and every earlier
+ * delivery it actually gates on ({@link gatesOn}) will likewise resolve on its
+ * own.
+ *
+ * A step does not gate on an unclaimed buffered payload, so such a payload
+ * cannot keep it from resolving. A step DOES gate on earlier armed waits and
+ * hooks, so one parked behind an unclaimed payload makes the step
+ * non-self-resolving in turn. Disagreeing with {@link awaitEarlierDeliveries}
+ * here would not be a cosmetic problem: this predicate is what
+ * {@link hasParkedCommittedDelivery} uses to decide whether idle is reachable,
+ * and an entry reported self-resolving while it is in fact parked behind a
+ * payload that only the idle safety net can retire would gate its own
+ * retirement.
  *
  * Recursion terminates because every edge points to a strictly smaller index.
- * `memo` is required rather than an optimization: without it the walk is
- * exponential in the number of live hook/wait barriers (each armed entry
- * re-walks every earlier entry of the opposite kind, T(n) = Σ T(j)), and the
- * registry is not small by construction — `EventsConsumer` drains
- * consecutively consumable events synchronously while barriers only retire on
- * microtask-driven deliveries, so a fan-out of `Promise.race([hook, sleep])`
- * branches accumulates one barrier per branch per kind. Memoized, the walk is
- * linear in registry size. The memo MUST be per-call: `armed` mutates between
+ * `memo` keeps the walk linear in registry size, and the registry is not small
+ * by construction — `EventsConsumer` drains consecutively consumable events
+ * synchronously while barriers only retire on microtask-driven deliveries, so
+ * a fan-out of `Promise.race([hook, sleep])` branches accumulates one barrier
+ * per branch per kind. The memo MUST be per-call: `armed` mutates between
  * calls as buffered payloads are claimed.
+ *
+ * The memo is an optimization, not a correctness requirement. It once was one:
+ * `awaitEarlierDeliveries` used to run this walk for every earlier entry of a
+ * step delivery, with no early exit, which unmemoized is T(n) = Σ T(j) —
+ * measured at 4.3e8 recursive calls (84s) for 40 alternating armed hook/wait
+ * barriers. That call site is gone; a step now tests `armed` directly. The one
+ * surviving caller, {@link hasParkedCommittedDelivery}, cannot reach that
+ * shape: it returns at the FIRST self-resolving entry, so it only ever
+ * advances past entries that are non-self-resolving, and those short-circuit
+ * on their first false child. Every entry it evaluates therefore has
+ * all-false predecessors and returns after one child, degenerating the walk to
+ * a chain (measured: 98 calls unmemoized for the worst 40-barrier shape, 1
+ * call for the registry above). Do not restore an exponential claim here
+ * without restoring a caller that can produce it.
  */
 function resolvesOnItsOwn(
   barriers: Map<number, DeliveryBarrierEntry>,
@@ -313,16 +358,11 @@ function computeResolvesOnItsOwn(
   if (!entry.armed) {
     return false;
   }
-  if (entry.kind === 'step') {
-    return true;
-  }
-  const deferBehind = DEFER_BEHIND[entry.kind];
   for (const [otherIndex, other] of barriers) {
-    if (
-      otherIndex < index &&
-      deferBehind.includes(other.kind) &&
-      !resolvesOnItsOwn(barriers, otherIndex, other, memo)
-    ) {
+    if (!gatesOn(entry.kind, index, otherIndex, other)) {
+      continue;
+    }
+    if (!resolvesOnItsOwn(barriers, otherIndex, other, memo)) {
       return false;
     }
   }
@@ -342,31 +382,44 @@ function computeResolvesOnItsOwn(
  * suspension point first; see the comment at that `await` for why ordering the
  * `resolve()` calls alone is not enough.
  *
- * One asymmetry: a STEP result additionally skips any earlier delivery that
- * will not resolve on its own, i.e. one blocked (directly or transitively) on
- * a buffered hook payload no consumer has claimed. Such a payload is delivered
- * only when the workflow next reads the hook, and reaching that read very
- * commonly requires the step result itself (`await stepX()` before the read).
- * Gating the step on it would stall the workflow until the barrier's idle
- * safety net fires, which then releases every delivery queued behind that
+ * What counts as "defers behind" is {@link gatesOn}, shared with
+ * {@link computeResolvesOnItsOwn} so the two cannot drift.
+ *
+ * One asymmetry: a STEP result skips any earlier delivery that is UNARMED,
+ * i.e. a buffered hook payload no consumer has claimed. Such a payload is
+ * delivered only when the workflow next reads the hook, and reaching that read
+ * very commonly requires the step result itself (`await stepX()` before the
+ * read). Gating the step on it would stall the workflow until the barrier's
+ * idle safety net fires, which then releases every delivery queued behind that
  * payload at once — losing exactly the race this ordering exists to protect.
  * Waits and hooks keep gating on unclaimed payloads: for them, waiting for the
  * claim IS the ordering guarantee (a `wait_completed` must not preempt a
  * payload the log ordered first).
  *
- * A delivery that does gate on an unclaimed payload still delivers in log
- * order once that payload's barrier is retired, and that rests on the
- * PAYLOAD's barrier being retired before that of anything parked behind it.
- * That order is structural: safety-net retirements go through one per-context
- * dispenser that only ever retires the lowest-index entry at delivery idle,
- * and every retirement that wakes a chain flips
- * {@link hasParkedCommittedDelivery} back to true, re-blocking the dispenser
- * until the chain has drained — see {@link ensureBarrierSafetyNet}. (This
- * used to rest on the FIFO of one idle poll per barrier, which held for a
- * single parked segment but decayed to timing noise with several — the
- * release order, and therefore the ULIDs drawn by the woken branches, then
- * depended on how much log the replay had loaded. storm-log-replay.test.ts
- * replays a production log corrupted exactly that way.)
+ * The skip is direct, never transitive. A step still gates on an earlier ARMED
+ * wait or hook, including one that is itself parked behind an unclaimed
+ * payload. Skipping those too would invert log order for the commonest shape
+ * there is: a workflow that creates a hook it does not read on this branch,
+ * races `step` against `sleep`, and has the log say the sleep won. The step
+ * would then overtake the wait, both branches would swap the correlation ids
+ * they draw next, and replay would diverge — see
+ * `step-delivery-ordering.test.ts`. Waiting instead is safe because the
+ * payload's own idle safety net retires it and the whole chain then delivers
+ * in log order; {@link hasParkedCommittedDelivery} deliberately reports such a
+ * step as not self-resolving so that idle stays reachable.
+ *
+ * "The whole chain then delivers in log order" rests on the PAYLOAD's barrier
+ * being retired before that of anything parked behind it. That order is
+ * structural: safety-net retirements go through one per-context dispenser that
+ * only ever retires the lowest-index entry at delivery idle, and every
+ * retirement that wakes a chain flips {@link hasParkedCommittedDelivery} back
+ * to true, re-blocking the dispenser until the chain has drained — see
+ * {@link ensureBarrierSafetyNet}. (This used to rest on the FIFO of one idle
+ * poll per barrier, which held for a single parked segment but decayed to
+ * timing noise with several — the release order, and therefore the ULIDs
+ * drawn by the woken branches, then depended on how much log the replay had
+ * loaded. storm-log-replay.test.ts replays a production log corrupted exactly
+ * that way.)
  */
 export async function awaitEarlierDeliveries(
   ctx: WorkflowOrchestratorContext,
@@ -382,18 +435,9 @@ export async function awaitEarlierDeliveries(
     return;
   }
   const barriers = ctx.pendingDeliveryBarriers;
-  const deferBehind = DEFER_BEHIND[kind];
   const earlier: Promise<void>[] = [];
-  // Shared across this call only — see `resolvesOnItsOwn`.
-  const selfResolving = new Map<number, boolean>();
   for (const [index, entry] of barriers) {
-    if (index >= eventIndex || !deferBehind.includes(entry.kind)) {
-      continue;
-    }
-    if (
-      kind === 'step' &&
-      !resolvesOnItsOwn(barriers, index, entry, selfResolving)
-    ) {
+    if (!gatesOn(kind, eventIndex, index, entry)) {
       continue;
     }
     earlier.push(entry.delivered);
@@ -641,7 +685,10 @@ function canRetireAbandonedBarriers(ctx: WorkflowOrchestratorContext): boolean {
  * Deliveries that do NOT resolve on their own must be excluded, not for
  * accuracy but for termination: an unclaimed buffered hook payload is retired
  * BY the idle safety net in {@link registerDeliveryBarrier}, so counting it
- * here would gate its own retirement. Self-resolving deliveries always
+ * here would gate its own retirement. That reasoning extends to whatever is
+ * parked behind such a payload — a wait, and a step gating on that wait — for
+ * the same reason: the whole chain moves only once the net fires, and it
+ * cannot fire while the chain is counted. Self-resolving deliveries always
  * deliver from their own chains (see the INVARIANT on
  * {@link registerDeliveryBarrier}) and never need that net, so waiting on
  * them is deadlock-free.

--- a/packages/core/src/private.ts
+++ b/packages/core/src/private.ts
@@ -137,6 +137,14 @@ export interface WorkflowOrchestratorContext {
   invocationsQueue: Map<string, QueueItem>;
   onWorkflowError: (error: Error) => void;
   generateUlid: () => string;
+  /**
+   * Monotone count of correlation-id draws this replay has made. Progress
+   * metric for {@link quiesceEarlierCascades}: a macrotask turn in which it
+   * does not move (and no hydration is in flight) means every woken branch has
+   * run as far as it can without another delivery. Optional so lightweight
+   * test contexts degrade to the single-yield behavior.
+   */
+  readonly mintCount?: number;
   generateNanoid: () => string;
   /**
    * Sequential promise queue that ensures all event-driven promise resolutions
@@ -280,6 +288,11 @@ const DEFER_BEHIND: Record<DeliveryKind, readonly DeliveryKind[]> = {
  * Those two MUST agree exactly, and the doc block on
  * {@link awaitEarlierDeliveries} stakes deadlock-freedom on it, so the
  * condition lives here rather than being spelled out twice.
+ *
+ * One deliberate exception: the log-order-draws turnstile in
+ * {@link quiesceEarlierCascades} waits on ANY lower armed entry, a strictly
+ * wider relation than this one. Why that width cannot deadlock the
+ * safety-net dispenser is argued at the turnstile itself.
  */
 function gatesOn(
   kind: DeliveryKind,
@@ -421,17 +434,127 @@ function computeResolvesOnItsOwn(
  * loaded. storm-log-replay.test.ts replays a production log corrupted exactly
  * that way.)
  */
+/**
+ * Whether correlation-id draw order is pinned to event-log order. Default ON:
+ * only the literal string `WORKFLOW_LOG_ORDER_DRAWS=0` opts out — `=false`,
+ * `=off`, and every other value keep it enabled. Read per call so tests can
+ * flip it.
+ *
+ * Off, a delivery that had to defer yields ONE macrotask after its
+ * predecessors resolve — enough for short consumers, but a woken branch whose
+ * path to its next draw crosses more hops (a `Promise.race` resolution, a
+ * user-level semaphore, an async-iterator read) can still be overtaken by a
+ * later-in-log delivery's shorter cascade, so the run's draw order — and
+ * therefore its correlation ids — depends on how much log this replay loaded.
+ * On, the yield becomes a fixpoint: the delivery resolves only once every
+ * earlier cascade has quiesced, making the draw sequence a pure function of
+ * the dense log, stable under prefix extension, and concurrent writers'
+ * duplicate creates identical (deduped) instead of colliding.
+ */
+function isLogOrderDrawsEnabled(): boolean {
+  return process.env.WORKFLOW_LOG_ORDER_DRAWS !== '0';
+}
+
+/**
+ * One quiescence turn: lets the entire pending microtask queue drain, then
+ * yields to the event loop once. `setImmediate` (check phase) is used where
+ * available because Node clamps `setTimeout(0)` to ~1ms while `setImmediate`
+ * costs ~20µs — and every branch-deciding delivery pays this turn at least
+ * once, so on a sequential replay the clamp is the whole cost. Timers still
+ * run between consecutive turns (the loop re-enters the event loop each
+ * iteration, passing through the timers phase), so chains parked on the
+ * safety-net dispenser's `setTimeout` cadence are not starved.
+ */
+function quiescenceTurn(delayMs: number): Promise<void> {
+  if (delayMs === 0 && typeof setImmediate === 'function') {
+    return new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  return new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * Waits until the workflow can make no further progress without another
+ * delivery: repeated (promise-queue drain + event-loop turn)s until a full
+ * turn passes with no new ULID draws and no hydration in flight.
+ *
+ * Termination: each extra iteration requires a new ULID draw or a hydration
+ * started in the previous turn. `mintCount` counts EVERY draw from the run's
+ * sequence — correlation ids and the serialization-driven draws (stream ids
+ * minted through the `STABLE_ULID` global while dehydrating) — which is
+ * conservative in the safe direction: serialization draws only extend the
+ * wait, and both body progress and the serialization work one cascade can
+ * schedule are finite between deliveries, so the fixpoint is reached. The
+ * loop holds this delivery's own barrier registered (its `markDelivered` has
+ * not run), so `isDeliveryIdle` stays false and no suspension can preempt the
+ * cascade being waited out.
+ *
+ * A rejected `promiseQueue` settles immediately and forever, so looping at
+ * the normal cadence on a failed run would degenerate into a busy loop (the
+ * same hazard {@link ensureBarrierSafetyNet} documents). Iterations that
+ * observe the queue rejected back off to a 50ms tick instead.
+ */
+async function quiesceEarlierCascades(
+  ctx: WorkflowOrchestratorContext,
+  eventIndex: number
+): Promise<void> {
+  for (;;) {
+    const mintsBefore = ctx.mintCount ?? 0;
+    const pendingBefore = ctx.pendingDeliveries;
+    // Settled or rejected, the queue snapshot only orders us behind work
+    // already chained; a rejection is the run failing elsewhere.
+    const queueRejected = await ctx.promiseQueue.then(
+      () => false,
+      () => true
+    );
+    await quiescenceTurn(queueRejected ? 50 : 0);
+    if (
+      (ctx.mintCount ?? 0) !== mintsBefore ||
+      pendingBefore !== 0 ||
+      ctx.pendingDeliveries !== 0
+    ) {
+      continue;
+    }
+    // Quiet is not enough on its own: several delivery chains can be sitting
+    // in this loop at once, and letting the first quiet observation resolve
+    // would break the tie by timer arrival — the arrival-order dependence this
+    // mode removes. A lower-index ARMED barrier is a delivery committed to
+    // happening that has not happened yet, so this one keeps waiting. Unarmed
+    // entries (buffered payloads nobody has claimed) do not block, exactly as
+    // in `gatesOn`: their handover is claim-driven, which is body-position
+    // determined and therefore already a function of the prefix.
+    //
+    // This is deliberately a WIDER waits-for relation than `gatesOn` (which,
+    // e.g., excludes wait→wait): under log-order draws EVERY branch-deciding
+    // delivery must resolve in log order, kinds included. The width is safe
+    // against the dispenser deadlock that `resolvesOnItsOwn` guards, because
+    // the one edge the wider relation adds — waiting on an armed entry that
+    // gatesOn does not model — always bottoms out at the same unarmed payload:
+    // a lower armed WAIT is non-self-resolving only when it is (transitively)
+    // parked behind an unclaimed buffered payload, and a wait gates on every
+    // lower hook and step directly, so the spinner here also gates on that
+    // payload through `gatesOn` and is itself reported non-self-resolving.
+    // The dispenser therefore stays unblocked and retires the chain head; see
+    // the parked-chain test in delivery-barrier-coverage.test.ts.
+    let lowerArmed = false;
+    for (const [index, entry] of ctx.pendingDeliveryBarriers ?? []) {
+      if (index < eventIndex && entry.armed) {
+        lowerArmed = true;
+        break;
+      }
+    }
+    if (!lowerArmed) {
+      return;
+    }
+  }
+}
+
 export async function awaitEarlierDeliveries(
   ctx: WorkflowOrchestratorContext,
   eventIndex: number | undefined,
   kind: DeliveryKind
 ): Promise<void> {
   // Defensive: tolerate contexts that predate this field (test harnesses).
-  if (
-    eventIndex === undefined ||
-    !ctx.pendingDeliveryBarriers ||
-    ctx.pendingDeliveryBarriers.size === 0
-  ) {
+  if (eventIndex === undefined || !ctx.pendingDeliveryBarriers) {
     return;
   }
   const barriers = ctx.pendingDeliveryBarriers;
@@ -444,6 +567,19 @@ export async function awaitEarlierDeliveries(
   }
   if (earlier.length > 0) {
     await Promise.all(earlier);
+  }
+  if (isLogOrderDrawsEnabled()) {
+    // Unconditional, not just when a barrier was still registered: an earlier
+    // delivery's barrier deregisters when its resolve() runs, but the branch
+    // it woke may still be hops away from its next draw. A later delivery
+    // consumed after that deregistration sees an empty gate set, and without
+    // this it would resolve mid-cascade and overtake the draw — the exact
+    // arrival-order dependence this mode exists to remove. Costs one quiet
+    // macrotask turn when nothing is in flight.
+    await quiesceEarlierCascades(ctx, eventIndex);
+    return;
+  }
+  if (earlier.length > 0) {
     // An earlier delivery being "delivered" only means its `resolve()` ran.
     // The branch it woke may need an arbitrary number of further microtask
     // hops before it reaches its next `useStep` call and draws a ULID — a

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -779,7 +779,9 @@ export function workflowEntrypoint(
                       events,
                       cursor: eventsCursor ?? null,
                     };
-                    let result: Awaited<ReturnType<typeof handleSuspension>>;
+                    let result:
+                      | Awaited<ReturnType<typeof handleSuspension>>
+                      | undefined;
                     try {
                       result = await handleSuspension({
                         suspension: err,
@@ -801,15 +803,28 @@ export function workflowEntrypoint(
                         );
                         return { timeoutSeconds: 0 };
                       }
-                      throw suspensionError;
+                      if (!CorruptedEventLogError.is(suspensionError)) {
+                        throw suspensionError;
+                      }
+                      // The suspension handler found a `step_created` that a
+                      // concurrent replay already wrote for the same
+                      // correlation id but for a DIFFERENT step invocation
+                      // (see `verifyDuplicateStepCreate`). Redelivery would
+                      // replay into the same collision, and continuing would
+                      // hand that step's result to the wrong call, so fall
+                      // through to the terminal path below and fail the run
+                      // as CORRUPTED_EVENT_LOG.
+                      err = suspensionError;
                     }
 
-                    if (result.timeoutSeconds !== undefined) {
-                      return { timeoutSeconds: result.timeoutSeconds };
-                    }
+                    if (result) {
+                      if (result.timeoutSeconds !== undefined) {
+                        return { timeoutSeconds: result.timeoutSeconds };
+                      }
 
-                    // Suspension handled, no further work needed
-                    return;
+                      // Suspension handled, no further work needed
+                      return;
+                    }
                   }
 
                   // Transient infrastructure failures talking to the

--- a/packages/core/src/runtime/step-create-conflict.ts
+++ b/packages/core/src/runtime/step-create-conflict.ts
@@ -1,0 +1,160 @@
+import { CorruptedEventLogError } from '@workflow/errors';
+import type { World } from '@workflow/world';
+import type { CryptoKey } from '../encryption.js';
+import { runtimeLogger } from '../logger.js';
+import { decodeFormatPrefix, maybeDecrypt } from '../serialization.js';
+import { UNSERIALIZABLE_STEP_INPUT_MARKER } from './unserializable-step.js';
+
+/**
+ * Verify that a `step_created` the World rejected as a duplicate (409) was
+ * written for the SAME step invocation this replay is trying to create.
+ *
+ * Correlation ids are ordinals of one per-run draw sequence, so two replays
+ * that reach a `useStep` call in different orders can hand one id to two
+ * different invocations. The World keeps whichever `step_created` landed
+ * first, so the step body runs with the winner's arguments while the loser's
+ * branch awaits the same id: its continuation then receives a result that
+ * belongs to a different call. When the two calls are the same step function
+ * (a fan-out mapping the same step over a list is the common shape), the
+ * name check in the step consumer cannot see this, and the run completes
+ * with silently cross-wired data.
+ *
+ * A duplicate whose persisted name and input match ours is the benign case
+ * (two replays that agree on the binding raced on the write) and is
+ * ignored, as before. A duplicate that persisted a different step name or a
+ * different input is proof that the run's replay is non-deterministic, and
+ * this throws a {@link CorruptedEventLogError} so the run fails instead of
+ * continuing with the wrong result.
+ *
+ * Inputs are compared as plaintext bytes after decryption: the persisted
+ * input and ours were both produced by `dehydrateStepArguments` from the
+ * same deterministic VM state, so the same invocation yields identical
+ * bytes, and AES-GCM's random nonce is the only reason the stored bytes
+ * could differ for the same input.
+ *
+ * Verification is best-effort: when the persisted step cannot be read, or
+ * either side is not in a comparable form, the duplicate is treated as
+ * benign and logged, exactly like before this check existed. The check must
+ * never turn a transient read failure into a failed run.
+ */
+export async function verifyDuplicateStepCreate({
+  world,
+  runId,
+  correlationId,
+  stepName,
+  dehydratedInput,
+  encryptionKey,
+  conflictMessage,
+}: {
+  world: World;
+  runId: string;
+  correlationId: string;
+  stepName: string;
+  dehydratedInput: unknown;
+  encryptionKey: CryptoKey | undefined;
+  conflictMessage: string;
+}): Promise<void> {
+  const details = {
+    workflowRunId: runId,
+    correlationId,
+    stepName,
+    message: conflictMessage,
+  };
+
+  let persisted: { stepName: string; input?: unknown };
+  try {
+    persisted = await world.steps.get(runId, correlationId);
+  } catch (err) {
+    runtimeLogger.warn(
+      'Step already exists, but the persisted step could not be read to verify it; continuing',
+      { ...details, error: err instanceof Error ? err.message : String(err) }
+    );
+    return;
+  }
+
+  if (persisted.stepName !== stepName) {
+    throw new CorruptedEventLogError(
+      `Step ${correlationId} was already created as "${persisted.stepName}", but this replay invoked "${stepName}" under the same correlation id. Two replays of this run assigned the same correlation id to different step calls, so the run's replay is not deterministic.`
+    );
+  }
+
+  const comparison = await compareDehydratedInputs(
+    persisted.input,
+    dehydratedInput,
+    encryptionKey
+  );
+
+  if (comparison === 'equal') {
+    runtimeLogger.info('Step already exists, continuing', details);
+    return;
+  }
+
+  if (comparison === 'incomparable') {
+    runtimeLogger.warn(
+      'Step already exists, but its persisted input could not be compared with this replay; continuing',
+      details
+    );
+    return;
+  }
+
+  throw new CorruptedEventLogError(
+    `Step ${correlationId} ("${stepName}") was already created with different arguments than this replay passed to it. Two replays of this run assigned the same correlation id to different invocations of "${stepName}", so the step's result would be delivered to the wrong call.`
+  );
+}
+
+async function compareDehydratedInputs(
+  persisted: unknown,
+  local: unknown,
+  encryptionKey: CryptoKey | undefined
+): Promise<'equal' | 'different' | 'incomparable'> {
+  if (persisted === undefined || local === undefined) {
+    return 'incomparable';
+  }
+  let a: unknown;
+  let b: unknown;
+  try {
+    [a, b] = await Promise.all([
+      maybeDecrypt(persisted, encryptionKey),
+      maybeDecrypt(local, encryptionKey),
+    ]);
+  } catch {
+    return 'incomparable';
+  }
+  if (a instanceof Uint8Array && b instanceof Uint8Array) {
+    if (bytesEqual(a, b)) return 'equal';
+    // The winner recorded the placeholder `finalizeUnserializableStep`
+    // writes when a step's arguments refuse to serialize. That branch is
+    // about to fail the step with the serialization error, which is the
+    // outcome the user should see; do not mask it with a corruption report.
+    if (isUnserializablePlaceholder(a)) return 'incomparable';
+    return 'different';
+  }
+  if (a instanceof Uint8Array || b instanceof Uint8Array) {
+    return 'incomparable';
+  }
+  // Legacy specVersion 1 runs store step input as plain JSON.
+  try {
+    return JSON.stringify(a) === JSON.stringify(b) ? 'equal' : 'different';
+  } catch {
+    return 'incomparable';
+  }
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function isUnserializablePlaceholder(plaintext: Uint8Array): boolean {
+  try {
+    const { payload } = decodeFormatPrefix(plaintext);
+    return new TextDecoder()
+      .decode(payload)
+      .includes(UNSERIALIZABLE_STEP_INPUT_MARKER);
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -1,12 +1,21 @@
-import { EntityConflictError, RunExpiredError } from '@workflow/errors';
+import {
+  CorruptedEventLogError,
+  EntityConflictError,
+  RunExpiredError,
+} from '@workflow/errors';
 import type { WorkflowRun, World } from '@workflow/world';
 import { describe, expect, it, vi } from 'vitest';
+import { type CryptoKey, importKey } from '../encryption.js';
 import { WorkflowSuspension } from '../global.js';
-import { hydrateStepArguments } from '../serialization.js';
+import {
+  dehydrateStepArguments,
+  hydrateStepArguments,
+} from '../serialization.js';
 import { handleSuspension } from './suspension-handler.js';
 import {
   isUnserializableStepInputPlaceholder,
   UNSERIALIZABLE_STEP_INPUT_MARKER,
+  unserializableStepInputPlaceholder,
 } from './unserializable-step.js';
 
 vi.mock('../version.js', () => ({ version: '0.0.0-test' }));
@@ -354,5 +363,156 @@ describe('step-argument serialization failure', () => {
       []
     );
     expect(isUnserializableStepInputPlaceholder(hydrated)).toBe(true);
+  });
+});
+
+describe('duplicate step_created verification', () => {
+  // Two replays that assign one correlation id to different `useStep` calls
+  // race on the same `step_created`; the World keeps the first. The loser
+  // must notice when the persisted step is not the invocation it is holding,
+  // or its branch silently receives another call's result.
+  const RUN_ID = run.runId;
+
+  function stepItem(correlationId: string, stepName: string, args: unknown[]) {
+    return { type: 'step' as const, correlationId, stepName, args };
+  }
+
+  async function persistedInput(
+    args: unknown[],
+    key?: CryptoKey,
+    extra: Record<string, unknown> = {}
+  ) {
+    return dehydrateStepArguments(
+      { args, closureVars: undefined, thisVal: undefined, ...extra },
+      RUN_ID,
+      key,
+      globalThis
+    );
+  }
+
+  function conflictingWorld(
+    persisted: { stepName: string; input?: unknown } | Error,
+    rawKey?: Uint8Array
+  ) {
+    const eventsCreate = vi
+      .fn()
+      .mockRejectedValue(new EntityConflictError('already exists'));
+    const stepsGet =
+      persisted instanceof Error
+        ? vi.fn().mockRejectedValue(persisted)
+        : vi.fn().mockResolvedValue({
+            runId: RUN_ID,
+            stepId: 's_1',
+            status: 'pending',
+            attempt: 0,
+            ...persisted,
+          });
+    const world = {
+      events: { create: eventsCreate },
+      steps: { get: stepsGet },
+      queue: vi.fn().mockResolvedValue({ messageId: 'msg_123' }),
+      getEncryptionKeyForRun: vi.fn().mockResolvedValue(rawKey),
+    } as unknown as World;
+    return { world, eventsCreate, stepsGet };
+  }
+
+  async function suspend(world: World, item = stepItem('s_1', 'update', [42])) {
+    return handleSuspension({
+      suspension: new WorkflowSuspension(
+        new Map([[item.correlationId, item]]),
+        globalThis
+      ),
+      world,
+      run,
+    });
+  }
+
+  it('continues when the persisted step is the same invocation', async () => {
+    const { world, stepsGet } = conflictingWorld({
+      stepName: 'update',
+      input: await persistedInput([42]),
+    });
+
+    await expect(suspend(world)).resolves.toBeDefined();
+
+    expect(stepsGet).toHaveBeenCalledWith(RUN_ID, 's_1');
+    // The step message still goes out: the winner's step is this step.
+    expect(world.queue).toHaveBeenCalledWith(
+      '__wkf_step_update',
+      expect.objectContaining({ stepId: 's_1' }),
+      expect.anything()
+    );
+  });
+
+  it('fails the run when the persisted step has different arguments', async () => {
+    const { world } = conflictingWorld({
+      stepName: 'update',
+      input: await persistedInput([43]),
+    });
+
+    await expect(suspend(world)).rejects.toThrow(CorruptedEventLogError);
+    await expect(suspend(world)).rejects.toThrow(
+      /s_1 \("update"\) was already created with different arguments/
+    );
+  });
+
+  it('fails the run when the persisted step is a different step function', async () => {
+    const { world } = conflictingWorld({
+      stepName: 'somethingElse',
+      input: await persistedInput([42]),
+    });
+
+    await expect(suspend(world)).rejects.toThrow(CorruptedEventLogError);
+    await expect(suspend(world)).rejects.toThrow(
+      /already created as "somethingElse", but this replay invoked "update"/
+    );
+  });
+
+  it('compares encrypted inputs by plaintext, not ciphertext', async () => {
+    const rawKey = crypto.getRandomValues(new Uint8Array(32));
+    const key = await importKey(rawKey);
+    // A separate encryption of the same arguments: different nonce, so
+    // the stored bytes differ even though the input is identical.
+    const { world } = conflictingWorld(
+      { stepName: 'update', input: await persistedInput([42], key) },
+      rawKey
+    );
+
+    await expect(suspend(world)).resolves.toBeDefined();
+
+    const { world: mismatched } = conflictingWorld(
+      { stepName: 'update', input: await persistedInput([43], key) },
+      rawKey
+    );
+    await expect(suspend(mismatched)).rejects.toThrow(CorruptedEventLogError);
+  });
+
+  it('continues when the persisted step cannot be read', async () => {
+    const { world } = conflictingWorld(new Error('steps.get unavailable'));
+
+    await expect(suspend(world)).resolves.toBeDefined();
+    expect(world.queue).toHaveBeenCalled();
+  });
+
+  it('continues when the persisted step has no input to compare', async () => {
+    const { world } = conflictingWorld({ stepName: 'update' });
+
+    await expect(suspend(world)).resolves.toBeDefined();
+  });
+
+  it('leaves a concurrent serialization failure to its own step_failed', async () => {
+    // The winner could not serialize its arguments and recorded the
+    // placeholder; that branch fails the step with the real error.
+    const { world } = conflictingWorld({
+      stepName: 'update',
+      input: await dehydrateStepArguments(
+        unserializableStepInputPlaceholder(),
+        RUN_ID,
+        undefined,
+        globalThis
+      ),
+    });
+
+    await expect(suspend(world)).resolves.toBeDefined();
   });
 });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -30,6 +30,7 @@ import {
   queueMessage,
   withPreconditionRetry,
 } from './helpers.js';
+import { verifyDuplicateStepCreate } from './step-create-conflict.js';
 import { unserializableStepInputPlaceholder } from './unserializable-step.js';
 
 /**
@@ -472,10 +473,17 @@ export async function handleSuspension({
             await createGuarded(stepEvent, { requestId });
           } catch (err) {
             if (EntityConflictError.is(err)) {
-              runtimeLogger.info('Step already exists, continuing', {
-                workflowRunId: runId,
+              // A concurrent handler wrote this step first. Benign when it
+              // wrote the same invocation; a different name or input under
+              // this id is a non-deterministic replay and fails the run.
+              await verifyDuplicateStepCreate({
+                world,
+                runId,
                 correlationId: queueItem.correlationId,
-                message: err.message,
+                stepName: queueItem.stepName,
+                dehydratedInput,
+                encryptionKey,
+                conflictMessage: err.message,
               });
             } else {
               throw err;

--- a/packages/core/src/step-delivery-ordering.test.ts
+++ b/packages/core/src/step-delivery-ordering.test.ts
@@ -143,7 +143,14 @@ const CORR_IDS = [
   '01K11TFZ62YS0YYFDQ3E8B9YCW',
   '01K11TFZ62YS0YYFDQ3E8B9YCX',
   '01K11TFZ62YS0YYFDQ3E8B9YCY',
+  '01K11TFZ62YS0YYFDQ3E8B9YCZ',
 ];
+
+function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
+  return [...ctx.invocationsQueue.values()]
+    .filter((item) => item.type === 'step')
+    .map((item) => (item.type === 'step' ? item.stepName : ''));
+}
 
 async function runWithDiscontinuation(
   ctx: WorkflowOrchestratorContext,
@@ -301,12 +308,6 @@ describe('step result delivery ordering across replays', () => {
 
         await Promise.all([branchStep, branchSleep]);
       };
-    }
-
-    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
-      return [...ctx.invocationsQueue.values()]
-        .filter((item) => item.type === 'step')
-        .map((item) => (item.type === 'step' ? item.stepName : ''));
     }
 
     it('delivers the wait before the step result on the first replay, matching the log', async () => {
@@ -506,12 +507,6 @@ describe('step result delivery ordering across replays', () => {
       };
     }
 
-    function pendingStepNames(ctx: WorkflowOrchestratorContext): string[] {
-      return [...ctx.invocationsQueue.values()]
-        .filter((item) => item.type === 'step')
-        .map((item) => (item.type === 'step' ? item.stepName : ''));
-    }
-
     it('delivers the hook payload before the step result on the first replay, matching the log', async () => {
       const hydration = delayHydration();
       spy = await hydration.install();
@@ -598,6 +593,208 @@ describe('step result delivery ordering across replays', () => {
         ]);
         expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
       }
+    });
+  });
+
+  /**
+   * Third shape, and the one that survives the ordering fix in #3139: a step
+   * result overtaking a wait that is itself parked behind an UNCLAIMED hook
+   * payload.
+   *
+   * A hook payload registers its delivery barrier unarmed when no branch is
+   * waiting on it (`workflow/hook.ts`, `armed: promises.length > 0`), because
+   * nothing in the workflow will ever resolve it — only the barrier registry's
+   * idle safety net retires it. Every other delivery that defers behind hooks
+   * therefore parks behind that payload, waits included.
+   *
+   * A step result may skip an unclaimed payload, or it would stall until that
+   * safety net fires. The bug is that the skip is TRANSITIVE: the step also
+   * skips the wait that is merely parked behind the payload, even though the
+   * wait sits earlier in the log and would otherwise gate it. The step wins a
+   * race the committed log recorded for the wait, the two branches swap
+   * correlation ids, and replay diverges.
+   *
+   * Production shape (o2flow `stepStormReproWorkflow`): the workflow creates a
+   * poke hook it never reads, so every `hook_received` arrives unclaimed, and
+   * the watchdog `wait_completed` events that decide each `Promise.race` sit
+   * behind it. The hook-storm variant of the same workflow consumes its hook
+   * and has never reproduced the divergence, which is the control below.
+   *
+   * Unlike the two shapes above, this one needs no hydration delay and no
+   * shared payload cache: the inversion is structural, not a latency race, so
+   * a single replay on the ordinary path is enough to show it.
+   */
+  describe('step_completed behind a wait parked on an unclaimed hook payload', () => {
+    const resumeAt = new Date('2026-07-27T12:00:05.000Z');
+
+    async function buildEventLog(): Promise<Event[]> {
+      const ops: Promise<any>[] = [];
+      const [hookPayload, stepAResult] = await Promise.all([
+        dehydrateStepReturnValue({ kind: 'poke' }, 'wrun_test', undefined, ops),
+        dehydrateStepReturnValue('ok', 'wrun_test', undefined, ops),
+      ]);
+
+      return [
+        {
+          eventId: 'evnt_0',
+          runId: 'wrun_test',
+          eventType: 'hook_created',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'poke-token', isWebhook: false },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_1',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_2',
+          runId: 'wrun_test',
+          eventType: 'wait_created',
+          correlationId: `wait_${CORR_IDS[2]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_3',
+          runId: 'wrun_test',
+          eventType: 'step_started',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA' },
+          createdAt: new Date(),
+        },
+        // Nothing in the workflow reads this hook, so its barrier registers
+        // unarmed and every later delivery that defers behind hooks parks on
+        // it.
+        {
+          eventId: 'evnt_4',
+          runId: 'wrun_test',
+          eventType: 'hook_received',
+          correlationId: `hook_${CORR_IDS[0]}`,
+          eventData: { token: 'poke-token', payload: hookPayload },
+          createdAt: new Date(),
+        },
+        // The live invocation delivered the wait BEFORE the step result: the
+        // sleep branch resumed first and drew the next correlation id.
+        {
+          eventId: 'evnt_5',
+          runId: 'wrun_test',
+          eventType: 'wait_completed',
+          correlationId: `wait_${CORR_IDS[2]}`,
+          eventData: { resumeAt },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_6',
+          runId: 'wrun_test',
+          eventType: 'step_completed',
+          correlationId: `step_${CORR_IDS[1]}`,
+          eventData: { stepName: 'stepA', result: stepAResult },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_7',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[3]}`,
+          eventData: { stepName: 'afterSleep' },
+          createdAt: new Date(),
+        },
+        {
+          eventId: 'evnt_8',
+          runId: 'wrun_test',
+          eventType: 'step_created',
+          correlationId: `step_${CORR_IDS[4]}`,
+          eventData: { stepName: 'afterStep' },
+          createdAt: new Date(),
+        },
+      ];
+    }
+
+    /**
+     * Draw order: `createHook()` takes CORR_IDS[0], `stepA()` CORR_IDS[1],
+     * `sleep()` CORR_IDS[2]; then whichever branch resumes FIRST takes
+     * CORR_IDS[3] and the other takes CORR_IDS[4].
+     *
+     * The `awaited` variant adds a third branch that awaits the payload and
+     * draws nothing, so both variants replay the SAME event log and differ
+     * only in whether the payload is claimed.
+     */
+    function workflowBody(
+      ctx: WorkflowOrchestratorContext,
+      poke: 'unclaimed' | 'awaited'
+    ) {
+      const useStep = createUseStep(ctx);
+      const sleep = createSleep(ctx);
+      const createHook = createCreateHook(ctx);
+
+      return async () => {
+        const stepA = useStep('stepA');
+        const afterStep = useStep('afterStep');
+        const afterSleep = useStep('afterSleep');
+        const pokeHook = createHook<{ kind: string }>({ token: 'poke-token' });
+
+        const branchStep = (async () => {
+          await stepA();
+          await afterStep();
+        })();
+        const branchSleep = (async () => {
+          await sleep(resumeAt);
+          await afterSleep();
+        })();
+        const branchPoke = (async () => {
+          if (poke === 'awaited') {
+            await pokeHook;
+          }
+        })();
+
+        await Promise.all([branchStep, branchSleep, branchPoke]);
+      };
+    }
+
+    it('keeps log order when the hook payload is never claimed', async () => {
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(
+        ctx,
+        workflowBody(ctx, 'unclaimed')
+      );
+
+      expect(error).toBeDefined();
+      // FAILS on `main`: the step result skips the wait transitively through
+      // the unclaimed payload, `afterStep` draws CORR_IDS[3], and replay
+      // diverges at evnt_7 with the production error shape ("... belongs to
+      // \"afterSleep\", but the current step consumer is \"afterStep\"").
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterSleep', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
+    });
+
+    // Control: same event log, but a branch awaits the payload, so the hook
+    // barrier arms, the wait no longer parks behind it, and the step gates on
+    // the wait the ordinary way. This passes on `main` and must keep passing.
+    it('keeps log order when the hook payload is claimed', async () => {
+      const events = await buildEventLog();
+
+      const ctx = setupWorkflowContext(events);
+      const { error } = await runWithDiscontinuation(
+        ctx,
+        workflowBody(ctx, 'awaited')
+      );
+
+      expect(error).toBeDefined();
+      if (!WorkflowSuspension.is(error)) {
+        throw error;
+      }
+      expect(pendingStepNames(ctx).sort()).toEqual(['afterSleep', 'afterStep']);
+      expect(ctx.eventsConsumer.eventIndex).toBe(events.length);
     });
   });
 });

--- a/packages/core/src/storm-log-replay.test.ts
+++ b/packages/core/src/storm-log-replay.test.ts
@@ -63,6 +63,10 @@ function setupWorkflowContext(
   const context = createContext({ seed: SEED, fixedTimestamp: FIXED_TS });
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
+  // Real-session parity: the log-order-draws quiescence fixpoint keys its
+  // progress metric on `mintCount`; without it the loop degrades to a single
+  // turn and this suite would only exercise a degraded variant.
+  let mintCount = 0;
   const promiseQueueHolder = { current: Promise.resolve() };
   const ctxRef: { current?: WorkflowOrchestratorContext } = {};
   const ctx: WorkflowOrchestratorContext = {
@@ -83,7 +87,13 @@ function setupWorkflowContext(
       getPromiseQueue: () => promiseQueueHolder.current,
     }),
     invocationsQueue: new Map(),
-    generateUlid: () => ulid(workflowStartedAt),
+    generateUlid: () => {
+      mintCount += 1;
+      return ulid(workflowStartedAt);
+    },
+    get mintCount() {
+      return mintCount;
+    },
     generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
     ),

--- a/packages/core/src/storm-log-sweep.test.ts
+++ b/packages/core/src/storm-log-sweep.test.ts
@@ -36,6 +36,10 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
   const context = createContext({ seed: SEED, fixedTimestamp: FIXED_TS });
   const ulid = monotonicFactory(() => context.globalThis.Math.random());
   const workflowStartedAt = context.globalThis.Date.now();
+  // Real-session parity: the log-order-draws quiescence fixpoint keys its
+  // progress metric on `mintCount`; without it the loop degrades to a single
+  // turn and this suite would only exercise a degraded variant.
+  let mintCount = 0;
   const promiseQueueHolder = { current: Promise.resolve() };
   const ctxRef: { current?: WorkflowOrchestratorContext } = {};
   const ctx: WorkflowOrchestratorContext = {
@@ -56,7 +60,13 @@ function setupWorkflowContext(events: Event[]): WorkflowOrchestratorContext {
       getPromiseQueue: () => promiseQueueHolder.current,
     }),
     invocationsQueue: new Map(),
-    generateUlid: () => ulid(workflowStartedAt),
+    generateUlid: () => {
+      mintCount += 1;
+      return ulid(workflowStartedAt);
+    },
+    get mintCount() {
+      return mintCount;
+    },
     generateNanoid: nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * context.globalThis.Math.random())
     ),

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -134,6 +134,21 @@ export async function runWorkflow(
     const workflowDiscontinuation = withResolvers<void>();
 
     const ulid = monotonicFactory(() => vmGlobalThis.Math.random());
+    // Correlation IDs are ordinals of this one seeded sequence. The draw
+    // counter is the progress metric for `quiesceEarlierCascades`
+    // (WORKFLOW_LOG_ORDER_DRAWS): a quiet turn is one that drew nothing. It
+    // counts EVERY draw from the sequence — this same function is installed as
+    // the `STABLE_ULID` global below, which serialization draws stream ids
+    // from during dehydration — deliberately: quiescence must also wait out
+    // serialization-driven draws, and counting extra draws only extends the
+    // wait (see the termination note on `quiesceEarlierCascades`). Seeding
+    // every draw with `startedAt` also keeps a stream id minted during
+    // dehydration from latching the host wall clock into the sequence.
+    let mintCount = 0;
+    const generateUlid = () => {
+      mintCount += 1;
+      return ulid(+startedAt);
+    };
     const generateNanoid = nanoid.customRandom(nanoid.urlAlphabet, 21, (size) =>
       new Uint8Array(size).map(() => 256 * vmGlobalThis.Math.random())
     );
@@ -170,7 +185,10 @@ export async function runWorkflow(
       globalThis: vmGlobalThis,
       onWorkflowError: workflowDiscontinuation.reject,
       eventsConsumer,
-      generateUlid: () => ulid(+startedAt),
+      generateUlid,
+      get mintCount() {
+        return mintCount;
+      },
       generateNanoid,
       invocationsQueue: new Map(),
       // Use getter/setter so the EventsConsumer's getPromiseQueue() always
@@ -234,7 +252,7 @@ export async function runWorkflow(
     // @ts-expect-error - `@types/node` says symbol is not valid, but it does work
     vmGlobalThis[WORKFLOW_CONTEXT_SYMBOL] = ctx;
     // @ts-expect-error - `@types/node` says symbol is not valid, but it does work
-    vmGlobalThis[STABLE_ULID] = ulid;
+    vmGlobalThis[STABLE_ULID] = generateUlid;
 
     // NOTE: Will have a config override to use the custom fetch step.
     //       For now `fetch` must be explicitly imported from `workflow`.


### PR DESCRIPTION
Backport of #3406 and #3700 to `stable`, plus a new guard that turns the silent variant of the same bug into a run failure.

## Why

A production run on `workflow@4.8.5` completed successfully while one branch of a `Promise.allSettled` fan-out wrote another branch's step result to its own row. The event log shows how: the fan-out's 14 `findCurrentStatusStep` creates were minted by two concurrent invocations (a queue-woken replay and the original invocation continuing after its inline step), each drawing the run's ordinal correlation ids in a different order and each losing 6-8 of its `step_created` writes to the other as duplicates. The step body ran with the first writer's arguments; a later replay bound the same id to a different branch and handed that branch the result.

This is exactly the draw-order dependence #3700 fixes on `main`. `stable` has #3554 (delivery *retirement* pinned to log order) but not #3700 (*draw* order pinned to log order), so 4.8.5 through 4.8.8 are all affected. It stayed silent because the step consumer only checks the step *name* on an incoming event, and the suspension handler swallows the 409 on a duplicate `step_created` with an info log; when both branches call the same step function nothing notices.

## What's in here

1. **#3406** (`gatesOn` extraction; prerequisite for #3700's `private.ts` changes). This is the same commit as the open backport #3718, cherry-picked here because #3700 doesn't apply without it. If #3718 merges first this PR rebases trivially; otherwise #3718 can be closed as included.
2. **#3700**, ported by hand:
   - `workflow.ts` on `stable` has drifted from `main` (no `onDuplicateEvent`, no clock guard, `generateUlid` inline on the context), so the `mintCount` plumbing was rewritten against the `stable` shape.
   - `stable` had `vmGlobalThis[STABLE_ULID] = ulid` (the raw factory, unseeded). It now installs the counting, `startedAt`-seeded generator, which is what #3700 relies on for quiescence and is also #3301's fix for a stream id minted during dehydration latching the host wall clock into the id sequence.
   - `test-support/orchestrator-context.ts` doesn't exist on `stable` (it came with #3381); the four affected suites here each define their own context and received the same `mintCount` addition. `log-order-draws.test.ts` uses `runWorkflow` and ports unchanged.
   - The changeset bump is `patch`, not `minor`: on `stable` this is a bug fix, and a `workflow` minor would force a major on `@workflow/ai`'s peer range.
   - The `runtime-tuning.mdx` docs hunk targets the v5 docs tree, which `stable` doesn't have; `stable` has no runtime env-var reference page to add `WORKFLOW_LOG_ORDER_DRAWS` to, so it's documented in the changeset only.
3. **New: `verifyDuplicateStepCreate`** (`runtime/step-create-conflict.ts`). On a 409 for `step_created`, read the persisted step and compare its name and its decrypted input bytes with ours. Same invocation: continue as before. Different name or arguments: throw `CorruptedEventLogError`, which `runtime.ts` now routes to the normal terminal path so the run fails as `CORRUPTED_EVENT_LOG` instead of redelivering or continuing with the wrong result. Best-effort by design: if the persisted step can't be read or compared, it logs and continues, so the check can't turn a transient read failure into a failed run. A concurrent serialization-failure placeholder is left to its own `step_failed`.

## Testing

- `packages/core`: 20 tests in `suspension-handler.test.ts` + `log-order-draws.test.ts` pass, including 7 new guard tests (same input, different input, different name, encrypted compare by plaintext, unreadable step, missing input, placeholder).
- Full `@workflow/core` suite: 866 passed, 7 failed. The 7 are `serialization.test.ts > DOMException serialization` and fail identically on an untouched `origin/stable` checkout with Node 22.18, so they are unrelated to this change.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
