### PR TITLE
[e2e] Add a cycle-hook scenario to the event-log race repro

### DIFF
--- a/.changeset/cycle-hook-repro-scenario.md
+++ b/.changeset/cycle-hook-repro-scenario.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a `cycle-hook` scenario to the event-log-race-repro harness: a per-cycle hook raced against a sleep, so a hook write lands while an abandoned wait is still open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ pnpm run test:e2e
 ### Event log race repro
 
 `packages/core/e2e/event-log-race-repro.test.ts` is a dedicated harness for
-`CORRUPTED_EVENT_LOG`. It drives five scenarios against one deployment:
+`CORRUPTED_EVENT_LOG`. It drives six scenarios against one deployment:
 `step-storm` and `hook-storm` (concurrent replays of a single run racing the
 per-branch watchdog; `hook-storm` is a production shape), `blocked-branch`
 (each branch parks on a launch step before its hook race, so a woken replay can
@@ -140,8 +140,13 @@ sibling's wait is about to get; it covers the class the wake-order fixes miss),
 heartbeat sleep, no fan-out; the driver supplies the concurrency with bursty
 resumes and resumes aimed at the heartbeat deadline, the shape of a production
 run whose replays of one immutable prefix diverged non-deterministically on an
-unconsumable `wait_created`), plus a `hook-sleep` control that provides the
-calibration baseline. Any outcome
+unconsumable `wait_created`), `cycle-hook` (the same race, but the hook is
+created fresh *inside* every cycle and disposed only when the sleep wins, so a
+`hook_created` commits while the previous cycle's abandoned sleep is still open
+— the state that decides whether the runtime settles a hook's awaiter from its
+own writes or re-reads the log; taken from a production run that died on the
+density check rather than on a divergence), plus a `hook-sleep` control that
+provides the calibration baseline. Any outcome
 other than `completed` fails the run, except `infra`, which means the harness
 could not reach the deployment.
 

--- a/packages/core/e2e/event-log-race-repro.test.ts
+++ b/packages/core/e2e/event-log-race-repro.test.ts
@@ -72,6 +72,7 @@ type Scenario =
   | 'hook-storm'
   | 'blocked-branch'
   | 'wake-loop'
+  | 'cycle-hook'
   | 'hook-sleep';
 
 type Outcome =
