### PR TITLE
[e2e] Capture the divergence signature in the event-log-race-repro harness

### DIFF
--- a/.changeset/repro-error-signature.md
+++ b/.changeset/repro-error-signature.md
@@ -1,0 +1,4 @@
+---
+---
+
+Capture the divergence signature in the event-log-race-repro harness so two corruptions sharing an `errorCode` can be told apart.

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -11,7 +11,12 @@ import {
   start as rawStart,
   resumeHook,
 } from '../src/runtime';
-import { getWorkflowMetadata, setupWorld, trackRun } from './utils';
+import {
+  describeRunError,
+  getWorkflowMetadata,
+  setupWorld,
+  trackRun,
+} from './utils';
 
 /**
  * Deliberate reproduction harness for `CORRUPTED_EVENT_LOG`.
@@ -592,21 +597,24 @@ async function pollTerminalRun(
 
     if (runData.status === 'failed') {
       // The machine-readable reason is the plaintext top-level `errorCode`.
-      // `error` is rehydrated into an `Error` instance carrying only
-      // `name`/`message`, so reading `error.code` misclassifies every real
-      // failure as `other` — which is exactly how earlier runs of this job
-      // reported corruptions.
-      const failure = runData as {
-        errorCode?: string;
-        error?: { name?: string; message?: string };
-      };
+      // Reading `error.code` instead misclassifies every real failure as
+      // `other` — which is exactly how earlier runs of this job reported
+      // corruptions.
+      //
+      // `errorCode` alone cannot tell two corruptions apart, and telling them
+      // apart is the whole point of a job that has to say whether a fix
+      // closed *this* class. The divergence text lives in `error`, which
+      // world-vercel hands back as un-hydrated bytes, so `describeRunError`
+      // hydrates it rather than reading a `.message` that is always
+      // `undefined` there.
+      const failure = runData as { errorCode?: string; error?: unknown };
+      const described = await describeRunError(failure.error, run.runId);
       return {
         ...base,
         outcome: classifyFailure(failure.errorCode),
         status: runData.status,
         errorCode: failure.errorCode,
-        errorMessage: failure.error?.message,
-        errorName: failure.error?.name,
+        ...described,
         durationMs: Date.now() - startedAt,
       };
     }

--- a/packages/core/e2e/utils.test.ts
+++ b/packages/core/e2e/utils.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { dehydrateRunError } from '../src/serialization';
 import {
   createPerTestState,
+  describeRunError,
   getCollectedRunIds,
   getRecordedInfraEvents,
   hasStepSourceMaps,
@@ -244,5 +246,82 @@ describe('per-test state isolation', () => {
     expect(
       Object.fromEntries(entries.map((e) => [e.runId, e.testName]))
     ).toEqual({ wrun_a: 'test-a', wrun_b: 'test-b' });
+  });
+});
+
+describe('describeRunError', () => {
+  const RUN_ID = 'wrun_test';
+
+  test('reads the message out of world-vercel SerializedData bytes', async () => {
+    // What `runs.get()` actually returns on world-vercel: the bytes
+    // `dehydrateRunError` wrote, with no `.message` on them.
+    const message =
+      'Workflow replay diverged 4 times after 3 recovery replays; latest ' +
+      'divergent event was evnt_00000000000000000000000303. Last divergence: ' +
+      'Replay could not consume event: eventType=wait_created, ' +
+      'correlationId=wait_01M1C1YT7AQPWWDBJB3APX3C4D, ' +
+      'eventId=evnt_00000000000000000000000303.';
+    const wire = await dehydrateRunError(
+      new Error(message),
+      RUN_ID,
+      undefined,
+      []
+    );
+
+    // The shape the harness used to read straight off the run.
+    expect((wire as { message?: string }).message).toBeUndefined();
+
+    expect(await describeRunError(wire, RUN_ID)).toEqual({
+      errorName: 'Error',
+      errorMessage: message,
+    });
+  });
+
+  test('distinguishes two corruptions that share an errorCode', async () => {
+    // The reason the signature is worth hydrating at all: `errorCode` is
+    // `CORRUPTED_EVENT_LOG` for both of these.
+    const waitShape = await dehydrateRunError(
+      new Error('Replay could not consume event: eventType=wait_created'),
+      RUN_ID,
+      undefined,
+      []
+    );
+    const attrShape = await dehydrateRunError(
+      new Error('Replay finished without consuming event: eventType=attr_set'),
+      RUN_ID,
+      undefined,
+      []
+    );
+
+    const a = await describeRunError(waitShape, RUN_ID);
+    const b = await describeRunError(attrShape, RUN_ID);
+
+    expect(a.errorMessage).toContain('wait_created');
+    expect(b.errorMessage).toContain('attr_set');
+    expect(a.errorMessage).not.toEqual(b.errorMessage);
+  });
+
+  test('passes through an already-hydrated Error (local / postgres worlds)', async () => {
+    const err = new TypeError('already an Error');
+    expect(await describeRunError(err, RUN_ID)).toEqual({
+      errorName: 'TypeError',
+      errorMessage: 'already an Error',
+    });
+  });
+
+  test('passes through a legacy plain record', async () => {
+    expect(
+      await describeRunError({ name: 'Legacy', message: 'old shape' }, RUN_ID)
+    ).toEqual({ errorName: 'Legacy', errorMessage: 'old shape' });
+  });
+
+  test('yields no signature rather than throwing on an unreadable error', async () => {
+    // Encrypted without a key, or simply not a payload this build can read.
+    // The run still has to be reported.
+    await expect(
+      describeRunError(new Uint8Array([1, 2, 3, 4]), RUN_ID)
+    ).resolves.toEqual({});
+    await expect(describeRunError(undefined, RUN_ID)).resolves.toEqual({});
+    await expect(describeRunError(null, RUN_ID)).resolves.toEqual({});
   });
 });

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -11,6 +11,7 @@ import { onTestFailed } from 'vitest';
 import { getTrustedSourcesHeaders } from '../../../scripts/trusted-sources-headers.mjs';
 import type { Run } from '../src/runtime';
 import { getWorld, start as runtimeStart, setWorld } from '../src/runtime';
+import { hydrateRunError } from '../src/serialization';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultCliTimeoutMs = Number(
@@ -1515,3 +1516,64 @@ export const cliInspectJsonUntil = async (
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
 };
+
+/**
+ * The `name` / `message` of a failed run, from whatever shape the World
+ * returned for `run.error`.
+ *
+ * `errorCode` is a plaintext field and always readable, but it only says
+ * *which class* a run died of. Telling two `CORRUPTED_EVENT_LOG`s apart needs
+ * the divergence text, and on world-vercel that is not sitting on the run:
+ * `runs.get()` returns `error` as the `SerializedData` bytes
+ * `dehydrateRunError` wrote, and world-vercel's `deserializeError` is a
+ * pass-through cast, so `run.error.message` is `undefined` no matter what the
+ * run actually failed with. The CLI and the web UI read the text because they
+ * hydrate it themselves; a caller that does not, silently gets nothing.
+ *
+ * Hydration is therefore the caller's job, and this does it the same way,
+ * tolerating every shape a World may hand back:
+ *
+ * - `SerializedData` bytes (world-vercel, spec >= 2), hydrated here.
+ * - An already-hydrated `Error`, which is what the local and Postgres Worlds
+ *   produce and what the encrypted case degrades to.
+ * - A legacy plain `{ name, message }` record.
+ *
+ * Never throws and never rejects: this runs on the reporting path of a job
+ * whose whole purpose is to describe a failure, so an unreadable error must
+ * still yield a row. An unreadable one comes back `undefined`, which reads as
+ * "no signature" in the results JSON rather than as a passing run.
+ */
+export async function describeRunError(
+  error: unknown,
+  runId: string,
+  key?: Parameters<typeof hydrateRunError>[2]
+): Promise<{ errorName?: string; errorMessage?: string }> {
+  if (error == null) return {};
+
+  // Already an Error or a legacy `{name, message}` record.
+  const direct = error as { name?: unknown; message?: unknown };
+  if (typeof direct.message === 'string' || typeof direct.name === 'string') {
+    return {
+      errorName: typeof direct.name === 'string' ? direct.name : undefined,
+      errorMessage:
+        typeof direct.message === 'string' ? direct.message : undefined,
+    };
+  }
+
+  try {
+    const hydrated = (await hydrateRunError(error, runId, key)) as {
+      name?: unknown;
+      message?: unknown;
+    } | null;
+    if (hydrated == null) return {};
+    return {
+      errorName: typeof hydrated.name === 'string' ? hydrated.name : undefined,
+      errorMessage:
+        typeof hydrated.message === 'string' ? hydrated.message : undefined,
+    };
+  } catch {
+    // Encrypted without a key, a format this build cannot read, or plain
+    // corruption. The run still gets reported, just without a signature.
+    return {};
+  }
+}


