### PR TITLE
test: relax Windows CLI cancellation timeout

### DIFF
--- a/.changeset/chubby-bears-check.md
+++ b/.changeset/chubby-bears-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Give Windows cancellation E2E tests the standard CLI timeout budget.

--- a/packages/core/e2e/utils.ts
+++ b/packages/core/e2e/utils.ts
@@ -603,11 +603,13 @@ export const cliInspectJson = async (args: string) => {
 export const cliCancel = async (runId: string) => {
   const cliAppPath = getWorkbenchAppPath();
   const cliArgs = splitArgs(getCliArgs());
+  // Use the shared CLI budget. Windows startup plus local-world filesystem
+  // contention can consume most of 10 seconds before cancellation runs; the
+  // shared 20-second default still leaves ample room inside the test timeout.
   const result = await awaitCommand(
     'node',
     ['./node_modules/workflow/bin/run.js', 'cancel', runId, ...cliArgs],
-    cliAppPath,
-    10_000
+    cliAppPath
   );
   return result;
 };


### PR DESCRIPTION
## Summary & Motivation

`cliCancel` was the only CLI helper with its own timeout, and 10 seconds is too tight on Windows, where a successful cancellation takes about 8. Dropping the override lets it use the harness' 20-second default.

## Test Plan

Existing coverage runs in CI; the Windows E2E cancellation lane is the real signal.
