### PR TITLE
perf(streams): overlap WebSocket takeover after first write

### DIFF
--- a/.changeset/quiet-streams-connect.md
+++ b/.changeset/quiet-streams-connect.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-vercel': patch
+---
+
+Start stream WebSocket connections after the first HTTP group without delaying later HTTP writes.

--- a/packages/world-vercel/src/http-core.ts
+++ b/packages/world-vercel/src/http-core.ts
@@ -549,7 +549,13 @@ export interface InstrumentedFetchOptions extends HttpClientSpanOptions {
    * Non-2xx bodies consumed by `buildError` are still reported here.
    */
   deferTransportSuccessUntilBody?: boolean;
-  /** Error code used when the request itself fails before a response arrives. */
+  /**
+   * Called synchronously after the request promise is created, before awaiting
+   * its response. This observes local dispatch only; it does not imply that any
+   * bytes reached the origin. Must not throw.
+   */
+  onRequestDispatched?: () => void;
+  /** Error code used when the request itself fails before a response arrived. */
   transportErrorCode?: 'TRANSPORT' | 'STREAM_ERROR';
 }
 
@@ -585,6 +591,7 @@ export async function instrumentedFetch(
     durationAttribute,
     onTransportOutcome,
     deferTransportSuccessUntilBody = false,
+    onRequestDispatched,
     transportErrorCode = 'TRANSPORT',
   } = opts;
   const label = logLabel ?? url;
