### PR TITLE
Fix lazy v4 event metadata decoding

### DIFF
--- a/.changeset/lazy-v4-event-metadata.md
+++ b/.changeset/lazy-v4-event-metadata.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Fix v4 lazy event reads failing when an expired payload is omitted from otherwise valid event metadata.

--- a/.changeset/lazy-v4-event-metadata.md
+++ b/.changeset/lazy-v4-event-metadata.md
@@ -2,4 +2,4 @@
 '@workflow/world-vercel': patch
 ---
 
-Fix v4 lazy event reads failing when an expired payload is omitted from otherwise valid event metadata.
+Fix lazy event reads failing when an expired payload is omitted from otherwise valid event metadata.

--- a/packages/world-vercel/src/events-v4.test.ts
+++ b/packages/world-vercel/src/events-v4.test.ts
@@ -322,6 +322,93 @@ describe('getWorkflowRunEventsV4 over HTTP', () => {
     agent.assertNoPendingInterceptors();
   });
 
+  it('accepts a lazy step_completed frame whose payload metadata is unavailable', async () => {
+    const origin =
+      WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    agent
+      .get(origin)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events?returnAll=true&remoteRefBehavior=lazy',
+        method: 'GET',
+      })
+      .reply(
+        200,
+        Buffer.concat([
+          encodeFrame(
+            {
+              eventId: 'evnt_53',
+              runId: 'wrun_1',
+              eventType: 'step_completed',
+              correlationId: 'step_1',
+              createdAt: CREATED_AT,
+              eventData: { stepName: 'capture' },
+            },
+            new Uint8Array()
+          ),
+          encodeFrame(
+            { _end: 1, next: 'eid:evnt_53', hasMore: false },
+            new Uint8Array()
+          ),
+        ]),
+        { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+      );
+
+    const result = await getWorkflowRunEventsV4(
+      'wrun_1',
+      { remoteRefBehavior: 'lazy' },
+      { token: 'test-token', dispatcher: agent }
+    );
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        eventId: 'evnt_53',
+        eventType: 'step_completed',
+        eventData: { stepName: 'capture' },
+      }),
+    ]);
+    agent.assertNoPendingInterceptors();
+  });
+
+  it('still rejects a resolved step_completed frame without event data', async () => {
+    const origin =
+      WORKFLOW_SERVER_URL_OVERRIDE || 'https://vercel-workflow.com';
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+
+    agent
+      .get(origin)
+      .intercept({
+        path: '/api/v4/runs/wrun_1/events?returnAll=true&remoteRefBehavior=resolve',
+        method: 'GET',
+      })
+      .reply(
+        200,
+        encodeFrame(
+          {
+            eventId: 'evnt_53',
+            runId: 'wrun_1',
+            eventType: 'step_completed',
+            correlationId: 'step_1',
+            createdAt: CREATED_AT,
+          },
+          new Uint8Array()
+        ),
+        { headers: { 'content-type': V4_FRAME_CONTENT_TYPE } }
+      );
+
+    await expect(
+      getWorkflowRunEventsV4(
+        'wrun_1',
+        { remoteRefBehavior: 'resolve' },
+        { token: 'test-token', dispatcher: agent }
+      )
+    ).rejects.toMatchObject({ code: 'SCHEMA_VALIDATION' });
+    agent.assertNoPendingInterceptors();
+  });
+
   // A permanently missing payload arrives as a terminal frame rather than a
   // truncated body, because a truncated body is what a dropped socket looks
   // like: the runtime cannot tell "retry me" from "this can never work" and

--- a/packages/world-vercel/src/events-v4.ts
+++ b/packages/world-vercel/src/events-v4.ts
@@ -463,9 +463,61 @@ function decodeLegacyStructuredError(payload: Uint8Array): unknown {
   }
 }
 