### PR DESCRIPTION
Closes #3418.

## The gap

`errorCode` says which *class* a run died of, not which corruption it was. A job whose whole purpose is to say whether a fix closed *this* class needs the divergence text — and the harness was reading it off `run.error.message`.

On world-vercel that property does not exist:

- `runs.get()` returns `error` as the `SerializedData` bytes `dehydrateRunError` wrote.
- `normalizeSerializedData` only unwraps the gzip/zstd envelope.
- `deserializeError` in `world-vercel/src/utils.ts` is `return obj as T` — a pass-through cast.

So `run.error?.message` is `undefined` for every real failure, and every corruption the harness reported carried an empty signature. The CLI and the web UI read the text because they hydrate it themselves (`hydrateResourceIO`); a caller that does not, silently gets nothing. That is why the RCA on the production `wait_created` run had the full message (it came from `wf inspect`) while the job that exists to catch that exact shape could not name it.

## The change

`describeRunError` in `e2e/utils.ts` hydrates it the same way, and the harness uses it. It handles the three shapes a World can return:

| Shape | Where from |
|---|---|
| `SerializedData` bytes | world-vercel, spec >= 2 — hydrated here |
| An already-hydrated `Error` | local / Postgres worlds |
| Legacy `{ name, message }` | older records |

It never throws or rejects. This runs on the reporting path of a job that exists to describe a failure, so an unreadable error (encrypted without a key, a format this build cannot read) still has to produce a row — it just comes back without a signature, which reads as "no signature" rather than as a passing run.

## Tests

In `e2e/utils.test.ts`, which is inside `packages/core`'s unit-test scope (`vitest run src e2e/utils.test.ts`), so the round trip is covered on **every** PR rather than only when the harness runs:

- world-vercel bytes → message recovered. The test first asserts the wire value has **no** `.message`, pinning the premise.
- Two corruptions that share `errorCode: CORRUPTED_EVENT_LOG` (a `wait_created` one and an `attr_set` one) produce distinguishable signatures — the thing the job could not do before.
- An already-hydrated `Error` and a legacy record pass through.
- Unreadable input resolves to `{}` instead of throwing.

`packages/core`: 2402 passed, 0 failed. Empty changeset — nothing under `packages/core/e2e/` is published (core's `files` is `dist`, `docs`, `runtime.js`).

## Note for reviewers

Building the workspace first matters here: `packages/core` resolves its siblings from `dist`, and running the suite against unbuilt dists produces hundreds of unrelated failures.