@@ -623,8 +630,8 @@ export async function instrumentedFetch(
         span?.setAttributes({
           ...WorkflowHttpTransport(nodeAgents ? 'node-http' : 'undici'),
         });
-        response = nodeAgents
-          ? await nodeHttpFetch(url, {
+        const request = nodeAgents
+          ? nodeHttpFetch(url, {
               method,
               headers,
               body,
@@ -637,7 +644,7 @@ export async function instrumentedFetch(
               headersTimeoutMs: NODE_HTTP_HEADERS_TIMEOUT_MS,
               bodyTimeoutMs: NODE_HTTP_BODY_TIMEOUT_MS,
             })
-          : await fetch(url, {
+          : fetch(url, {
               method,
               headers,
               body,
@@ -645,6 +652,8 @@ export async function instrumentedFetch(
               // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undici dispatcher type doesn't match @types/node's RequestInit
               dispatcher,
             } as any);
+        onRequestDispatched?.();
+        response = await request;
       } catch (error) {
         const elapsed = Date.now() - start;
         // Report the raw error, before the timeout mapping below rewraps it: the

--- a/packages/world-vercel/src/streamer.ts
+++ b/packages/world-vercel/src/streamer.ts
@@ -211,7 +211,8 @@ export async function writeStreamSessionOverHttp(
   name: string,
   chunks: (string | Uint8Array)[],
   config?: APIConfig,
-  attributes?: Attributes
+  attributes?: Attributes,
+  onRequestDispatched?: () => void
 ): Promise<void> {
   const httpConfig = await getHttpConfig(config);
   httpConfig.headers.set('X-Stream-Multi', 'true');
@@ -231,6 +232,7 @@ export async function writeStreamSessionOverHttp(
       logLabel: url.pathname,
       spanName: 'workflow.stream.write',
       durationAttribute: 'workflow.stream.write.chunk_rtt',
+      onRequestDispatched: offset === 0 ? onRequestDispatched : undefined,
       attributes: {
         ...streamSpanAttributes({
           runId,
@@ -282,13 +284,14 @@ export function createStreamer(config?: APIConfig): Streamer {
                 name,
                 writerId,
                 config,
-                (chunks, attributes) =>
+                (chunks, attributes, onRequestDispatched) =>
                   writeStreamSessionOverHttp(
                     runId,
                     name,
                     chunks,
                     config,
-                    attributes
+                    attributes,
+                    onRequestDispatched
                   ),
                 () => closeStreamSessionOverHttp(runId, name, config)
               );

--- a/packages/world-vercel/src/trace-propagation.test.ts
+++ b/packages/world-vercel/src/trace-propagation.test.ts
@@ -345,14 +345,16 @@ describe('ws stream transport upgrade trace propagation', () => {
     await tracer.startActiveSpan('flow-invocation', async (span) => {
       traceId = span.spanContext().traceId;
       spanId = span.spanContext().spanId;
-      createStreamWriteSession(
+      const session = createStreamWriteSession(
         'wrun_1',
         'user',
         'wrtr_01ARZ3NDEKTSV4RRFFQ69G5FAV',
         { token: 'test-token' },
-        async () => {},
+        async (_chunks, _attributes, dispatched) => dispatched?.(),
         async () => {}
       );
+      await session.write(0, ['first']);
+      await session.write(1, ['second']);
       await vi.waitFor(() => expect(wsUpgrades).toHaveLength(1));
       span.end();
     });

--- a/packages/world-vercel/src/ws-stream-connect.ts
+++ b/packages/world-vercel/src/ws-stream-connect.ts
@@ -1,11 +1,10 @@
 import type { WebSocket } from 'ws';
 import { trace } from './telemetry.js';
 
-/**
- * Initial implementation-level wait for an opted-in stream socket to open.
- * Tune from deployment measurements; this is not protocol semantics.
- */
-export const STREAM_WS_CONNECT_BUDGET_MS = 250;
+/** Background initial upgrade bound; writes continue over HTTP meanwhile. */
+export const STREAM_WS_INITIAL_CONNECT_TIMEOUT_MS = 10_000;
+/** Bounded wait while reconnecting after an established socket drains/closes. */
+export const STREAM_WS_RECONNECT_BUDGET_MS = 250;
 /** Cleanup-only wait after semantic close success; not protocol semantics. */
 export const STREAM_WS_CLOSE_BUDGET_MS = 250;
 

--- a/packages/world-vercel/src/ws-stream-session.test.ts
+++ b/packages/world-vercel/src/ws-stream-session.test.ts
@@ -122,6 +122,7 @@ beforeEach(() => {
   injectTraceContextIntoHeaders.mockClear();
   writeSpans.length = 0;
   delete process.env.WORKFLOW_STREAMS_TRANSPORT;
+  delete process.env.WORKFLOW_REQUEST_TIMEOUT_MS;
 });
 
 afterEach(() => {
@@ -131,9 +132,18 @@ afterEach(() => {
 });
 
 function makeSession(
-  config: { token?: string } | undefined = { token: 'token' }
+  config: { token?: string } | undefined = { token: 'token' },
+  connectAfterFirstWrite = false
 ) {
-  const writeHttp = vi.fn().mockResolvedValue(undefined);
+  const writeHttp = vi.fn(
+    async (
+      _chunks: (string | Uint8Array)[],
+      _attributes?: Record<string, unknown>,
+      onRequestDispatched?: () => void
+    ) => {
+      onRequestDispatched?.();
+    }
+  );
   const closeHttp = vi.fn().mockResolvedValue(undefined);
   const session = createStreamWriteSession(
     'wrun_1',
@@ -141,7 +151,8 @@ function makeSession(
     writerId,
     config,
     writeHttp,
-    closeHttp
+    closeHttp,
+    connectAfterFirstWrite
   );
   activeSessions.push(session);
   return { session, writeHttp, closeHttp };
@@ -156,6 +167,124 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     expect(sockets).toHaveLength(0);
     expect(writeHttp).toHaveBeenCalledWith(['one']);
     expect(closeHttp).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts WS during the second HTTP group and keeps writing HTTP until OPEN', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    let releaseSecond: (() => void) | undefined;
+    const secondPending = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+
+    await session.write(0, ['one']);
+    expect(sockets).toHaveLength(0);
+    expect(writeHttp).toHaveBeenNthCalledWith(
+      1,
+      ['one'],
+      expect.objectContaining({
+        'workflow.stream.ws.session_first_write': true,
+        'workflow.stream.ws.http_group_ordinal': 1,
+      })
+    );
+
+    writeHttp.mockImplementationOnce(
+      async (_chunks, _attributes, dispatched) => {
+        dispatched?.();
+        await secondPending;
+      }
+    );
+    const second = session.write(1, ['two']);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    expect(writeHttp).toHaveBeenNthCalledWith(
+      2,
+      ['two'],
+      expect.objectContaining({
+        'workflow.stream.ws.connect_after_http_group': 2,
+      }),
+      expect.any(Function)
+    );
+    expect(sockets[0].sent).toHaveLength(0);
+    releaseSecond?.();
+    await second;
+
+    const third = session.write(2, ['three']);
+    await third;
+    expect(writeHttp.mock.calls[2]?.[0]).toEqual(['three']);
+    sockets[0].open();
+
+    const fourth = session.write(3, ['four']);
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    expect((await decodeOne(sockets[0].sent[0])).meta).toMatchObject({
+      type: 'write',
+      chunkSeq: 3,
+      numChunks: 1,
+    });
+    sockets[0].reply(
+      encodeFrame({ type: 'write_ack', reqId: 1 }, new Uint8Array())
+    );
+    await fourth;
+  });
+
+  it('closes over HTTP without waiting for the background socket', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const { session, closeHttp } = makeSession({ token: 'token' }, true);
+    await session.write(0, ['one']);
+    await session.write(1, ['two']);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+
+    await session.close();
+    expect(closeHttp).toHaveBeenCalledTimes(1);
+    expect(sockets[0].closed).toContainEqual([1000, 'stream closed over HTTP']);
+  });
+
+  it('retires a provisional socket after an ambiguous second HTTP outcome', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const error = new Error('second HTTP outcome unknown');
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+    await session.write(0, ['one']);
+    let rejectSecond: ((error: Error) => void) | undefined;
+    const secondPending = new Promise<void>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    writeHttp.mockImplementationOnce(
+      async (_chunks, _attributes, dispatched) => {
+        dispatched?.();
+        await secondPending;
+      }
+    );
+
+    const second = session.write(1, ['two']);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    rejectSecond?.(error);
+    await expect(second).rejects.toBe(error);
+    await expect(session.write(2, ['three'])).rejects.toBe(error);
+    expect(sockets[0].sent).toHaveLength(0);
+    expect(sockets[0].closed).toContainEqual([
+      1011,
+      'unknown stream write outcome',
+    ]);
+  });
+
+  it('does not start a socket after an ambiguous first HTTP outcome', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const error = new Error('HTTP outcome unknown');
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
+    writeHttp.mockRejectedValueOnce(error);
+
+    await expect(session.write(0, ['one'])).rejects.toBe(error);
+    await expect(session.write(1, ['two'])).rejects.toBe(error);
+    expect(sockets).toHaveLength(0);
+  });
+
+  it('closes a one-group stream without starting a socket', async () => {
+    process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
+    const { session, closeHttp } = makeSession({ token: 'token' }, true);
+
+    await session.write(0, ['only']);
+    await session.close();
+    expect(closeHttp).toHaveBeenCalledTimes(1);
+    expect(sockets).toHaveLength(0);
   });
 
   it('sends immediately over HTTP while the initial socket connects, then switches to WS', async () => {
@@ -239,27 +368,33 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     });
   });
 
-  it('tombstones to HTTP when the background connect budget expires', async () => {
+  it('bounds the background connect attempt without delaying HTTP writes', async () => {
     vi.useFakeTimers();
     process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
-    const { session, writeHttp } = makeSession();
+    process.env.WORKFLOW_REQUEST_TIMEOUT_MS = '10000';
+    const { session, writeHttp } = makeSession({ token: 'token' }, true);
     const first = session.write(0, ['one']);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(writeHttp).toHaveBeenCalledWith(
-      ['one'],
-      expect.objectContaining({
-        'workflow.stream.ws.session_first_write': true,
-        'workflow.stream.ws.connecting_at_write': true,
-      })
+    await vi.waitFor(() =>
+      expect(writeHttp).toHaveBeenCalledWith(
+        ['one'],
+        expect.objectContaining({
+          'workflow.stream.ws.session_first_write': true,
+          'workflow.stream.ws.connecting_at_write': false,
+          'workflow.stream.ws.connect_deferred_at_write': true,
+        })
+      )
     );
     await first;
+    expect(sockets).toHaveLength(0);
+    await session.write(1, ['two']);
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
 
-    await vi.advanceTimersByTimeAsync(250);
-    const second = session.write(1, ['two']);
-    await second;
-    expect(writeHttp).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await session.write(2, ['three']);
+    expect(writeHttp).toHaveBeenCalledTimes(3);
     expect(writeHttp.mock.calls[0]?.[0]).toEqual(['one']);
-    expect(writeHttp.mock.calls[1]).toEqual([['two']]);
+    expect(writeHttp.mock.calls[1]?.[0]).toEqual(['two']);
+    expect(writeHttp.mock.calls[2]).toEqual([['three']]);
     expect(sockets[0].sent).toHaveLength(0);
     expect(sockets[0].closed).toContainEqual([1000, 'connect budget expired']);
     sockets[0].open();
@@ -766,15 +901,16 @@ describe('v1 stream WebSocket writer lifecycle', () => {
     expect(sockets).toHaveLength(0);
   });
 
-  it('forwards streamer-wrapper disposal after session materialization', async () => {
+  it('keeps streamer-wrapper disposal socket-free before its first write', async () => {
     process.env.WORKFLOW_STREAMS_TRANSPORT = 'ws';
     const { createStreamer } = await import('./streamer.js');
     const session = createStreamer({
       token: 'token',
     }).streams.createWriteSession?.('wrun_1', 'stream/1', { writerId });
-    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sockets).toHaveLength(0);
     await session?.dispose?.();
-    expect(sockets[0].closed).toContainEqual([1000, 'stream writer disposed']);
+    expect(sockets).toHaveLength(0);
   });
 
   it('disposes transport without sending protocol close', async () => {

--- a/packages/world-vercel/src/ws-stream-session.ts
+++ b/packages/world-vercel/src/ws-stream-session.ts
@@ -22,14 +22,27 @@ import type { APIConfig } from './utils.js';
 import { getHttpConfig } from './utils.js';
 import {
   beginNormalWsClose,
-  STREAM_WS_CONNECT_BUDGET_MS,
+  STREAM_WS_INITIAL_CONNECT_TIMEOUT_MS,
+  STREAM_WS_RECONNECT_BUDGET_MS,
 } from './ws-stream-connect.js';
 import { isWsStreamsTransportEnabled } from './ws-transport-enabled.js';
 
-type Mode = 'connecting' | 'draining' | 'ws' | 'http' | 'closed' | 'poisoned';
+type Mode =
+  | 'deferred'
+  | 'waiting_to_connect'
+  | 'connecting'
+  | 'draining'
+  | 'ws'
+  | 'http'
+  | 'closed'
+  | 'poisoned';
 type WriteTiming = {
   startedAt: number;
   sessionFirstWrite: boolean;
+};
+type WriteMetadata = {
+  chunkSeq: number;
+  numChunks: number;
 };
 type ConnectionTiming = {
   attempt: number;
@@ -181,8 +194,8 @@ function asBytes(raw: unknown): Uint8Array {
 class VercelStreamWriteSession implements StreamWriteSession {
   private mode: Mode = 'connecting';
   private socket: WebSocket | undefined;
-  private connect: Promise<void>;
-  private transportDecision: Promise<void>;
+  private connect = Promise.resolve();
+  private transportDecision = Promise.resolve();
   private tail = Promise.resolve();
   private inbound = Promise.resolve();
   private nextReqId = 1;
@@ -207,12 +220,17 @@ class VercelStreamWriteSession implements StreamWriteSession {
     private readonly config: APIConfig | undefined,
     private readonly writeHttp: (
       chunks: (string | Uint8Array)[],
-      attributes?: Attributes
+      attributes?: Attributes,
+      onRequestDispatched?: () => void
     ) => Promise<void>,
-    private readonly closeHttp: () => Promise<void>
+    private readonly closeHttp: () => Promise<void>,
+    private readonly connectAfterFirstWrite: boolean
   ) {
-    this.connect = this.startConnect();
-    this.transportDecision = this.makeTransportDecision();
+    if (connectAfterFirstWrite) {
+      this.mode = 'deferred';
+    } else {
+      this.startInitialConnect();
+    }
   }
 
   write(chunkSeq: number, chunks: (string | Uint8Array)[]): Promise<void> {
@@ -230,23 +248,16 @@ class VercelStreamWriteSession implements StreamWriteSession {
     timing: WriteTiming
   ): Promise<void> {
     this.assertUsable();
-    if (this.mode === 'connecting' && this.connectionAttempt === 1) {
-      // Assign complete groups to HTTP while the initial socket opens in the
-      // background. The serial operation chain prevents later WS work from
-      // overtaking this request, and a failed HTTP request poisons the writer:
-      // its outcome may be unknown, so it must never be replayed over WS.
-      try {
-        await this.writeHttp(chunks, {
-          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
-          'workflow.stream.ws.connection_attempt': this.connectionAttempt,
-          'workflow.stream.ws.connecting_at_write': true,
-          'workflow.stream.ws.session_to_write_ms':
-            timing.startedAt - this.sessionCreatedAt,
-        });
-      } catch (error) {
-        this.failUnknown(error);
-        throw this.poisonError;
-      }
+    if (this.mode === 'deferred') {
+      await this.writeFirstGroup(chunks, timing);
+      return;
+    }
+    if (this.mode === 'waiting_to_connect') {
+      await this.writeSecondGroupAndStartConnect(chunks, timing);
+      return;
+    }
+    if (this.shouldWriteHttpWhileConnecting()) {
+      await this.writeWhileInitialConnectRuns(chunks, timing);
       return;
     }
     await this.transportDecision;
@@ -280,7 +291,8 @@ class VercelStreamWriteSession implements StreamWriteSession {
               },
               batch
             ),
-          offset === 0 ? timing : undefined
+          offset === 0 ? timing : undefined,
+          { chunkSeq: chunkSeq + offset, numChunks: batch.length }
         );
       } catch (error) {
         if (!(error instanceof StreamWsRequestNotSentError)) throw error;
@@ -294,6 +306,82 @@ class VercelStreamWriteSession implements StreamWriteSession {
         );
       }
     }
+  }
+
+  private shouldWriteHttpWhileConnecting(): boolean {
+    return this.mode === 'connecting' && this.connectionAttempt === 1;
+  }
+
+  private async writeWhileInitialConnectRuns(
+    chunks: (string | Uint8Array)[],
+    timing: WriteTiming
+  ): Promise<void> {
+    // Continue complete groups over HTTP while the initial socket opens in the
+    // background. No write waits for the upgrade; the serial operation chain
+    // prevents WS from overtaking HTTP. An HTTP failure poisons the writer
+    // because its outcome may be unknown and must never be replayed over WS.
+    try {
+      await this.writeHttp(chunks, {
+        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+        'workflow.stream.ws.connection_attempt': this.connectionAttempt,
+        'workflow.stream.ws.connecting_at_write': true,
+        'workflow.stream.ws.session_to_write_ms':
+          timing.startedAt - this.sessionCreatedAt,
+      });
+    } catch (error) {
+      this.failUnknown(error);
+      throw this.poisonError;
+    }
+  }
+
+  private async writeSecondGroupAndStartConnect(
+    chunks: (string | Uint8Array)[],
+    timing: WriteTiming
+  ): Promise<void> {
+    try {
+      await this.writeHttp(
+        chunks,
+        {
+          'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+          'workflow.stream.ws.connection_attempt': 0,
+          'workflow.stream.ws.connecting_at_write': false,
+          'workflow.stream.ws.connect_after_http_group': 2,
+          'workflow.stream.ws.session_to_write_ms':
+            timing.startedAt - this.sessionCreatedAt,
+        },
+        () => {
+          if (this.mode !== 'waiting_to_connect') return;
+          this.startInitialConnect();
+        }
+      );
+    } catch (error) {
+      this.failUnknown(error);
+      throw this.poisonError;
+    }
+  }
+
+  private async writeFirstGroup(
+    chunks: (string | Uint8Array)[],
+    timing: WriteTiming
+  ): Promise<void> {
+    // Keep socket setup off the first-chunk critical path. Only a confirmed
+    // HTTP success may start the background upgrade; an ambiguous outcome must
+    // never be followed by work on another transport.
+    try {
+      await this.writeHttp(chunks, {
+        'workflow.stream.ws.session_first_write': timing.sessionFirstWrite,
+        'workflow.stream.ws.connection_attempt': 0,
+        'workflow.stream.ws.connecting_at_write': false,
+        'workflow.stream.ws.connect_deferred_at_write': true,
+        'workflow.stream.ws.http_group_ordinal': 1,
+        'workflow.stream.ws.session_to_write_ms':
+          timing.startedAt - this.sessionCreatedAt,
+      });
+    } catch (error) {
+      this.failUnknown(error);
+      throw this.poisonError;
+    }
+    if (this.mode === 'deferred') this.mode = 'waiting_to_connect';
   }
 
   dispose(): void {
@@ -312,6 +400,18 @@ class VercelStreamWriteSession implements StreamWriteSession {
   close(): Promise<void> {
     return this.enqueue(async () => {
       this.assertUsable();
+      if (
+        this.mode === 'deferred' ||
+        this.mode === 'waiting_to_connect' ||
+        (this.connectAfterFirstWrite &&
+          this.mode === 'connecting' &&
+          this.connectionAttempt === 1)
+      ) {
+        await this.closeHttp();
+        this.mode = 'closed';
+        this.socket?.close(1000, 'stream closed over HTTP');
+        return;
+      }
       await this.transportDecision;
       this.assertUsable();
       if (this.mode === 'http') {
@@ -352,8 +452,14 @@ class VercelStreamWriteSession implements StreamWriteSession {
     if (this.mode === 'closed') throw new Error('stream writer is closed');
   }
 
+  private startInitialConnect(): void {
+    this.mode = 'connecting';
+    this.connect = this.startConnect();
+    this.transportDecision = this.makeTransportDecision(false);
+  }
+
   /** One shared bounded decision for all operations queued while connecting. */
-  private makeTransportDecision(): Promise<void> {
+  private makeTransportDecision(reconnecting: boolean): Promise<void> {
     return new Promise((resolve) => {
       let decided = false;
       const decide = () => {
@@ -362,13 +468,18 @@ class VercelStreamWriteSession implements StreamWriteSession {
         clearTimeout(timer);
         resolve();
       };
-      const timer = setTimeout(() => {
-        if (this.mode === 'connecting') {
-          this.mode = 'http';
-          this.socket?.close(1000, 'connect budget expired');
-        }
-        decide();
-      }, STREAM_WS_CONNECT_BUDGET_MS);
+      const timer = setTimeout(
+        () => {
+          if (this.mode === 'connecting') {
+            this.mode = 'http';
+            this.socket?.close(1000, 'connect budget expired');
+          }
+          decide();
+        },
+        reconnecting
+          ? STREAM_WS_RECONNECT_BUDGET_MS
+          : STREAM_WS_INITIAL_CONNECT_TIMEOUT_MS
+      );
       timer.unref?.();
       void this.connect.then(decide);
     });
@@ -640,7 +751,7 @@ class VercelStreamWriteSession implements StreamWriteSession {
       this.mode = 'connecting';
       this.socket = undefined;
       this.connect = this.startConnect(forceRefresh);
-      const nextDecision = this.makeTransportDecision();
+      const nextDecision = this.makeTransportDecision(true);
       this.transportDecision = nextDecision;
       void nextDecision.then(() => this.finishDrainWait());
       return;
@@ -660,12 +771,13 @@ class VercelStreamWriteSession implements StreamWriteSession {
     this.mode = 'connecting';
     this.socket = undefined;
     this.connect = this.startConnect();
-    this.transportDecision = this.makeTransportDecision();
+    this.transportDecision = this.makeTransportDecision(true);
   }
 
   private async request(
     buildFrame: (reqId: number) => Uint8Array,
-    writeTiming?: WriteTiming
+    writeTiming?: WriteTiming,
+    writeMetadata?: WriteMetadata
   ): Promise<Record<string, unknown>> {
     this.assertUsable();
     const ws = this.socket;
@@ -695,6 +807,12 @@ class VercelStreamWriteSession implements StreamWriteSession {
         attributes: {
           'workflow.stream.transport': 'ws',
           'workflow.stream.ws.req_id': reqId,
+          ...(writeMetadata
+            ? {
+                'workflow.stream.ws.chunk_seq': writeMetadata.chunkSeq,
+                'workflow.stream.ws.num_chunks': writeMetadata.numChunks,
+              }
+            : {}),
           ...firstWriteAttributes(
             detailedTiming,
             connectionTiming,
@@ -795,9 +913,11 @@ export function createStreamWriteSession(
   config: APIConfig | undefined,
   writeHttp: (
     chunks: (string | Uint8Array)[],
-    attributes?: Attributes
+    attributes?: Attributes,
+    onRequestDispatched?: () => void
   ) => Promise<void>,
-  closeHttp: () => Promise<void>
+  closeHttp: () => Promise<void>,
+  connectAfterFirstWrite = true
 ): StreamWriteSession {
   return new VercelStreamWriteSession(
     runId,
@@ -805,6 +925,7 @@ export function createStreamWriteSession(
     StreamWriterIdSchema.parse(writerId),
     config,
     writeHttp,
-    closeHttp
+    closeHttp,
+    connectAfterFirstWrite
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Keeps WebSocket setup off the first stream group, then starts the background upgrade when the second HTTP request is dispatched. Later groups continue over HTTP without waiting until the socket is OPEN, when the serialized writer switches transports at a confirmed request boundary. One-group streams never create a socket.

An ambiguous HTTP outcome poisons the writer and retires any provisional socket before it can carry a frame. Initial upgrades have a dedicated 10-second background timeout; the existing 250ms bound remains scoped to reconnects after an established socket closes. WS write spans include chunk sequence and count for direct takeover analysis.

## Test Plan

Tests cover dispatch overlap, continued HTTP writes while connecting, one-group streams, close during background connection, ambiguous HTTP outcomes, timeout and late OPEN behavior, and trace propagation. The world-vercel suite and typecheck pass locally.
