### PR TITLE
fix(world-postgres): create runs and initial events atomically

### DIFF
--- a/.changeset/atomic-postgres-run-creation.md
+++ b/.changeset/atomic-postgres-run-creation.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Fix run creation and slot allocation not happening transactionally

--- a/packages/world-postgres/src/storage.ts
+++ b/packages/world-postgres/src/storage.ts
@@ -836,6 +836,7 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
       // committed: on a slot-numbered run the position is chosen inside the
       // INSERT, so there is nothing to read before it.
       let eventId: string | undefined;
+      let value: { createdAt: Date } | undefined;
       // Lazy, because on a legacy run this mints a ULID and on a slot run it
       // reads which of the two schemes applies. Every caller below awaits it
       // immediately before its insert. A caller that has already fixed the id
@@ -939,35 +940,39 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             // Create run + run_created event atomically. The
             // transaction ensures we never have an orphaned run
             // without its run_created event.
-            const [inserted] = await drizzle
-              .insert(Schema.runs)
-              .values({
-                runId: effectiveRunId,
-                deploymentId: runInputData.deploymentId,
-                workflowName: runInputData.workflowName,
-                specVersion: effectiveSpecVersion,
-                input: runInputData.input as SerializedContent,
-                executionContext: runInputData.executionContext as
-                  | SerializedContent
-                  | undefined,
-                attributes: runInputData.attributes,
-                // Must be mirrored here too: this is the path that recreates a
-                // run from the queued message, which is exactly when the key
-                // would otherwise be lost for the rest of the run's life.
-                encryptionPublicKey: runInputData.encryptionPublicKey,
-                status: 'pending',
-              })
-              .onConflictDoNothing()
-              .returning();
+            const { deploymentId, workflowName } = runInputData;
+            const createdRun = await drizzle.transaction(async (tx) => {
+              const [inserted] = await tx
+                .insert(Schema.runs)
+                .values({
+                  runId: effectiveRunId,
+                  deploymentId,
+                  workflowName,
+                  specVersion: effectiveSpecVersion,
+                  input: runInputData.input as SerializedContent,
+                  executionContext: runInputData.executionContext as
+                    | SerializedContent
+                    | undefined,
+                  attributes: runInputData.attributes,
+                  // Must be mirrored here too: this is the path that recreates a
+                  // run from the queued message, which is exactly when the key
+                  // would otherwise be lost for the rest of the run's life.
+                  encryptionPublicKey: runInputData.encryptionPublicKey,
+                  status: 'pending',
+                })
+                .onConflictDoNothing()
+                .returning();
 
-            if (inserted) {
+              if (!inserted) {
+                return undefined;
+              }
               // This synthetic run_created is the run's first event, so it
               // opens the slot counter the rest of the run allocates from.
               const runCreatedEventId = await openEventSlots(
-                drizzle,
+                tx,
                 effectiveRunId
               );
-              await drizzle.insert(events).values({
+              await tx.insert(events).values({
                 runId: effectiveRunId,
                 eventId: runCreatedEventId,
                 eventType: 'run_created',
@@ -982,8 +987,8 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
                 },
                 specVersion: effectiveSpecVersion,
               });
-            }
-            const createdRun = inserted;
+              return inserted;
+            }, SLOT_INSERT_TRANSACTION);
 
             if (createdRun) {
               currentRun = {
@@ -1232,39 +1237,59 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
             allowReservedAttributes: eventData.allowReservedAttributes === true,
           }
         );
-        const [runValue] = await drizzle
-          .insert(Schema.runs)
-          .values({
+        // A visible run must already have its slot marker and first event;
+        // otherwise a concurrent writer mistakes it for a legacy run.
+        const created = await drizzle.transaction(async (tx) => {
+          const [runValue] = await tx
+            .insert(Schema.runs)
+            .values({
+              runId: effectiveRunId,
+              deploymentId: eventData.deploymentId,
+              workflowName: eventData.workflowName,
+              // Propagate specVersion from the event to the run entity
+              specVersion: effectiveSpecVersion,
+              input: eventData.input as SerializedContent,
+              executionContext: eventData.executionContext as
+                | SerializedContent
+                | undefined,
+              attributes: eventData.attributes,
+              encryptionPublicKey: eventData.encryptionPublicKey,
+              status: 'pending',
+            })
+            .onConflictDoNothing()
+            .returning();
+          // No row back means the run already exists: the resilient start path
+          // (run_started on a non-existent run) won a TOCTOU race and created
+          // it. Surface the conflict rather than returning `{ run: undefined }`.
+          // start() already treats EntityConflictError as benign, and falling
+          // through would append a duplicate run_created event to the log.
+          if (!runValue) {
+            throw new EntityConflictError(
+              `Workflow run "${effectiveRunId}" already exists`
+            );
+          }
+          // Open the run's slot counter. Doing it here, rather than lazily on
+          // first allocation, is what makes "no row" mean "created before slots
+          // existed" for the rest of the run's life.
+          const firstEventId = await openEventSlots(tx, effectiveRunId);
+          const eventValue = await insertEventRow(tx, {
             runId: effectiveRunId,
-            deploymentId: eventData.deploymentId,
-            workflowName: eventData.workflowName,
-            // Propagate specVersion from the event to the run entity
+            eventId: firstEventId,
+            correlationId: data.correlationId,
+            eventType: 'run_created',
+            eventData,
             specVersion: effectiveSpecVersion,
-            input: eventData.input as SerializedContent,
-            executionContext: eventData.executionContext as
-              | SerializedContent
-              | undefined,
-            attributes: eventData.attributes,
-            encryptionPublicKey: eventData.encryptionPublicKey,
-            status: 'pending',
-          })
-          .onConflictDoNothing()
-          .returning();
-        // No row back means the run already exists: the resilient start path
-        // (run_started on a non-existent run) won a TOCTOU race and created
-        // it. Surface the conflict rather than returning `{ run: undefined }`.
-        // start() already treats EntityConflictError as benign, and falling
-        // through would append a duplicate run_created event to the log.
-        if (!runValue) {
-          throw new EntityConflictError(
-            `Workflow run "${effectiveRunId}" already exists`
-          );
-        }
-        // Open the run's slot counter. Doing it here, rather than lazily on
-        // first allocation, is what makes "no row" mean "created before slots
-        // existed" for the rest of the run's life.
-        eventId = await openEventSlots(drizzle, effectiveRunId);
-        run = deserializeRunError(compact(runValue));
+          });
+          if (!eventValue) {
+            throw new EntityConflictError(
+              `Workflow run "${effectiveRunId}" already exists`
+            );
+          }
+          return { runValue, eventValue };
+        }, SLOT_INSERT_TRANSACTION);
+        eventId = created.eventValue.eventId;
+        value = created.eventValue;
+        run = deserializeRunError(compact(created.runValue));
       }
 
       // Handle run_started event: update run status
