### PR TITLE
[core] Fail the run when a duplicate step_created belongs to a different invocation

### DIFF
--- a/.changeset/step-created-conflict-guard.md
+++ b/.changeset/step-created-conflict-guard.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Fail a run as `CORRUPTED_EVENT_LOG` when a concurrent replay already created a step under the same correlation id but with a different step name or different arguments, instead of continuing and delivering that step's result to the wrong call.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3423,11 +3423,22 @@ export function workflowEntrypoint(
                             // hand it back to the queue to spin again.
                             throw escalation.error;
                           }
-                          if (!FatalError.is(suspensionError)) {
+                          if (
+                            !FatalError.is(suspensionError) &&
+                            !CorruptedEventLogError.is(suspensionError)
+                          ) {
                             // Transient failures propagate to the queue
                             // handler so the message is redelivered.
                             throw suspensionError;
                           }
+                          // A CorruptedEventLogError here means the handler
+                          // found a `step_created` a concurrent replay wrote
+                          // under the same correlation id for a DIFFERENT
+                          // step invocation (`verifyDuplicateStepCreate`).
+                          // Redelivery would replay into the same collision
+                          // and continuing would hand that step's result to
+                          // the wrong call, so it fails the run below like
+                          // any other non-retryable suspension failure.
                           // Non-retryable failure while committing the
                           // suspension's events, e.g. an attribute write
                           // the World rejected as invalid (the cumulative

--- a/packages/core/src/runtime/step-create-conflict.ts
+++ b/packages/core/src/runtime/step-create-conflict.ts
@@ -1,0 +1,167 @@
+import { CorruptedEventLogError } from '@workflow/errors';
+import type { World } from '@workflow/world';
+import type { CryptoKey } from '../encryption.js';
+import { runtimeLogger } from '../logger.js';
+import {
+  decodeFormatPrefix,
+  decompress,
+  maybeDecrypt,
+} from '../serialization.js';
+import { UNSERIALIZABLE_STEP_INPUT_MARKER } from './unserializable-step.js';
+
+/**
+ * Verify that a `step_created` the World rejected as a duplicate (409) was
+ * written for the SAME step invocation this replay is trying to create.
+ *
+ * Correlation ids are ordinals of one per-run draw sequence, so two replays
+ * that reach a `useStep` call in different orders can hand one id to two
+ * different invocations. The World keeps whichever `step_created` landed
+ * first, so the step body runs with the winner's arguments while the loser's
+ * branch awaits the same id: its continuation then receives a result that
+ * belongs to a different call. When the two calls are the same step function
+ * (a fan-out mapping the same step over a list is the common shape), the
+ * name check in the step consumer cannot see this, and the run completes
+ * with silently cross-wired data.
+ *
+ * A duplicate whose persisted name and input match ours is the benign case
+ * (two replays that agree on the binding raced on the write) and is
+ * ignored, as before. A duplicate that persisted a different step name or a
+ * different input is proof that the run's replay is non-deterministic, and
+ * this throws a {@link CorruptedEventLogError} so the run fails instead of
+ * continuing with the wrong result.
+ *
+ * Inputs are compared as plaintext bytes after decryption and decompression: the persisted
+ * input and ours were both produced by `dehydrateStepArguments` from the
+ * same deterministic VM state, so the same invocation yields identical
+ * bytes, and AES-GCM's random nonce is the only reason the stored bytes
+ * could differ for the same input.
+ *
+ * Verification is best-effort: when the persisted step cannot be read, or
+ * either side is not in a comparable form, the duplicate is treated as
+ * benign and logged, exactly like before this check existed. The check must
+ * never turn a transient read failure into a failed run.
+ */
+export async function verifyDuplicateStepCreate({
+  world,
+  runId,
+  correlationId,
+  stepName,
+  dehydratedInput,
+  encryptionKey,
+  conflictMessage,
+}: {
+  world: World;
+  runId: string;
+  correlationId: string;
+  stepName: string;
+  dehydratedInput: unknown;
+  encryptionKey: CryptoKey | undefined;
+  conflictMessage: string;
+}): Promise<void> {
+  const details = {
+    workflowRunId: runId,
+    correlationId,
+    stepName,
+    message: conflictMessage,
+  };
+
+  let persisted: { stepName: string; input?: unknown };
+  try {
+    persisted = await world.steps.get(runId, correlationId);
+  } catch (err) {
+    runtimeLogger.warn(
+      'Step already exists, but the persisted step could not be read to verify it; continuing',
+      { ...details, error: err instanceof Error ? err.message : String(err) }
+    );
+    return;
+  }
+
+  if (persisted.stepName !== stepName) {
+    throw new CorruptedEventLogError(
+      `Step ${correlationId} was already created as "${persisted.stepName}", but this replay invoked "${stepName}" under the same correlation id. Two replays of this run assigned the same correlation id to different step calls, so the run's replay is not deterministic.`
+    );
+  }
+
+  const comparison = await compareDehydratedInputs(
+    persisted.input,
+    dehydratedInput,
+    encryptionKey
+  );
+
+  if (comparison === 'equal') {
+    runtimeLogger.info('Step already exists, continuing', details);
+    return;
+  }
+
+  if (comparison === 'incomparable') {
+    runtimeLogger.warn(
+      'Step already exists, but its persisted input could not be compared with this replay; continuing',
+      details
+    );
+    return;
+  }
+
+  throw new CorruptedEventLogError(
+    `Step ${correlationId} ("${stepName}") was already created with different arguments than this replay passed to it. Two replays of this run assigned the same correlation id to different invocations of "${stepName}", so the step's result would be delivered to the wrong call.`
+  );
+}
+
+async function compareDehydratedInputs(
+  persisted: unknown,
+  local: unknown,
+  encryptionKey: CryptoKey | undefined
+): Promise<'equal' | 'different' | 'incomparable'> {
+  if (persisted === undefined || local === undefined) {
+    return 'incomparable';
+  }
+  let a: unknown;
+  let b: unknown;
+  try {
+    // Peel the layers `dehydrateStepArguments` adds around the devalue
+    // payload (encryption, then compression) so two encodings of the same
+    // arguments compare equal even when only one side was compressed.
+    [a, b] = await Promise.all([
+      maybeDecrypt(persisted, encryptionKey).then((d) => decompress(d)),
+      maybeDecrypt(local, encryptionKey).then((d) => decompress(d)),
+    ]);
+  } catch {
+    return 'incomparable';
+  }
+  if (a instanceof Uint8Array && b instanceof Uint8Array) {
+    if (bytesEqual(a, b)) return 'equal';
+    // The winner recorded the placeholder `finalizeUnserializableStep`
+    // writes when a step's arguments refuse to serialize. That branch is
+    // about to fail the step with the serialization error, which is the
+    // outcome the user should see; do not mask it with a corruption report.
+    if (isUnserializablePlaceholder(a)) return 'incomparable';
+    return 'different';
+  }
+  if (a instanceof Uint8Array || b instanceof Uint8Array) {
+    return 'incomparable';
+  }
+  // Legacy specVersion 1 runs store step input as plain JSON.
+  try {
+    return JSON.stringify(a) === JSON.stringify(b) ? 'equal' : 'different';
+  } catch {
+    return 'incomparable';
+  }
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function isUnserializablePlaceholder(plaintext: Uint8Array): boolean {
+  try {
+    const { payload } = decodeFormatPrefix(plaintext);
+    return new TextDecoder()
+      .decode(payload)
+      .includes(UNSERIALIZABLE_STEP_INPUT_MARKER);
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -1,5 +1,6 @@
 import { runInNewContext } from 'node:vm';
 import {
+  CorruptedEventLogError,
   EntityConflictError,
   FatalError,
   PreconditionFailedError,
@@ -15,13 +16,21 @@ import {
   type World,
 } from '@workflow/world';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type CryptoKey, importKey } from '../encryption.js';
 import { type QueueItem, WorkflowSuspension } from '../global.js';
-import { hydrateStepArguments, hydrateStepError } from '../serialization.js';
+import {
+  dehydrateStepArguments,
+  hydrateStepArguments,
+  hydrateStepError,
+} from '../serialization.js';
 import { COMPUTE_INSTANCE_ID } from './compute-instance.js';
 import { maxEventSlot, stepDispatchIdempotencyKey } from './helpers.js';
 import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
 import { handleSuspension } from './suspension-handler.js';
-import { isUnserializableStepInputPlaceholder } from './unserializable-step.js';
+import {
+  isUnserializableStepInputPlaceholder,
+  unserializableStepInputPlaceholder,
+} from './unserializable-step.js';
 
 vi.mock('../version.js', () => ({ version: '0.0.0-test' }));
 
@@ -2642,5 +2651,182 @@ describe('step-argument serialization failure', () => {
       })
     ).rejects.toMatchObject({ name: 'SerializationError' });
     expect(eventsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('duplicate step_created verification', () => {
+  // Two replays that assign one correlation id to different `useStep` calls
+  // race on the same `step_created`; the World keeps the first. The loser
+  // must notice when the persisted step is not the invocation it is holding,
+  // or its branch silently receives another call's result.
+  const RUN_ID = run.runId;
+
+  function stepItem(correlationId: string, stepName: string, args: unknown[]) {
+    return { type: 'step' as const, correlationId, stepName, args };
+  }
+
+  // s1-s3 take the lazy-inline slots (default cap 3) and write no
+  // step_created here; s_dup is the eager step whose create conflicts.
+  function pending(dup = stepItem('s_dup', 'update', [42])) {
+    return new Map<string, ReturnType<typeof stepItem>>([
+      ['s1', stepItem('s1', 'a', [])],
+      ['s2', stepItem('s2', 'b', [])],
+      ['s3', stepItem('s3', 'c', [])],
+      [dup.correlationId, dup],
+    ]);
+  }
+
+  async function persistedInput(args: unknown[], key?: CryptoKey) {
+    return dehydrateStepArguments(
+      { args, closureVars: undefined, thisVal: undefined },
+      RUN_ID,
+      key,
+      globalThis
+    );
+  }
+
+  function conflictingWorld(
+    persisted: { stepName: string; input?: unknown } | Error,
+    rawKey?: Uint8Array
+  ) {
+    const eventsCreate = vi
+      .fn()
+      .mockImplementation(
+        async (_runId: string, event: { correlationId?: string }) => {
+          if (event.correlationId === 's_dup') {
+            throw new EntityConflictError('already exists');
+          }
+          return { event };
+        }
+      );
+    const stepsGet =
+      persisted instanceof Error
+        ? vi.fn().mockRejectedValue(persisted)
+        : vi.fn().mockResolvedValue({
+            runId: RUN_ID,
+            stepId: 's_dup',
+            status: 'pending',
+            attempt: 0,
+            ...persisted,
+          });
+    const world = {
+      events: { create: eventsCreate },
+      steps: { get: stepsGet },
+      queue: vi.fn().mockResolvedValue({ messageId: 'msg_123' }),
+      getEncryptionKeyForRun: vi.fn().mockResolvedValue(rawKey),
+    } as unknown as World;
+    return { world, eventsCreate, stepsGet };
+  }
+
+  const stepDispatch = () => ({
+    queueName: '__wkf_workflow_test-workflow' as ValidQueueName,
+    getTraceCarrier: vi.fn().mockResolvedValue({}),
+  });
+
+  function suspend(world: World, items = pending()) {
+    return handleSuspension({
+      suspension: new WorkflowSuspension(items, globalThis),
+      world,
+      run,
+    });
+  }
+
+  it('continues when the persisted step is the same invocation', async () => {
+    const { world, stepsGet } = conflictingWorld({
+      stepName: 'update',
+      input: await persistedInput([42]),
+    });
+
+    await expect(suspend(world)).resolves.toBeDefined();
+    expect(stepsGet).toHaveBeenCalledWith(RUN_ID, 's_dup');
+  });
+
+  it('fails the run when the persisted step has different arguments', async () => {
+    const { world } = conflictingWorld({
+      stepName: 'update',
+      input: await persistedInput([43]),
+    });
+
+    await expect(suspend(world)).rejects.toThrow(CorruptedEventLogError);
+    await expect(suspend(world)).rejects.toThrow(
+      /s_dup \("update"\) was already created with different arguments/
+    );
+  });
+
+  it('fails the run when the persisted step is a different step function', async () => {
+    const { world } = conflictingWorld({
+      stepName: 'somethingElse',
+      input: await persistedInput([42]),
+    });
+
+    await expect(suspend(world)).rejects.toThrow(
+      /already created as "somethingElse", but this replay invoked "update"/
+    );
+  });
+
+  it('compares encrypted inputs by plaintext, not ciphertext', async () => {
+    const rawKey = crypto.getRandomValues(new Uint8Array(32));
+    const key = await importKey(rawKey);
+    // A separate encryption of the same arguments: different nonce, so the
+    // stored bytes differ even though the input is identical.
+    const same = conflictingWorld(
+      { stepName: 'update', input: await persistedInput([42], key) },
+      rawKey
+    );
+    await expect(suspend(same.world)).resolves.toBeDefined();
+
+    const different = conflictingWorld(
+      { stepName: 'update', input: await persistedInput([43], key) },
+      rawKey
+    );
+    await expect(suspend(different.world)).rejects.toThrow(
+      CorruptedEventLogError
+    );
+  });
+
+  it('continues when the persisted step cannot be read', async () => {
+    const { world } = conflictingWorld(new Error('steps.get unavailable'));
+    await expect(suspend(world)).resolves.toBeDefined();
+  });
+
+  it('continues when the persisted step has no input to compare', async () => {
+    const { world } = conflictingWorld({ stepName: 'update' });
+    await expect(suspend(world)).resolves.toBeDefined();
+  });
+
+  it('leaves a concurrent serialization failure to its own step_failed', async () => {
+    // The winner could not serialize its arguments and recorded the
+    // placeholder; that branch fails the step with the real error.
+    const { world } = conflictingWorld({
+      stepName: 'update',
+      input: await dehydrateStepArguments(
+        unserializableStepInputPlaceholder(),
+        RUN_ID,
+        undefined,
+        globalThis
+      ),
+    });
+    await expect(suspend(world)).resolves.toBeDefined();
+  });
+
+  it('verifies the duplicate on the resilient dispatch path too', async () => {
+    vi.stubEnv('WORKFLOW_RESILIENT_STEP_DISPATCH', '1');
+    try {
+      const { world, stepsGet } = conflictingWorld({
+        stepName: 'update',
+        input: await persistedInput([43]),
+      });
+      await expect(
+        handleSuspension({
+          suspension: new WorkflowSuspension(pending(), globalThis),
+          world,
+          run: { ...run, specVersion: 3 },
+          stepDispatch: stepDispatch(),
+        })
+      ).rejects.toThrow(CorruptedEventLogError);
+      expect(stepsGet).toHaveBeenCalledWith(RUN_ID, 's_dup');
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -64,6 +64,7 @@ import {
   stepDispatchIdempotencyKey,
 } from './helpers.js';
 import { ReplayRecoveryReporter } from './replay-recovery-reporter.js';
+import { verifyDuplicateStepCreate } from './step-create-conflict.js';
 import type { PreclaimedInlineStart } from './step-executor.js';
 import { unserializableStepInputPlaceholder } from './unserializable-step.js';
 
@@ -1106,6 +1107,24 @@ export async function handleSuspension({
     event: CreateEventRequest;
   }[] = [];
   const batchPreps: Promise<void>[] = [];
+  /** Same check as the single-write paths, for a `step_created` that the
+   *  batch commit reported as a duplicate. */
+  const verifyDuplicateBatchedStepCreate = (
+    entry: (typeof batchQueue)[number],
+    conflictMessage: string
+  ): Promise<void> =>
+    verifyDuplicateStepCreate({
+      world,
+      runId,
+      correlationId: entry.correlationId,
+      stepName: entry.stepName ?? '',
+      dehydratedInput:
+        entry.event.eventType === 'step_created'
+          ? entry.event.eventData.input
+          : undefined,
+      encryptionKey,
+      conflictMessage,
+    });
 
   // Pre-claimed inline pairs: fold each lazy-inline step's deferred
   // `step_created` (carrying its input) AND its `step_started` claim (bare,
@@ -1318,10 +1337,17 @@ export async function handleSuspension({
               // Concurrent handler wrote it first, same as the sequential
               // path. The step message is already out; a duplicate publish
               // by that handler dedupes on the shared idempotency key.
-              runtimeLogger.info('Step already exists, continuing', {
-                workflowRunId: runId,
+              // Benign only if it wrote the SAME invocation: a different
+              // name or input under this id fails the run (see
+              // verifyDuplicateStepCreate).
+              await verifyDuplicateStepCreate({
+                world,
+                runId,
                 correlationId: queueItem.correlationId,
-                message: err.message,
+                stepName: queueItem.stepName,
+                dehydratedInput,
+                encryptionKey,
+                conflictMessage: err.message,
               });
             } else if (isRetryableWorldError(err)) {
               // Resilient: the write failed transiently (429 / 5xx /
@@ -1369,10 +1395,17 @@ export async function handleSuspension({
           createdStepCorrelationIds.add(queueItem.correlationId);
         } catch (err) {
           if (EntityConflictError.is(err)) {
-            runtimeLogger.info('Step already exists, continuing', {
-              workflowRunId: runId,
+            // A concurrent handler wrote this step first. Benign when it
+            // wrote the same invocation; a different name or input under
+            // this id is a non-deterministic replay and fails the run.
+            await verifyDuplicateStepCreate({
+              world,
+              runId,
               correlationId: queueItem.correlationId,
-              message: err.message,
+              stepName: queueItem.stepName,
+              dehydratedInput,
+              encryptionKey,
+              conflictMessage: err.message,
             });
           } else {
             throw err;
@@ -1481,16 +1514,15 @@ export async function handleSuspension({
             }
           } catch (err) {
             if (EntityConflictError.is(err)) {
-              runtimeLogger.info(
-                entry.kind === 'step'
-                  ? 'Step already exists, continuing'
-                  : 'Wait already exists, continuing',
-                {
+              if (entry.kind === 'step') {
+                await verifyDuplicateBatchedStepCreate(entry, err.message);
+              } else {
+                runtimeLogger.info('Wait already exists, continuing', {
                   workflowRunId: runId,
                   correlationId: entry.correlationId,
                   message: err.message,
-                }
-              );
+                });
+              }
             } else {
               throw err;
             }
@@ -1658,6 +1690,12 @@ export async function handleSuspension({
                 // exactly the single path's semantics (create lost + claim
                 // won still runs the body; create won + claim lost skips).
                 inlineClaims.set(entry.correlationId, { owned: false });
+                if (entry.kind === 'inline-created') {
+                  // The created row lost: the entity already existed. Make
+                  // sure it is the same invocation before this replay goes
+                  // on to await its result (verifyDuplicateStepCreate).
+                  await verifyDuplicateBatchedStepCreate(entry, item.message);
+                }
                 runtimeLogger.info('Inline step pre-claim lost, continuing', {
                   workflowRunId: runId,
                   correlationId: entry.correlationId,
@@ -1666,17 +1704,18 @@ export async function handleSuspension({
                 continue;
               }
               // Same tolerance as the single path's EntityConflictError: a
-              // concurrent or earlier delivery already created it.
-              runtimeLogger.info(
-                entry.kind === 'step'
-                  ? 'Step already exists, continuing'
-                  : 'Wait already exists, continuing',
-                {
+              // concurrent or earlier delivery already created it. For a
+              // step, only when it created the SAME invocation
+              // (verifyDuplicateStepCreate).
+              if (entry.kind === 'step') {
+                await verifyDuplicateBatchedStepCreate(entry, item.message);
+              } else {
+                runtimeLogger.info('Wait already exists, continuing', {
                   workflowRunId: runId,
                   correlationId: entry.correlationId,
                   message: item.message,
-                }
-              );
+                });
+              }
               continue;
             }
             throw new WorkflowWorldError(


### PR DESCRIPTION
Detection half of the correlation-id draw-order bug: when a concurrent replay already created a step under the same correlation id, verify it is the *same* step invocation before continuing, and fail the run if it is not.

## Why

Correlation ids are ordinals of one per-run draw sequence. When two replays reach a `useStep` call in different orders, one id gets bound to two different invocations; the World keeps whichever `step_created` landed first, and the loser's branch goes on to await an id whose body runs with someone else's arguments. #3554 and #3700 make the schedule deterministic so this should no longer happen, but the failure mode when it does is the worst kind: the step consumer only checks the step *name* on an incoming event, and every duplicate-create path in the suspension handler swallows the 409 with `Step already exists, continuing`. Two branches mapping the same step over a list swap results silently and the run completes. A production run on `4.8.5` did exactly that (fix for that channel: the `stable` backport of #3700 is in a separate PR).

## What this does

New `runtime/step-create-conflict.ts`, `verifyDuplicateStepCreate`: on a duplicate `step_created`, read the persisted step (`world.steps.get`) and compare

- its `stepName` with ours, and
- its input with ours as plaintext bytes after `maybeDecrypt` and `decompress`, so the AES-GCM nonce and the compression layer can't produce a false difference.

Same invocation: continue exactly as before. Different name or arguments: throw `CorruptedEventLogError`. `runtime.ts` treats that like a `FatalError` from the suspension handler (fails the run with the classified code, here `CORRUPTED_EVENT_LOG`) rather than redelivering into the same collision.

Best-effort by design: an unreadable persisted step, a missing input, a non-binary (legacy v1) input, or a serialization-failure placeholder logs and continues, so the guard can never turn a transient read failure into a failed run.

Wired into every path that tolerates a duplicate `step_created`: sequential write, resilient dispatch, batch of one, batched fan-out, and the folded lazy-inline pair (verified when the *created* row loses; a lost *started* row alone means we created it).

**Not covered here:** the unfolded lazy-inline claim in `step-executor.ts`, where a lost `step_started` claim returns `skipped` before the workflow continues to await the id. It has the same hazard and the same inputs available; it needs its own look at how an error thrown from `executeStep` propagates, so it's a follow-up.

## Testing

- 8 new tests in `suspension-handler.test.ts` (same input, different input, different name, encrypted compare by plaintext, unreadable step, missing input, placeholder, resilient-dispatch path).
- Full `@workflow/core` suite green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