-function decodeEventFrame({ meta, body }: DecodedFrame): Event {
+/**
+ * Validate a metadata-only frame without requiring its omitted payload field.
+ *
+ * A lazy v4 listing is an observability read: old or expired event rows can
+ * legitimately retain the event metadata after their payload descriptor is no
+ * longer available. `EventSchema` describes a materialized runtime event and
+ * therefore still requires fields such as `step_completed.eventData.result`.
+ * Validate the rest of the event by temporarily supplying an empty payload,
+ * then remove it again before returning the metadata-only event.
+ */
+function decodeLazyEventMeta(
+  meta: Record<string, unknown>,
+  eventType: EventType
+): Event {
+  const payloadField = getEventDataPayloadField(eventType);
+  if (!payloadField) return EventSchema.parse(meta);
+
+  const eventData =
+    meta.eventData && typeof meta.eventData === 'object'
+      ? (meta.eventData as Record<string, unknown>)
+      : undefined;
+  if (eventData?.[payloadField] !== undefined) {
+    return EventSchema.parse(meta);
+  }
+
+  const parsed = EventSchema.parse({
+    ...meta,
+    eventData: {
+      ...eventData,
+      [payloadField]: new Uint8Array(),
+    },
+  });
+  const parsedEventData = {
+    ...(parsed.eventData as Record<string, unknown>),
+  };
+  delete parsedEventData[payloadField];
+
+  return {
+    ...parsed,
+    ...(Object.keys(parsedEventData).length > 0
+      ? { eventData: parsedEventData }
+      : { eventData: undefined }),
+  } as Event;
+}
+
+function decodeEventFrame(
+  { meta, body }: DecodedFrame,
+  remoteRefBehavior: 'resolve' | 'lazy' = 'resolve'
+): Event {
   const eventType = EventTypeSchema.parse(meta.eventType);
-  if (body.byteLength === 0) return EventSchema.parse(meta);
+  if (body.byteLength === 0) {
+    return remoteRefBehavior === 'lazy'
+      ? decodeLazyEventMeta(meta, eventType)
+      : EventSchema.parse(meta);
+  }
 
   const payloadField = getEventDataPayloadField(eventType);
   assert(payloadField, `Event type ${eventType} cannot carry a payload body`);
@@ -1507,7 +1559,7 @@ export async function getEventV4(
       if (Object.keys(frame.meta).some((key) => key.startsWith('_'))) {
         throw new Error('v4 getEvent: unexpected control frame');
       }
-      return decodeEventFrame(frame);
+      return decodeEventFrame(frame, remoteRefBehavior);
     }
   } catch (cause) {
     if (cause instanceof IncompleteFrameError && StreamError.is(cause.cause)) {
@@ -1609,6 +1661,7 @@ function partialEventFrameStream(
 async function consumeEventFrameStream(
   response: Response,
   opName: string,
+  remoteRefBehavior: 'resolve' | 'lazy' = 'resolve',
   replayEventObserver?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const contentType = response.headers.get('content-type');
@@ -1642,7 +1695,7 @@ async function consumeEventFrameStream(
       if (Object.keys(frame.meta).some((key) => key.startsWith('_'))) {
         throw new Error(`v4 ${opName}: unexpected control frame`);
       }
-      const event = decodeEventFrame(frame);
+      const event = decodeEventFrame(frame, remoteRefBehavior);
       events.push(event);
       try {
         replayEventObserver?.(event);
@@ -1700,6 +1753,7 @@ async function consumeReplayLogResponse(
   const page = await consumeEventFrameStream(
     response,
     'createEvent',
+    'resolve',
     replayEventObserver
   );
   if (!page.hasMore) {
@@ -1743,6 +1797,7 @@ async function consumeListFrameStream(
   headers: Headers,
   config: APIConfig | undefined,
   opName: string,
+  remoteRefBehavior: 'resolve' | 'lazy',
   replayEventObserver?: (event: Event) => void
 ): Promise<EventFrameStreamResult> {
   const response = await fetchV4(
@@ -1751,7 +1806,12 @@ async function consumeListFrameStream(
     config,
     opName
   );
-  return consumeEventFrameStream(response, opName, replayEventObserver);
+  return consumeEventFrameStream(
+    response,
+    opName,
+    remoteRefBehavior,
+    replayEventObserver
+  );
 }
 
 /**
@@ -1809,6 +1869,7 @@ export async function getWorkflowRunEventsV4(
       headers,
       config,
       'listEvents',
+      params.remoteRefBehavior ?? 'resolve',
       replayEventObserver
     );
     const cursorAdvanced = !!consumed.cursor && consumed.cursor !== cursor;
@@ -1873,7 +1934,8 @@ export async function getEventsByCorrelationIdV4(
     url,
     headers,
     config,
-    'listEventsByCorrelationId'
+    'listEventsByCorrelationId',
+    params.remoteRefBehavior ?? 'resolve'
   );
   if (consumed.kind === 'partial') throw consumed.error;
   return {


### PR DESCRIPTION
### Description

Fix v4 lazy event reads failing when an event payload has expired and the server omits its payload field from otherwise valid metadata.

The v4 decoder previously validated every zero-body frame as a fully materialized runtime event. Dashboard observability requests use lazy remote-reference behavior, so an expired payload can legitimately be absent. The decoder now validates lazy metadata by temporarily supplying the expected payload field, removes it from the returned event, and threads remote-reference behavior through list, correlation, and single-event reads. Resolved reads and replay remain strict.

Includes a patch changeset for `@workflow/world-vercel`.

### How did you test your changes?

- `pnpm --filter @workflow/world-vercel test` — 31 files, 688 tests passed
- `pnpm --filter @workflow/world-vercel typecheck`
- Focused regression coverage verifies lazy `step_completed` metadata without `result` succeeds and resolved events without event data still fail validation.

### PR Checklist - Required to merge

- [x] 📦 Added a patch changeset
- [x] 🔒 Commit includes DCO sign-off
- [x] 📝 Pinged `@vercel/workflow` in a comment