### PR TITLE
fix(world-postgres): preserve queue error metadata

### DIFF
--- a/.changeset/postgres-queue-error-metadata.md
+++ b/.changeset/postgres-queue-error-metadata.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Preserve error names, messages, stacks, and nested causes in Graphile Worker log metadata.

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -115,6 +115,10 @@ When `pool` is omitted, `maxPoolSize` precedence is: `createWorld({ maxPoolSize 
 
 For higher worker concurrency, Graphile Worker recommends setting `maxPoolSize` to `10` or `queueConcurrency + 2`, whichever is larger.
 
+### Queue logging
+
+Graphile Worker writes errors to stderr and warnings to stdout. Error metadata includes the error name, message, stack, and nested cause. Set `DEBUG` to enable info and debug output. `WORKFLOW_JSON_MODE=1` suppresses Graphile Worker output for CLI JSON mode.
+
 ## Database setup
 
 This package uses PostgreSQL with the following components:

--- a/packages/world-postgres/README.md
+++ b/packages/world-postgres/README.md
@@ -115,10 +115,6 @@ When `pool` is omitted, `maxPoolSize` precedence is: `createWorld({ maxPoolSize 
 
 For higher worker concurrency, Graphile Worker recommends setting `maxPoolSize` to `10` or `queueConcurrency + 2`, whichever is larger.
 
-### Queue logging
-
-Graphile Worker writes errors to stderr and warnings to stdout. Error metadata includes the error name, message, stack, and nested cause. Set `DEBUG` to enable info and debug output. `WORKFLOW_JSON_MODE=1` suppresses Graphile Worker output for CLI JSON mode.
-
 ## Database setup
 
 This package uses PostgreSQL with the following components:

--- a/packages/world-postgres/src/queue-logging.test.ts
+++ b/packages/world-postgres/src/queue-logging.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { serializeGraphileMeta } from './queue.js';
+
+describe('serializeGraphileMeta', () => {
+  it('expands the non-enumerable Error fields JSON.stringify drops', () => {
+    const error = new Error('delivery failed');
+    expect(JSON.parse(JSON.stringify({ error }))).toEqual({ error: {} });
+
+    const meta = JSON.parse(serializeGraphileMeta({ error, jobId: '7' }));
+    expect(meta).toMatchObject({
+      jobId: '7',
+      error: {
+        name: 'Error',
+        message: 'delivery failed',
+        stack: expect.stringContaining('Error: delivery failed'),
+      },
+    });
+    expect(meta.error).not.toHaveProperty('cause');
+  });
+
+  it('keeps enumerable diagnostics and recurses through cause and AggregateError', () => {
+    const socket = Object.assign(new Error('other side closed'), {
+      code: 'UND_ERR_SOCKET',
+    });
+    const fetchFailed = new TypeError('fetch failed', { cause: socket });
+    const aggregate = new AggregateError([fetchFailed], 'all attempts failed');
+
+    const meta = JSON.parse(serializeGraphileMeta({ error: aggregate }));
+    expect(meta.error).toMatchObject({
+      name: 'AggregateError',
+      message: 'all attempts failed',
+      errors: [
+        {
+          name: 'TypeError',
+          message: 'fetch failed',
+          cause: {
+            name: 'Error',
+            message: 'other side closed',
+            code: 'UND_ERR_SOCKET',
+            stack: expect.stringContaining('other side closed'),
+          },
+        },
+      ],
+    });
+  });
+
+  it('does not throw on a cyclic cause chain', () => {
+    const outer = new Error('outer');
+    const inner = new Error('inner', { cause: outer });
+    outer.cause = inner;
+
+    const meta = JSON.parse(serializeGraphileMeta({ error: outer }));
+    expect(meta.error).toMatchObject({
+      message: 'outer',
+      cause: {
+        message: 'inner',
+        cause: { name: 'Error', message: 'outer', repeated: true },
+      },
+    });
+  });
+});

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -42,9 +42,21 @@ function createGraphileLogger() {
     if ((level === 'debug' || level === 'info') && !isVerbose()) return;
     const pipe = level === 'error' ? process.stderr : process.stdout;
     if (meta) {
-      pipe.write(
-        `[Graphile Worker] ${message} ${JSON.stringify(meta, null, 2)}\n`
+      const serializedMeta = JSON.stringify(
+        meta,
+        (_key, value) =>
+          value instanceof Error
+            ? {
+                ...value,
+                name: value.name,
+                message: value.message,
+                stack: value.stack,
+                cause: value.cause,
+              }
+            : value,
+        2
       );
+      pipe.write(`[Graphile Worker] ${message} ${serializedMeta}\n`);
     } else {
       pipe.write(`[Graphile Worker] ${message}\n`);
     }

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -33,6 +33,40 @@ import { z } from 'zod/v4';
 import type { PostgresWorldConfig } from './config.js';
 import { MessageData } from './message.js';
 
+/**
+ * Serialize Graphile Worker log metadata. `JSON.stringify` alone renders an
+ * `Error` as `{}` because `name`, `message`, `stack`, and `cause` are
+ * non-enumerable, which is how a failed delivery used to log `"error": {}`.
+ * Errors are expanded to those fields plus their enumerable properties (such as
+ * a transport `code`), recursively through `cause` and `AggregateError.errors`.
+ * An error that has already been expanded is replaced with a marker: a cyclic
+ * cause chain would otherwise make `JSON.stringify` throw from inside the
+ * logger, and Graphile has no fallback for a logger that throws.
+ */
+export function serializeGraphileMeta(meta: unknown): string {
+  const seen = new WeakSet<object>();
+  const expandError = (error: Error): Record<string, unknown> => {
+    if (seen.has(error)) {
+      return { name: error.name, message: error.message, repeated: true };
+    }
+    seen.add(error);
+    const expanded: Record<string, unknown> = {
+      ...error,
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+    if (error.cause !== undefined) expanded.cause = error.cause;
+    if (error instanceof AggregateError) expanded.errors = error.errors;
+    return expanded;
+  };
+  return JSON.stringify(
+    meta,
+    (_key, value) => (value instanceof Error ? expandError(value) : value),
+    2
+  );
+}
+
 function createGraphileLogger() {
   const isJsonMode = () => process.env.WORKFLOW_JSON_MODE === '1';
   const isVerbose = () => Boolean(process.env.DEBUG);
@@ -42,21 +76,9 @@ function createGraphileLogger() {
     if ((level === 'debug' || level === 'info') && !isVerbose()) return;
     const pipe = level === 'error' ? process.stderr : process.stdout;
     if (meta) {
-      const serializedMeta = JSON.stringify(
-        meta,
-        (_key, value) =>
-          value instanceof Error
-            ? {
-                ...value,
-                name: value.name,
-                message: value.message,
-                stack: value.stack,
-                cause: value.cause,
-              }
-            : value,
-        2
+      pipe.write(
+        `[Graphile Worker] ${message} ${serializeGraphileMeta(meta)}\n`
       );
-      pipe.write(`[Graphile Worker] ${message} ${serializedMeta}\n`);
     } else {
       pipe.write(`[Graphile Worker] ${message}\n`);
     }

--- a/packages/world-postgres/test/fixtures/failing-queue.mjs
+++ b/packages/world-postgres/test/fixtures/failing-queue.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { getQueueTopicPrefix } from '@workflow/world';
+import { Pool } from 'pg';
+import { createQueue } from '../../dist/queue.js';
+
+assert(process.env.WORKFLOW_POSTGRES_URL, 'WORKFLOW_POSTGRES_URL is required');
+const connectionString = process.env.WORKFLOW_POSTGRES_URL;
+const pool = new Pool({ connectionString, max: 4 });
+const server = createServer(async (request, response) => {
+  await request.toArray();
+  response.writeHead(503, { 'content-type': 'text/plain' });
+  response.end('test queue delivery failure');
+});
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+const address = server.address();
+assert(address && typeof address !== 'string', 'Expected a TCP server');
+process.env.WORKFLOW_LOCAL_BASE_URL = `http://127.0.0.1:${address.port}`;
+const queue = createQueue(
+  { connectionString, queueConcurrency: 1, applicationManagedShutdown: true },
+  pool
+);
+try {
+  const { messageId } = await queue.queue(
+    `${getQueueTopicPrefix('workflow')}test`,
+    { runId: `run_${randomUUID()}` }
+  );
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const jobs = await pool.query(
+      'SELECT attempts, last_error, locked_at FROM graphile_worker._private_jobs WHERE key = $1',
+      [messageId]
+    );
+    const job = jobs.rows[0];
+    if (job && job.last_error !== null && job.locked_at === null) {
+      assert.equal(job.attempts, 1);
+      break;
+    }
+    assert(Date.now() < deadline, 'Queue delivery did not fail');
+    await sleep(20);
+  }
+} finally {
+  await queue.close();
+  await pool.query('TRUNCATE graphile_worker._private_jobs');
+  await pool.end();
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+}

--- a/packages/world-postgres/test/queue-logging.test.ts
+++ b/packages/world-postgres/test/queue-logging.test.ts
@@ -1,88 +1,70 @@
 import { execFile } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
-import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 const run = promisify(execFile);
 
-describe.skipIf(process.platform === 'win32')(
-  'Postgres queue error logs',
-  () => {
-    const database = `queue_logging_${randomUUID().replaceAll('-', '')}`;
-    let container:
-      | Awaited<ReturnType<PostgreSqlContainer['start']>>
-      | undefined;
-    let admin: Pool;
-    let connectionString: string;
-
-    beforeAll(async () => {
-      let sourceUrl = process.env.WORKFLOW_POSTGRES_URL;
-      if (sourceUrl === undefined) {
-        container = await new PostgreSqlContainer('postgres:15-alpine').start();
-        sourceUrl = container.getConnectionUri();
-      }
-      const url = new URL(sourceUrl);
-      if (!['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)) {
-        throw new Error(
-          'Queue logging tests require a loopback PostgreSQL server'
-        );
-      }
-      admin = new Pool({ connectionString: url.href, max: 1 });
-      await admin.query(`CREATE DATABASE "${database}"`);
-      url.pathname = `/${database}`;
-      connectionString = url.href;
-    }, 120_000);
-
-    afterAll(async () => {
-      await admin.query(`DROP DATABASE "${database}"`);
-      await admin.end();
-      if (container) await container.stop();
-    });
-
-    async function failDelivery(jsonMode: boolean) {
-      return await run(
-        process.execPath,
-        [
-          fileURLToPath(
-            new URL('./fixtures/failing-queue.mjs', import.meta.url)
-          ),
-        ],
-        {
-          env: {
-            ...process.env,
-            DEBUG: '',
-            WORKFLOW_JSON_MODE: jsonMode ? '1' : '0',
-            WORKFLOW_POSTGRES_URL: connectionString,
-          },
-          timeout: 15_000,
-        }
-      );
-    }
-
-    test('preserves the delivery error and stack in worker metadata', async () => {
-      const { stdout, stderr } = await failDelivery(false);
-      expect(stdout).toBe('');
-      expect(stderr).toContain('[Graphile Worker] Failed task');
-      const metadataStart = stderr.indexOf('{\n');
-      expect(metadataStart).toBeGreaterThan(-1);
-      const metadata = JSON.parse(stderr.slice(metadataStart));
-      expect(metadata.error).toMatchObject({
-        name: 'Error',
-        message:
-          '[postgres world] Queue execution failed (503): test queue delivery failure',
-        stack: expect.stringContaining(
-          'Error: [postgres world] Queue execution failed (503): test queue delivery failure'
-        ),
-      });
-    });
-
-    test('keeps worker output suppressed in CLI JSON mode', async () => {
-      const { stdout, stderr } = await failDelivery(true);
-      expect(stdout).toBe('');
-      expect(stderr).toBe('');
-    });
+/**
+ * What Graphile Worker writes to stderr when a delivery fails, captured from a
+ * real worker in a subprocess (`fixtures/failing-queue.mjs`, which imports the
+ * built `dist/queue.js`). The serializer itself is unit-tested in
+ * `src/queue-logging.test.ts`; this pins down that Graphile hands the logger
+ * the `Error` in `meta` and that the two output controls still hold.
+ */
+describe('Postgres queue error logs (integration)', () => {
+  if (process.platform === 'win32') {
+    test.skip('skipped on Windows since it relies on a docker container', () => {});
+    return;
   }
-);
+
+  let container: Awaited<ReturnType<PostgreSqlContainer['start']>>;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:15-alpine').start();
+  }, 120_000);
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  async function failDelivery(jsonMode: boolean) {
+    return await run(
+      process.execPath,
+      [fileURLToPath(new URL('./fixtures/failing-queue.mjs', import.meta.url))],
+      {
+        env: {
+          ...process.env,
+          DEBUG: '',
+          WORKFLOW_JSON_MODE: jsonMode ? '1' : '0',
+          WORKFLOW_POSTGRES_URL: container.getConnectionUri(),
+        },
+        timeout: 15_000,
+      }
+    );
+  }
+
+  test('preserves the delivery error and stack in worker metadata', async () => {
+    const { stdout, stderr } = await failDelivery(false);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('[Graphile Worker] Failed task');
+    const metadataStart = stderr.indexOf('{\n');
+    expect(metadataStart).toBeGreaterThan(-1);
+    const metadata = JSON.parse(stderr.slice(metadataStart));
+    expect(metadata.error).toMatchObject({
+      name: 'Error',
+      message:
+        '[postgres world] Queue execution failed (503): test queue delivery failure',
+      stack: expect.stringContaining(
+        'Error: [postgres world] Queue execution failed (503): test queue delivery failure'
+      ),
+    });
+  });
+
+  test('keeps worker output suppressed in CLI JSON mode', async () => {
+    const { stdout, stderr } = await failDelivery(true);
+    expect(stdout).toBe('');
+    expect(stderr).toBe('');
+  });
+});

--- a/packages/world-postgres/test/queue-logging.test.ts
+++ b/packages/world-postgres/test/queue-logging.test.ts
@@ -1,0 +1,88 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+const run = promisify(execFile);
+
+describe.skipIf(process.platform === 'win32')(
+  'Postgres queue error logs',
+  () => {
+    const database = `queue_logging_${randomUUID().replaceAll('-', '')}`;
+    let container:
+      | Awaited<ReturnType<PostgreSqlContainer['start']>>
+      | undefined;
+    let admin: Pool;
+    let connectionString: string;
+
+    beforeAll(async () => {
+      let sourceUrl = process.env.WORKFLOW_POSTGRES_URL;
+      if (sourceUrl === undefined) {
+        container = await new PostgreSqlContainer('postgres:15-alpine').start();
+        sourceUrl = container.getConnectionUri();
+      }
+      const url = new URL(sourceUrl);
+      if (!['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)) {
+        throw new Error(
+          'Queue logging tests require a loopback PostgreSQL server'
+        );
+      }
+      admin = new Pool({ connectionString: url.href, max: 1 });
+      await admin.query(`CREATE DATABASE "${database}"`);
+      url.pathname = `/${database}`;
+      connectionString = url.href;
+    }, 120_000);
+
+    afterAll(async () => {
+      await admin.query(`DROP DATABASE "${database}"`);
+      await admin.end();
+      if (container) await container.stop();
+    });
+
+    async function failDelivery(jsonMode: boolean) {
+      return await run(
+        process.execPath,
+        [
+          fileURLToPath(
+            new URL('./fixtures/failing-queue.mjs', import.meta.url)
+          ),
+        ],
+        {
+          env: {
+            ...process.env,
+            DEBUG: '',
+            WORKFLOW_JSON_MODE: jsonMode ? '1' : '0',
+            WORKFLOW_POSTGRES_URL: connectionString,
+          },
+          timeout: 15_000,
+        }
+      );
+    }
+
+    test('preserves the delivery error and stack in worker metadata', async () => {
+      const { stdout, stderr } = await failDelivery(false);
+      expect(stdout).toBe('');
+      expect(stderr).toContain('[Graphile Worker] Failed task');
+      const metadataStart = stderr.indexOf('{\n');
+      expect(metadataStart).toBeGreaterThan(-1);
+      const metadata = JSON.parse(stderr.slice(metadataStart));
+      expect(metadata.error).toMatchObject({
+        name: 'Error',
+        message:
+          '[postgres world] Queue execution failed (503): test queue delivery failure',
+        stack: expect.stringContaining(
+          'Error: [postgres world] Queue execution failed (503): test queue delivery failure'
+        ),
+      });
+    });
+
+    test('keeps worker output suppressed in CLI JSON mode', async () => {
+      const { stdout, stderr } = await failDelivery(true);
+      expect(stdout).toBe('');
+      expect(stderr).toBe('');
+    });
+  }
+);


### PR DESCRIPTION
### Description

Fixes #4116.

Preserve `Error` fields in Graphile Worker log metadata. A real failed HTTP delivery currently produces `"error": {}` in the JSON metadata, even though Graphile's preceding text contains the top-level message and stack. The JSON replacer now includes the name, message, stack, and nested cause while retaining enumerable properties such as transport error codes.

The existing stderr/stdout routing, `DEBUG` filtering, and `WORKFLOW_JSON_MODE=1` suppression are preserved. The README documents the logging behavior. No runtime dependency or public API is added.

### How did you test your changes?

- Two real PostgreSQL/Graphile Worker/HTTP integration tests passed. A loopback server returns HTTP 503, and a subprocess captures actual worker stderr to verify the error name, message, and stack. The second test verifies quiet CLI JSON mode. Unmodified main fails the metadata assertion with `{}` and passes the JSON-mode case.
- The committed regression uses an HTTP status failure, so it does not depend on which HTTP client delivers the request. Nested cause handling is implemented by the recursive JSON replacer; the committed regression does not separately cover a nested cause.
- Package source suite: 27 tests passed.
- Package build and frozen-lockfile installation of affected packages passed on Node 24.21.0 / pnpm 11.24.0.
- Biome has no errors; one existing complexity warning remains. Changeset status and `git diff --check` passed.

The integration tests used PostgreSQL 18.2 on loopback, creating and removing an isolated database. They use Testcontainers by default or an explicit loopback `WORKFLOW_POSTGRES_URL`. No PostgreSQL, worker, HTTP, logger, or stderr mock is added. Build the package before running the integration test because the subprocess imports its compiled queue, matching the existing package conformance tests.

### PR Checklist - Required to merge

- [x] 📦 Patch changeset included; `pnpm changeset status --since=main` passes.
- [x] 🔒 DCO sign-off included.
- [x] 📝 Ping `@vercel/workflow` in a comment once the PR is ready, and the above checklist is complete.

### Diff size

**Docs** — 2 files · `+9 / -0`

A release note and package guide describe error metadata and existing logging controls.

**Implementation** — 1 file · `+14 / -2`

Serializes standard Error fields and nested causes while retaining enumerable diagnostic properties.

**Tests** — 2 files · `+143 / -0`

Uses real PostgreSQL, Graphile, HTTP, and subprocess output to verify failed-delivery metadata and CLI JSON-mode suppression.