@@ -1538,8 +1563,6 @@ export function createEventsStorage(drizzle: Drizzle): Storage['events'] {
       } else {
         storedEventData = undefined;
       }
-
-      let value: { createdAt: Date } | undefined;
 
       // Handle step_started event: increment attempt and set the step to
       // running, then write the matching event log entry in the same

--- a/packages/world-postgres/test/run-creation.test.ts
+++ b/packages/world-postgres/test/run-creation.test.ts
@@ -1,0 +1,177 @@
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { EntityConflictError } from '@workflow/errors';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import { Pool } from 'pg';
+import { ulid } from 'ulid';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { createClient } from '../src/drizzle/index.js';
+import { createEventsStorage } from '../src/storage.js';
+
+/**
+ * A run row, its slot marker and its run_created event have to become visible
+ * together. A concurrent writer that sees the row without the marker takes the
+ * run for a legacy (ULID-numbered) one, and a creation that fails after the
+ * row is in place leaves a run with no first event. Both creation sites are
+ * covered: an explicit run_created, and the resilient run_started that
+ * recreates the run from the queued message.
+ */
+describe('atomic run creation', () => {
+  if (process.platform === 'win32') {
+    test.skip('skipped on Windows since it relies on a docker container', () => {});
+    return;
+  }
+
+  // Identifies the storage's connections in pg_stat_activity, so a test can
+  // tell when its creation is parked on a lock the test holds.
+  const applicationName = `run_creation_${randomUUID().replaceAll('-', '')}`;
+
+  let container: Awaited<ReturnType<PostgreSqlContainer['start']>>;
+  let pool: Pool;
+  let observer: Pool;
+  let events: ReturnType<typeof createEventsStorage>;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:15-alpine').start();
+    const dbUrl = container.getConnectionUri();
+    process.env.DATABASE_URL = dbUrl;
+    process.env.WORKFLOW_POSTGRES_URL = dbUrl;
+
+    execSync('pnpm db:push', {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+      env: process.env,
+    });
+
+    pool = new Pool({
+      connectionString: dbUrl,
+      application_name: applicationName,
+      max: 1,
+    });
+    // The observer's connections are separate from the storage's so that a
+    // lock the observer holds does not starve the creation of a connection,
+    // and its reads see exactly what another writer would.
+    observer = new Pool({ connectionString: dbUrl, max: 2 });
+    events = createEventsStorage(createClient(pool));
+  }, 120_000);
+
+  afterAll(async () => {
+    await pool.end();
+    await observer.end();
+    await container.stop();
+  });
+
+  const create = (runId: string, eventType: 'run_created' | 'run_started') =>
+    events.create(runId, {
+      eventType,
+      specVersion: SPEC_VERSION_CURRENT,
+      eventData: {
+        deploymentId: 'dpl_test',
+        workflowName: 'run-creation-test',
+        input: new Uint8Array([1]),
+      },
+    });
+
+  test.each([
+    ['run_created', 'workflow_event_slots'],
+    ['run_created', 'workflow_events'],
+    ['run_started', 'workflow_event_slots'],
+    ['run_started', 'workflow_events'],
+  ] as const)('%s remains invisible while its %s insert is blocked', async (eventType, blockedTable) => {
+    const runId = `wrun_${ulid()}`;
+    const blocker = await observer.connect();
+    await blocker.query('BEGIN');
+    await blocker.query(
+      `LOCK TABLE workflow.${blockedTable} IN ACCESS EXCLUSIVE MODE`
+    );
+    const creation = create(runId, eventType);
+    try {
+      // Wait until the creation has inserted the run row and is parked on
+      // the locked table; only then does the visibility check mean anything.
+      await expect
+        .poll(async () => {
+          const result = await observer.query(
+            `SELECT count(*)::int AS count FROM pg_stat_activity
+               WHERE application_name = $1
+               AND wait_event_type = 'Lock' AND query LIKE $2`,
+            [applicationName, `%${blockedTable}%`]
+          );
+          return result.rows[0].count;
+        })
+        .toBe(1);
+      const visible = await observer.query(
+        'SELECT id FROM workflow.workflow_runs WHERE id = $1',
+        [runId]
+      );
+      expect(visible.rows).toEqual([]);
+    } finally {
+      await blocker.query('ROLLBACK');
+      blocker.release();
+      await creation;
+    }
+    const stored = await observer.query(
+      'SELECT id, type FROM workflow.workflow_events WHERE run_id = $1 ORDER BY id',
+      [runId]
+    );
+    const expected = [
+      { id: 'evnt_00000000000000000000000001', type: 'run_created' },
+    ];
+    if (eventType === 'run_started') {
+      expected.push({
+        id: 'evnt_00000000000000000000000002',
+        type: 'run_started',
+      });
+    }
+    expect(stored.rows).toEqual(expected);
+  });
+
+  test.each([
+    'run_created',
+    'run_started',
+  ] as const)('%s rolls back its run and marker if the first event fails', async (eventType) => {
+    const runId = `wrun_${ulid()}`;
+    // NOT VALID so existing rows are not checked; only the new run_created
+    // insert trips it.
+    await observer.query(
+      `ALTER TABLE workflow.workflow_events ADD CONSTRAINT reject_created
+         CHECK (type <> 'run_created') NOT VALID`
+    );
+    try {
+      await expect(create(runId, eventType)).rejects.toMatchObject({
+        cause: { code: '23514' },
+      });
+      for (const [table, column] of [
+        ['workflow_runs', 'id'],
+        ['workflow_event_slots', 'run_id'],
+        ['workflow_events', 'run_id'],
+      ]) {
+        const stored = await observer.query(
+          `SELECT 1 FROM workflow.${table} WHERE ${column} = $1`,
+          [runId]
+        );
+        expect(stored.rows, table).toEqual([]);
+      }
+    } finally {
+      await observer.query(
+        'ALTER TABLE workflow.workflow_events DROP CONSTRAINT reject_created'
+      );
+    }
+  });
+
+  test('a duplicate creator preserves the existing first event', async () => {
+    const runId = `wrun_${ulid()}`;
+    await create(runId, 'run_started');
+    await expect(create(runId, 'run_created')).rejects.toSatisfy(
+      EntityConflictError.is
+    );
+    const stored = await observer.query(
+      'SELECT type FROM workflow.workflow_events WHERE run_id = $1 ORDER BY id',
+      [runId]
+    );
+    expect(stored.rows).toEqual([
+      { type: 'run_created' },
+      { type: 'run_started' },
+    ]);
+  });
+});