@@ -93,6 +94,7 @@ interface ReproConfig {
   hookStormAttempts: number;
   blockedBranchAttempts: number;
   wakeLoopAttempts: number;
+  cycleHookAttempts: number;
   hookSleepAttempts: number;
   concurrency: number;
   /** Wall-clock budget for *launching* attempts. Once it is spent no new
@@ -192,6 +194,25 @@ interface ReproConfig {
   wakeLoopIdleRatio: number;
   /** `wake-loop`: hard cap on cycles per run. */
   wakeLoopMaxCycles: number;
+  /** `cycle-hook`: hook wins to process before the run returns. Each win
+   *  abandons that cycle's sleep, so the NEXT cycle's `hook_created` commits
+   *  under an open wait — the state this scenario exists to exercise. */
+  cycleHookWakes: number;
+  /** `cycle-hook`: the per-cycle sleep raced against that cycle's hook. */
+  cycleHookHeartbeatMs: number;
+  /** `cycle-hook`: base duration of the cycle's drain step, and the
+   *  deterministic spread added to it. */
+  cycleHookStepDelayMs: number;
+  cycleHookStepDelayJitterMs: number;
+  /** `cycle-hook`: bytes every step returns, so replays pay real hydration. */
+  cycleHookStepPayloadBytes: number;
+  /** `cycle-hook`: share of cycles the driver resumes at the heartbeat
+   *  deadline (a hook win). The rest are left to the sleep, which disposes the
+   *  hook and closes the wait, so the ratio decides how often the loop sits in
+   *  the open-wait state. */
+  cycleHookWinRatio: number;
+  /** `cycle-hook`: hard cap on cycles, so a run whose hooks never land ends. */
+  cycleHookMaxCycles: number;
   /** `hook-sleep` control knobs. */
   iterations: number;
   sleepMs: number;
@@ -225,6 +246,17 @@ interface ReproRunResult {
     /** `wake-loop`: what the driver sent and what the run reported consuming.
      *  A corruption with `bursts: 0` and `idles: 0` would mean neither of the
      *  two collision patterns this scenario aims for was in play. */
+    /** `cycle-hook`: how many cycles the driver actually won at the heartbeat
+     *  deadline, and how many minted no reachable hook. A corruption with
+     *  `createsUnderOpenWait: 0` never reached the state the scenario is for. */
+    cycleHook?: {
+      resumed: number;
+      missedCycles: number;
+      cycles?: number;
+      hookWins?: number;
+      heartbeatWins?: number;
+      createsUnderOpenWait?: number;
+    };
     wakeLoop?: {
       fresh: number;
       stale: number;
@@ -276,6 +308,7 @@ const config: ReproConfig = {
     6
   ),
   wakeLoopAttempts: envNumber('EVENT_LOG_RACE_REPRO_WAKE_LOOP_ATTEMPTS', 6),
+  cycleHookAttempts: envNumber('EVENT_LOG_RACE_REPRO_CYCLE_HOOK_ATTEMPTS', 6),
   hookSleepAttempts: envNumber('EVENT_LOG_RACE_REPRO_ATTEMPTS', 2),
   // Cross-run concurrency is throughput only — the race being reproduced is
   // between concurrent replays *within* one run, driven by `rounds`/`width` and
@@ -374,6 +407,31 @@ const config: ReproConfig = {
     0.3
   ),
   wakeLoopMaxCycles: envNumber('EVENT_LOG_RACE_REPRO_WAKE_LOOP_MAX_CYCLES', 80),
+  cycleHookWakes: envNumber('EVENT_LOG_RACE_REPRO_CYCLE_HOOK_WAKES', 8),
+  cycleHookHeartbeatMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_HEARTBEAT_MS',
+    4000
+  ),
+  cycleHookStepDelayMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_STEP_DELAY_MS',
+    400
+  ),
+  cycleHookStepDelayJitterMs: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_STEP_DELAY_JITTER_MS',
+    400
+  ),
+  cycleHookStepPayloadBytes: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_STEP_PAYLOAD_BYTES',
+    8192
+  ),
+  cycleHookWinRatio: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_WIN_RATIO',
+    0.7
+  ),
+  cycleHookMaxCycles: envNumber(
+    'EVENT_LOG_RACE_REPRO_CYCLE_HOOK_MAX_CYCLES',
+    60
+  ),
   iterations: envNumber('EVENT_LOG_RACE_REPRO_ITERATIONS', 8),
   sleepMs: envNumber('EVENT_LOG_RACE_REPRO_SLEEP_MS', 5000),
   resumeDelayMs: envNumber('EVENT_LOG_RACE_REPRO_RESUME_DELAY_MS', 15_000),