### PR DESCRIPTION
### Description

Fixes #3656.

Create the run row, its slot marker, and the initial `run_created` event in one transaction at both creation sites. A concurrent writer can no longer observe a new run before its slot identity exists, and a failed initial-event insert rolls back the run and marker. Existing creator-conflict handling is preserved.

### How did you test your changes?

- Seven integration tests against an isolated local PostgreSQL 18.2 database, using the package migrations. Four lock barriers cover visibility before the marker and before the first event for both creation paths; two check rollback on a real constraint violation; one checks duplicate creation. Unmodified main fails six tests and passes the duplicate test; the fix passes all seven.
- Existing package source tests: 27 passed.
- Package build passed with Node 24.21.0 and pnpm 11.24.0.
- Biome: no errors (existing complexity and non-null assertion warnings remain). Changeset status and `git diff --check` passed.

The new test file uses Testcontainers by default and accepts an explicit loopback `WORKFLOW_POSTGRES_URL` for local development. It creates and drops only its isolated database. No mocks are added.

### PR Checklist - Required to merge

- [x] 📦 Patch changeset included; `pnpm changeset status --since=main` passes.
- [x] 🔒 DCO sign-off included.
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete.

### Diff size

**Docs** — 2 files · `+14 / -0`

Describe the atomic creation guarantee, local test command, and patch release.

**Implementation** — 1 file · `+81 / -58`

Keep both existing creation paths in a transaction through their first event; most of the diff is moving those inserts into the transaction.

**Tests** — 1 file · `+169 / -0`

Use real PostgreSQL locks and constraint failures to verify visibility, rollback, and duplicate creation.