@@ -1267,6 +1325,146 @@ async function runWakeLoopAttempt(attempt: number): Promise<ReproRunResult> {
  * delay. Kept at low attempt counts purely so each run reports a rate for the
  * one scenario with a known historical baseline (~0.1%).
  */
+async function runCycleHookAttempt(attempt: number): Promise<ReproRunResult> {
+  const scenario: Scenario = 'cycle-hook';
+  const startedAt = Date.now();
+  const token = makeToken(scenario, attempt);
+
+  try {
+    const workflow = await getWorkflowMetadata(
+      deploymentUrl,
+      STORM_WORKFLOW_FILE,
+      'cycleHookReproWorkflow'
+    );
+    const run = await start(
+      scenario,
+      STORM_WORKFLOW_FILE,
+      'cycleHookReproWorkflow',
+      workflow,
+      [
+        {
+          heartbeatMs: config.cycleHookHeartbeatMs,
+          maxCycles: config.cycleHookMaxCycles,
+          stepDelayJitterMs: config.cycleHookStepDelayJitterMs,
+          stepDelayMs: config.cycleHookStepDelayMs,
+          stepPayloadBytes: config.cycleHookStepPayloadBytes,
+          token,
+          wakes: config.cycleHookWakes,
+        },
+      ]
+    );
+
+    let resumed = 0;
+    let missed = 0;
+    const { runResult, state } = await drive(
+      run,
+      startedAt,
+      scenario,
+      async (driverState) => {
+        // Each cycle mints its own hook, so the driver walks the cycle index
+        // rather than holding one hook for the whole run.
+        for (
+          let cycle = 0;
+          cycle < config.cycleHookMaxCycles && !driverState.done;
+          cycle += 1
+        ) {
+          const hook = await waitForHook(
+            `${token}:c${cycle}`,
+            run.runId,
+            driverState,
+            // A cycle whose sleep wins disposes its hook and moves on, so a
+            // token that never appears is a normal outcome, not a failure.
+            // Bound the wait at roughly one heartbeat plus the cycle's steps.
+            config.cycleHookHeartbeatMs * 2
+          ).catch(() => undefined);
+          if (!hook || driverState.done) {
+            missed += 1;
+            continue;
+          }
+          // Aim at the heartbeat deadline: landing a `hook_received` next to
+          // the `wait_completed` is what the production log shows at every
+          // cycle boundary. A share of cycles is deliberately left to the
+          // sleep, since a hook win is what leaves the next cycle's
+          // `hook_created` sitting under an open wait.
+          if (Math.random() < config.cycleHookWinRatio) {
+            const spread = Math.floor(config.cycleHookHeartbeatMs * 0.15);
+            await sleep(
+              Math.max(
+                0,
+                config.cycleHookHeartbeatMs -
+                  spread +
+                  Math.floor(Math.random() * 2 * spread)
+              )
+            );
+            if (driverState.done) return;
+            resumed += 1;
+            await tryResume(driverState, hook, {
+              fresh: true,
+              sentAt: Date.now(),
+              seq: cycle,
+            });
+          } else {
+            // Let this cycle's sleep win; wait it out before the next token.
+            await sleep(config.cycleHookHeartbeatMs);
+          }
+        }
+      }
+    );
+
+    const pressure = {
+      resumesFailed: state.resumesFailed,
+      resumesSent: state.resumesSent,
+      cycleHook: { missedCycles: missed, resumed },
+    };
+
+    if (runResult.outcome !== 'completed') {
+      return { ...runResult, attempt, pressure, scenario, token };
+    }
+
+    const returnValue = await withTimeout(
+      run.returnValue,
+      30_000,
+      `Timed out reading return value for run ${run.runId}`
+    );
+    const summary = returnValue as {
+      cycles?: number;
+      hookWins?: number;
+      heartbeatWins?: number;
+      createsUnderOpenWait?: number;
+    };
+    if (typeof summary?.cycles !== 'number') {
+      return {
+        ...runResult,
+        attempt,
+        errorCode: 'BAD_CYCLE_HOOK_LEDGER',
+        errorMessage: 'Run returned no cycle-hook ledger.',
+        outcome: 'other',
+        pressure,
+        scenario,
+        token,
+      };
+    }
+    return {
+      ...runResult,
+      attempt,
+      pressure: {
+        ...pressure,
+        cycleHook: {
+          ...pressure.cycleHook,
+          createsUnderOpenWait: summary.createsUnderOpenWait,
+          cycles: summary.cycles,
+          heartbeatWins: summary.heartbeatWins,
+          hookWins: summary.hookWins,
+        },
+      },
+      scenario,
+      token,
+    };
+  } catch (err) {
+    return harnessFailure(scenario, attempt, token, startedAt, err);
+  }
+}
+
 async function runHookSleepAttempt(attempt: number): Promise<ReproRunResult> {
   const scenario: Scenario = 'hook-sleep';
   const startedAt = Date.now();
@@ -1415,6 +1613,7 @@ function summarizeByScenario(results: ReproRunResult[]) {
       'hook-storm': emptyOutcomeCounts(),
       'blocked-branch': emptyOutcomeCounts(),
       'wake-loop': emptyOutcomeCounts(),
+      'cycle-hook': emptyOutcomeCounts(),
       'hook-sleep': emptyOutcomeCounts(),
     }
   );
@@ -1433,6 +1632,7 @@ const plannedAttempts =
   config.hookStormAttempts +
   config.blockedBranchAttempts +
   config.wakeLoopAttempts +
+  config.cycleHookAttempts +
   config.hookSleepAttempts;
 let overallDeadline = Number.POSITIVE_INFINITY;
 let launchDeadline = Number.POSITIVE_INFINITY;
@@ -1629,6 +1829,11 @@ describe('event log race repro', { retry: 0 }, () => {
         config.wakeLoopAttempts,
         config.concurrency,
         runWakeLoopAttempt
+      );
+      await runScenario(
+        config.cycleHookAttempts,
+        config.concurrency,
+        runCycleHookAttempt
       );
       await runScenario(
         config.hookSleepAttempts,

--- a/workbench/nextjs-turbopack/workflows/103_event_log_corruption_repro.ts
+++ b/workbench/nextjs-turbopack/workflows/103_event_log_corruption_repro.ts
@@ -722,6 +722,137 @@ function normalizeWakeLoop(input: WakeLoopInput) {
  *    win, so a wake mistaken for a heartbeat, or the reverse, moves a
  *    `wait_created` in the correlation-id sequence.
  */
+interface CycleHookInput {
+  token: string;
+  /** Hook wins to process before returning. */
+  wakes?: number;
+  /** The heartbeat sleep raced against this cycle's hook. */
+  heartbeatMs?: number;
+  /** Base duration of the drain step, the long step of each cycle. */
+  stepDelayMs?: number;
+  /** Deterministic per-cycle spread added to `stepDelayMs`. */
+  stepDelayJitterMs?: number;
+  /** Bytes every step returns, so each replay pays real hydration per event. */
+  stepPayloadBytes?: number;
+  /** Hard cap so a run that never wins cannot spin forever. */
+  maxCycles?: number;
+}
+
+interface CycleHookResult {
+  runId: string;
+  cycles: number;
+  hookWins: number;
+  heartbeatWins: number;
+  /** Cycles entered while the previous cycle's sleep was still open. */
+  createsUnderOpenWait: number;
+}
+
+function normalizeCycleHook(input: CycleHookInput) {
+  return {
+    wakes: input.wakes ?? 8,
+    heartbeatMs: input.heartbeatMs ?? 4000,
+    stepDelayMs: input.stepDelayMs ?? 400,
+    stepDelayJitterMs: input.stepDelayJitterMs ?? 400,
+    stepPayloadBytes: input.stepPayloadBytes ?? 8192,
+    maxCycles: input.maxCycles ?? 60,
+  };
+}
+
+/**
+ * The cycle-hook shape: like `wake-loop`, one sequential loop racing a hook
+ * against a heartbeat sleep, but the hook is **created fresh inside every
+ * cycle** and disposed only when the sleep wins.
+ *
+ * That one difference is the point. `wake-loop` creates its hooks once, at the
+ * top, when no wait exists, so it commits exactly one `hook_created` before the
+ * first `wait_created` and never again. This loop commits a `hook_created` on
+ * every cycle, and after a cycle the hook won, it commits that write while the
+ * losing sleep from the previous cycle is **still open** — the one state that
+ * decides which path the runtime takes when it settles a hook's awaiter in
+ * process (an open wait forces a read of the log instead of carrying the
+ * suspension's own writes forward).
+ *
+ * Taken from a production run (`githubUserMonitor`, core 5.0.0-beta.48) whose
+ * log is this loop event for event: 56 `hook_created`, 54 `hook_disposed`, 55
+ * `wait_created`, 54 `wait_completed`, 18 `hook_received`, and at the moment it
+ * failed, one open wait and a `hook_received` immediately before the terminal
+ * event. Its sibling died the same way 26 minutes earlier at 29 events. Neither
+ * exhausted the replay-divergence budget and neither hit a missing payload, so
+ * the corruption came from the third producer, the density check, which reports
+ * a hole in the log the replay read rather than a divergence.
+ *
+ * The driver supplies the concurrency: it resumes each cycle's own token, some
+ * of them aimed at the heartbeat deadline so a `hook_received` and a
+ * `wait_completed` land next to each other, which is what the production log
+ * shows at every cycle boundary.
+ */
+export async function cycleHookReproWorkflow(
+  input: CycleHookInput
+): Promise<CycleHookResult> {
+  'use workflow';
+
+  const metadata = getWorkflowMetadata();
+  const config = normalizeCycleHook(input);
+  const runId = metadata.workflowRunId;
+  let cycles = 0;
+  let hookWins = 0;
+  let heartbeatWins = 0;
+  let createsUnderOpenWait = 0;
+  // True while a sleep this loop abandoned is still counting down. There is no
+  // way to close one (see vercel/workflow#3916), so it stays open across the
+  // next cycle's `hook_created`.
+  let openWait = false;
+
+  while (hookWins < config.wakes && cycles < config.maxCycles) {
+    const index = cycles;
+    cycles += 1;
+    const payloadBytes = config.stepPayloadBytes;
+
+    await verifyStep({ runId, cycle: index, phase: 'before', payloadBytes });
+    await drainStep({
+      runId,
+      cycle: index,
+      delayMs:
+        config.stepDelayMs +
+        Math.floor(((index * 7) % 10) * (config.stepDelayJitterMs / 10)),
+      // Every cycle races; the drain never asks for another.
+      continueEvery: 0,
+      payloadBytes,
+    });
+
+    if (openWait) createsUnderOpenWait += 1;
+
+    // The write whose continuation path the open wait above switches.
+    const hook = createHook<WakeLoopPayload>({
+      token: `${input.token}:c${index}`,
+    });
+    // Production publishes the token in a step after creating the hook, so the
+    // `hook_created` is not the suspension's only write.
+    await verifyStep({ runId, cycle: index, phase: 'publish', payloadBytes });
+
+    const winner = await Promise.race([
+      hook[Symbol.asyncIterator]()
+        .next()
+        .then((result) => ({ payload: result.value })),
+      sleep(config.heartbeatMs).then(() => HEARTBEAT),
+    ]);
+
+    if (winner === HEARTBEAT) {
+      heartbeatWins += 1;
+      openWait = false;
+      hook.dispose();
+      continue;
+    }
+
+    // The hook won, so this cycle's sleep is abandoned and stays in the log.
+    hookWins += 1;
+    openWait = true;
+    await syncStep({ runId, cycle: index, payloadBytes });
+  }
+
+  return { runId, cycles, hookWins, heartbeatWins, createsUnderOpenWait };
+}
+
 export async function wakeLoopReproWorkflow(
   input: WakeLoopInput
 ): Promise<WakeLoopResult> {


### PR DESCRIPTION
## Why

`wake-loop` creates its hooks **once**, at the top, before any wait exists. It commits one `hook_created` and never another, which leaves a state it can never reach: a hook write landing while a wait is already open.

Two production runs died in exactly that state. `githubUserMonitor` on core `5.0.0-beta.48` mints a **fresh hook inside every cycle**, races it against a heartbeat sleep, and disposes it only when the sleep wins. So after any cycle the hook won, the next cycle's `hook_created` commits with that cycle's abandoned sleep still counting down — and an open wait is precisely what decides whether the runtime settles a hook's awaiter from the suspension's own writes or re-reads the log first.

Neither run exhausted the replay-divergence budget and neither hit a missing payload, so the corruption came from the third producer — the density check — rather than from a divergence. That is a different failure mode from the one `wake-loop` was built for, on the same family of workload.

## What

`cycle-hook`: one sequential loop, a fresh hook per cycle, disposed only on a sleep win.

The 55-cycle production original is reproduced event for event:

| Event | Production run |
|---|--:|
| `hook_created` | 56 |
| `hook_disposed` | 54 |
| `wait_created` | 55 |
| `wait_completed` | 54 |
| `hook_received` | 18 |

with one wait still open at the moment it failed. Its sibling died the same way 26 minutes earlier at 29 events.

The driver walks the cycle index rather than holding one hook, resuming each cycle's own `:c<n>` token, and aims a configurable share (`CYCLE_HOOK_WIN_RATIO`, default 0.7) at the heartbeat deadline so a `hook_received` commits next to a `wait_completed`. The rest are deliberately left to the sleep, because a hook win is what sets up the *next* cycle's open-wait create.

`pressure.cycleHook.createsUnderOpenWait` reports how often the run actually reached that state, so a clean result can be distinguished from a run that never got there — the same reason `wake-loop` reports `bursts`/`idles`.

Knobs are `EVENT_LOG_RACE_REPRO_CYCLE_HOOK_*`, defaults alongside the other scenarios in the test file.

## Validation

Against world-local, three runs, reduced scale:

```
cycle-hook attempt=1 outcome=completed cycleHook={cycles: 14, hookWins: 4, heartbeatWins: 10, createsUnderOpenWait: 3}
cycle-hook attempt=2 outcome=completed cycleHook={cycles: 10, hookWins: 4, heartbeatWins:  6, createsUnderOpenWait: 3}
cycle-hook attempt=3 outcome=completed cycleHook={cycles:  7, hookWins: 4, heartbeatWins:  3, createsUnderOpenWait: 3}
```

Every run reached the open-wait create, across a mix of both branches. **That says the shape drives the intended interleaving, not that it reproduces the corruption.** The production failures were on world-vercel, and three world-local runs resolve nothing about a rate — per the harness's own note, a clean run means "the storms did not trip it".

Empty changeset: nothing here is published (`packages/core/e2e/`, `workbench/`).