### PR TITLE
test: persist E2E flake history

### DIFF
--- a/.changeset/breezy-days-run.md
+++ b/.changeset/breezy-days-run.md
@@ -1,0 +1,4 @@
+---
+---
+
+Persist a bounded 30-run history of E2E retry rates with exact lane dimensions and execution denominators.

--- a/.github/scripts/aggregate-e2e-results.js
+++ b/.github/scripts/aggregate-e2e-results.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { dimensionFor } = require('./generate-e2e-flake-history.js');
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -62,7 +63,7 @@ function findResultFiles(dir) {
     // trailing dot matters — the Python lane's report is
     // `e2e-conformance-python.json` and must keep matching.
     'e2e-conformance.',
-  ]);
+  ]).filter((file) => !file.endsWith('.flaky.json'));
 }
 
 // Find all e2e metadata JSON files
@@ -159,19 +160,34 @@ function loadFailures(dir) {
 // several jobs for one app is collapsed into a single entry with an
 // occurrence count so the section stays scannable.
 function loadFlaky(dir) {
-  // Map of `${app}\u0000${testName}` -> { app, testName, retryCount, occurrences }
+  // New sidecars pair 1:1 with exact result files; keep reading legacy names
+  // while artifacts from older branches can still reach the aggregator.
   const flaky = new Map();
-  const files = findJsonFiles(dir, 'e2e-flaky-');
+  const paired = findJsonFiles(dir, 'e2e-').filter((file) =>
+    file.endsWith('.flaky.json')
+  );
+  const legacy = findJsonFiles(dir, 'e2e-flaky-');
 
-  for (const file of files) {
-    const basename = path.basename(file, '.json');
-    const match = basename.match(/^e2e-flaky-(.+)-(?:vercel|local)$/);
-    const app = match ? match[1] : 'unknown';
+  for (const file of [...paired, ...legacy]) {
+    const basename = path.basename(file);
+    const pairedReport = basename.replace(/\.flaky\.json$/, '.json');
+    const dimension = basename.endsWith('.flaky.json')
+      ? dimensionFor(pairedReport)
+      : null;
+    const legacyMatch = path
+      .basename(file, '.json')
+      .match(/^e2e-flaky-(.+)-(?:vercel|local)$/);
+    const app = dimension?.app || legacyMatch?.[1] || 'unknown';
+    const lane = dimension
+      ? [dimension.lane, dimension.world, dimension.vm, dimension.variant]
+          .filter(Boolean)
+          .join(' / ')
+      : null;
     try {
       const entries = JSON.parse(fs.readFileSync(file, 'utf-8'));
       for (const entry of entries) {
         if (!entry.testName) continue;
-        const key = `${app}\u0000${entry.testName}`;
+        const key = `${lane || app}\u0000${entry.fullName || entry.testName}`;
         const existing = flaky.get(key);
         if (existing) {
           existing.occurrences++;
@@ -182,6 +198,7 @@ function loadFlaky(dir) {
         } else {
           flaky.set(key, {
             app,
+            lane,
             testName: entry.testName,
             retryCount: entry.retryCount || 1,
             occurrences: 1,
@@ -286,7 +303,8 @@ function renderFlakySection(flakyTests) {
   for (const test of sorted) {
     const jobs =
       test.occurrences > 1 ? ` — flaked in ${test.occurrences} jobs` : '';
-    console.log(`- \`${test.testName}\` (${test.app})${jobs}`);
+    const location = test.lane ? `${test.app} · ${test.lane}` : test.app;
+    console.log(`- \`${test.testName}\` (${location})${jobs}`);
   }
   console.log('');
   if (collapse) {

--- a/.github/scripts/aggregate-e2e-results.test.js
+++ b/.github/scripts/aggregate-e2e-results.test.js
@@ -131,6 +131,30 @@ test('all-passing runs omit the Failed E2E Tests section entirely', () => {
   assert.match(body, /<details>\n<summary>Summary<\/summary>/);
 });
 
+test('paired flaky sidecars retain exact lane and VM attribution', () => {
+  const body = renderAggregate({
+    'e2e-local-postgres-nextjs-turbopack-stable-quickjs.json': resultJson(
+      'a',
+      1
+    ),
+    'e2e-local-postgres-nextjs-turbopack-stable-quickjs.flaky.json':
+      JSON.stringify([
+        {
+          testName: 'passes on retry',
+          fullName: 'e2e passes on retry',
+          retryCount: 1,
+        },
+      ]),
+  });
+
+  assert.match(body, /`passes on retry`/);
+  assert.match(
+    body,
+    /nextjs-turbopack · local-postgres \/ postgres \/ quickjs \/ stable/
+  );
+  assert.doesNotMatch(body, /Results by File[\s\S]*\.flaky\.json/);
+});
+
 test('Details by Category has no nested collapsibles', () => {
   const body = renderAggregate({
     'e2e-vercel-prod-nextjs-turbopack.json': resultJson('a', 40, ['x']),

--- a/.github/scripts/generate-e2e-flake-history.js
+++ b/.github/scripts/generate-e2e-flake-history.js
@@ -1,0 +1,552 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MAX_RUNS = 30;
+const MAX_INPUT_BYTES = 10 * 1024 * 1024;
+const MAX_INPUT_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_REPORT_FILES = 512;
+const SCHEMA_VERSION = 1;
+
+function parseArgs(argv) {
+  const options = {
+    resultsDir: '.',
+    previous: null,
+    output: 'e2e-flake-history.json',
+    runId: process.env.GITHUB_RUN_ID || '',
+    attempt: process.env.GITHUB_RUN_ATTEMPT || '1',
+    sha: process.env.GITHUB_SHA || '',
+    startedAt: process.env.GITHUB_RUN_STARTED_AT || new Date().toISOString(),
+    runUrl: '',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (key === '--results-dir') options.resultsDir = value;
+    else if (key === '--previous') options.previous = value;
+    else if (key === '--output') options.output = value;
+    else if (key === '--run-id') options.runId = value;
+    else if (key === '--attempt') options.attempt = value;
+    else if (key === '--sha') options.sha = value;
+    else if (key === '--started-at') options.startedAt = value;
+    else if (key === '--run-url') options.runUrl = value;
+    else continue;
+    i++;
+  }
+  return options;
+}
+
+function findReports(dir) {
+  const reports = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) reports.push(...findReports(full));
+    else if (
+      entry.isFile() &&
+      entry.name.startsWith('e2e-') &&
+      entry.name.endsWith('.json') &&
+      !entry.name.endsWith('.flaky.json') &&
+      !/^(e2e-(?:metadata|failures|flaky|infra|diagnostics|runtime-logs)-|e2e-conformance\.)/.test(
+        entry.name
+      )
+    ) {
+      reports.push(full);
+    }
+  }
+  return reports.sort();
+}
+
+const DIMENSION_PATTERNS = [
+  [
+    /^e2e-vercel-prod-(.+)-(node|quickjs)$/,
+    (match) => ({
+      lane: 'vercel-prod',
+      app: match[1],
+      world: 'vercel',
+      vm: match[2],
+      platform: 'vercel',
+      variant: 'production',
+    }),
+  ],
+  [
+    /^e2e-vercel-(ws|http)-transport-(.+)$/,
+    (match) => ({
+      lane: `vercel-${match[1]}-transport`,
+      app: match[2],
+      world: 'vercel',
+      vm: 'node',
+      platform: 'vercel',
+      variant: match[1],
+    }),
+  ],
+  [
+    /^e2e-vercel-multi-region-(.+)$/,
+    (match) => ({
+      lane: 'vercel-multi-region',
+      app: match[1],
+      world: 'vercel',
+      vm: 'node',
+      platform: 'vercel',
+      variant: 'multi-region',
+    }),
+  ],
+  [
+    /^e2e-local-(dev|prod)-(.+)-(stable|canary(?:-lazy-discovery-(?:enabled|disabled))?)-(node|quickjs)$/,
+    (match) => ({
+      lane: `local-${match[1]}`,
+      app: match[2],
+      world: 'local',
+      vm: match[4],
+      platform: 'linux',
+      variant: match[3],
+    }),
+  ],
+  [
+    /^e2e-local-postgres-(.+)-(stable|canary(?:-lazy-discovery-(?:enabled|disabled))?)-(node|quickjs)$/,
+    (match) => ({
+      lane: 'local-postgres',
+      app: match[1],
+      world: 'postgres',
+      vm: match[3],
+      platform: 'linux',
+      variant: match[2],
+    }),
+  ],
+  [
+    /^e2e-local-(dev|prod)-(.+)-(node|quickjs)$/,
+    (match) => ({
+      lane: `local-${match[1]}`,
+      app: match[2],
+      world: 'local',
+      vm: match[3],
+      platform: 'linux',
+    }),
+  ],
+  [
+    /^e2e-local-postgres-(.+)-(node|quickjs)$/,
+    (match) => ({
+      lane: 'local-postgres',
+      app: match[1],
+      world: 'postgres',
+      vm: match[2],
+      platform: 'linux',
+    }),
+  ],
+  [
+    /^e2e-community-(.+)-dev$/,
+    (match) => ({
+      lane: 'community-dev',
+      app: match[1],
+      world: match[1],
+      vm: 'node',
+      platform: 'linux',
+    }),
+  ],
+  [
+    /^e2e-community-(.+)$/,
+    (match) => ({
+      lane: 'community',
+      app: match[1],
+      world: match[1],
+      vm: 'node',
+      platform: 'linux',
+    }),
+  ],
+  [
+    /^e2e-windows-(.+)-(node|quickjs)$/,
+    (match) => ({
+      lane: 'windows',
+      app: match[1],
+      world: 'local',
+      vm: match[2],
+      platform: 'windows',
+    }),
+  ],
+];
+
+function dimensionFor(filename) {
+  const stem = path.basename(filename, '.json');
+  if (stem === 'e2e-conformance-python') {
+    return {
+      lane: 'conformance',
+      app: 'python',
+      world: 'local',
+      vm: 'python',
+      platform: 'linux',
+    };
+  }
+  for (const [pattern, createDimension] of DIMENSION_PATTERNS) {
+    const match = stem.match(pattern);
+    if (match) return createDimension(match);
+  }
+  return null;
+}
+
+function normalizeFile(file) {
+  if (!file) return 'unknown';
+  const normalized = file.replaceAll('\\', '/');
+  const marker = '/packages/';
+  const workbenchMarker = '/workbench/';
+  const index = normalized.lastIndexOf(marker);
+  if (index >= 0) return normalized.slice(index + 1);
+  const workbenchIndex = normalized.lastIndexOf(workbenchMarker);
+  if (workbenchIndex >= 0) return normalized.slice(workbenchIndex + 1);
+  return normalized.replace(/^\.\//, '');
+}
+
+function validatePreviousHistory(history) {
+  const validRun = (run) =>
+    run &&
+    typeof run.id === 'string' &&
+    Number.isFinite(run.runId) &&
+    Number.isFinite(run.attempt) &&
+    typeof run.startedAt === 'string';
+  const validDimension = (dimension) =>
+    dimension &&
+    typeof dimension.lane === 'string' &&
+    typeof dimension.app === 'string' &&
+    typeof dimension.world === 'string' &&
+    typeof dimension.vm === 'string' &&
+    typeof dimension.platform === 'string';
+  const validTest = (test) =>
+    test && typeof test.file === 'string' && typeof test.name === 'string';
+  const validSeries = (series) =>
+    Array.isArray(series) &&
+    series.length === 6 &&
+    Number.isInteger(series[0]) &&
+    series[0] >= 0 &&
+    series[0] < history.dimensions.length &&
+    Number.isInteger(series[1]) &&
+    series[1] >= 0 &&
+    series[1] < history.tests.length &&
+    Number.isInteger(series[2]) &&
+    Number.isInteger(series[3]) &&
+    typeof series[4] === 'string' &&
+    /^[0-9a-f]+$/i.test(series[4]) &&
+    typeof series[5] === 'string' &&
+    /^[0-9a-f]+$/i.test(series[5]);
+
+  return (
+    history.schemaVersion === SCHEMA_VERSION &&
+    Array.isArray(history.runs) &&
+    history.runs.length <= MAX_RUNS &&
+    history.runs.every(validRun) &&
+    Array.isArray(history.dimensions) &&
+    history.dimensions.every(validDimension) &&
+    Array.isArray(history.tests) &&
+    history.tests.every(validTest) &&
+    Array.isArray(history.series) &&
+    history.series.every(validSeries)
+  );
+}
+
+function readPrevious(filename) {
+  if (!filename || !fs.existsSync(filename)) return null;
+  const stat = fs.statSync(filename);
+  if (stat.size === 0) return null;
+  if (stat.size > 10 * 1024 * 1024) {
+    throw new Error('Previous flake history exceeds the 10 MiB safety limit');
+  }
+  const parsed = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  if (!validatePreviousHistory(parsed)) {
+    throw new Error(
+      'Previous flake history uses an unsupported or corrupt schema'
+    );
+  }
+  return parsed;
+}
+
+function bitSet(mask, index) {
+  return (BigInt(`0x${mask || '0'}`) & (1n << BigInt(index))) !== 0n;
+}
+
+function dimensionKey(dimension) {
+  return JSON.stringify(dimension);
+}
+function testKey(test) {
+  return `${test.file}\u0000${test.name}`;
+}
+function observationKey(dimension, test) {
+  return `${dimensionKey(dimension)}\u0001${testKey(test)}`;
+}
+
+function previousObservations(history) {
+  const observations = new Map();
+  if (!history) return observations;
+  for (const [
+    dimensionIndex,
+    testIndex,
+    ,
+    ,
+    executedMask,
+    retryMask,
+  ] of history.series) {
+    const dimension = history.dimensions[dimensionIndex];
+    const test = history.tests[testIndex];
+    if (!dimension || !test) continue;
+    const key = observationKey(dimension, test);
+    const value = { dimension, test, executed: new Set(), retried: new Set() };
+    history.runs.forEach((run, index) => {
+      if (bitSet(executedMask, index)) value.executed.add(run.id);
+      if (bitSet(retryMask, index)) value.retried.add(run.id);
+    });
+    observations.set(key, value);
+  }
+  return observations;
+}
+
+function readJsonInput(filename, budget) {
+  const size = fs.statSync(filename).size;
+  if (size > MAX_INPUT_FILE_BYTES) {
+    throw new Error('file exceeds the 2 MiB input limit');
+  }
+  budget.bytes += size;
+  if (budget.bytes > MAX_INPUT_BYTES) {
+    throw new Error('inputs exceed the 10 MiB aggregate limit');
+  }
+  return JSON.parse(fs.readFileSync(filename, 'utf8'));
+}
+
+function validateReport(report) {
+  if (!report || !Array.isArray(report.testResults)) {
+    throw new Error('missing testResults');
+  }
+  for (const testFile of report.testResults) {
+    if (
+      !testFile ||
+      typeof testFile.name !== 'string' ||
+      !Array.isArray(testFile.assertionResults)
+    ) {
+      throw new Error('invalid test result');
+    }
+    for (const assertion of testFile.assertionResults) {
+      if (
+        !assertion ||
+        typeof assertion.status !== 'string' ||
+        (typeof assertion.fullName !== 'string' &&
+          typeof assertion.title !== 'string')
+      ) {
+        throw new Error('invalid assertion result');
+      }
+    }
+  }
+}
+
+function validateFlakyEntries(entries) {
+  if (!Array.isArray(entries)) throw new Error('expected an array');
+  for (const entry of entries) {
+    if (
+      !entry ||
+      typeof entry.file !== 'string' ||
+      (typeof entry.fullName !== 'string' && typeof entry.testName !== 'string')
+    ) {
+      throw new Error('invalid retry entry');
+    }
+  }
+}
+
+function addReportObservations(
+  report,
+  flakyEntries,
+  dimension,
+  runId,
+  observations
+) {
+  const retried = new Set(
+    flakyEntries.map(
+      (entry) =>
+        `${normalizeFile(entry.file)}\u0000${entry.fullName || entry.testName}`
+    )
+  );
+  for (const testFile of report.testResults) {
+    for (const assertion of testFile.assertionResults) {
+      if (assertion.status !== 'passed' && assertion.status !== 'failed') {
+        continue;
+      }
+      const test = {
+        file: normalizeFile(testFile.name),
+        name: assertion.fullName || assertion.title,
+      };
+      const key = observationKey(dimension, test);
+      const value = observations.get(key) || {
+        dimension,
+        test,
+        executed: new Set(),
+        retried: new Set(),
+      };
+      value.executed.add(runId);
+      if (assertion.status === 'passed' && retried.has(testKey(test))) {
+        value.retried.add(runId);
+      }
+      observations.set(key, value);
+    }
+  }
+}
+
+function loadCurrent(resultsDir, runId, observations) {
+  const reports = findReports(resultsDir);
+  if (reports.length > MAX_REPORT_FILES) {
+    throw new Error(`Found more than ${MAX_REPORT_FILES} E2E reports`);
+  }
+  const budget = { bytes: 0 };
+  let validReports = 0;
+  for (const reportFile of reports) {
+    const dimension = dimensionFor(reportFile);
+    if (!dimension) {
+      console.warn(
+        `Skipping report with unknown dimensions: ${path.basename(reportFile)}`
+      );
+      continue;
+    }
+    const flakyFile = reportFile.replace(/\.json$/, '.flaky.json');
+    if (!fs.existsSync(flakyFile)) {
+      console.warn(
+        `Skipping report without paired retry telemetry: ${path.basename(reportFile)}`
+      );
+      continue;
+    }
+    try {
+      const report = readJsonInput(reportFile, budget);
+      const flakyEntries = readJsonInput(flakyFile, budget);
+      validateReport(report);
+      validateFlakyEntries(flakyEntries);
+      addReportObservations(
+        report,
+        flakyEntries,
+        dimension,
+        runId,
+        observations
+      );
+      validReports++;
+    } catch (error) {
+      if (error.message.includes('aggregate limit')) throw error;
+      console.warn(
+        `Skipping invalid report pair ${reportFile}: ${error.message}`
+      );
+    }
+  }
+  return validReports;
+}
+
+function popcount(mask) {
+  let value = mask;
+  let count = 0;
+  while (value) {
+    count += Number(value & 1n);
+    value >>= 1n;
+  }
+  return count;
+}
+
+function buildHistory(options) {
+  const previous = readPrevious(options.previous);
+  const observations = previousObservations(previous);
+  const run = {
+    id: `${options.runId}.${options.attempt}`,
+    runId: Number(options.runId),
+    attempt: Number(options.attempt),
+    sha: options.sha,
+    startedAt: options.startedAt,
+    url: options.runUrl,
+  };
+  if (!options.runId || !Number.isFinite(run.runId))
+    throw new Error('--run-id is required');
+
+  // A repeated publication for the same workflow attempt replaces that
+  // attempt's observations instead of preserving stale retry bits.
+  for (const value of observations.values()) {
+    value.executed.delete(run.id);
+    value.retried.delete(run.id);
+  }
+  const validReports = loadCurrent(options.resultsDir, run.id, observations);
+  if (validReports === 0) {
+    console.warn(
+      'No valid E2E reports found; leaving previous history unchanged'
+    );
+    if (!previous) throw new Error('No valid reports and no previous history');
+    return previous;
+  }
+
+  const runsById = new Map(
+    (previous?.runs || []).map((item) => [item.id, item])
+  );
+  runsById.set(run.id, run);
+  const runs = [...runsById.values()]
+    .sort(
+      (a, b) =>
+        a.startedAt.localeCompare(b.startedAt) ||
+        a.runId - b.runId ||
+        a.attempt - b.attempt
+    )
+    .slice(-MAX_RUNS);
+  const retained = new Set(runs.map((item) => item.id));
+  const runIndex = new Map(runs.map((item, index) => [item.id, index]));
+
+  const dimensions = [];
+  const tests = [];
+  const dimensionIndexes = new Map();
+  const testIndexes = new Map();
+  const series = [];
+  for (const value of observations.values()) {
+    const executed = [...value.executed].filter((id) => retained.has(id));
+    if (executed.length === 0) continue;
+    const retried = [...value.retried].filter((id) => retained.has(id));
+    const dKey = dimensionKey(value.dimension);
+    const tKey = testKey(value.test);
+    if (!dimensionIndexes.has(dKey)) {
+      dimensionIndexes.set(dKey, dimensions.length);
+      dimensions.push(value.dimension);
+    }
+    if (!testIndexes.has(tKey)) {
+      testIndexes.set(tKey, tests.length);
+      tests.push(value.test);
+    }
+    let executedMask = 0n;
+    let retryMask = 0n;
+    for (const id of executed) executedMask |= 1n << BigInt(runIndex.get(id));
+    for (const id of retried) retryMask |= 1n << BigInt(runIndex.get(id));
+    series.push([
+      dimensionIndexes.get(dKey),
+      testIndexes.get(tKey),
+      popcount(executedMask),
+      popcount(retryMask),
+      executedMask.toString(16),
+      retryMask.toString(16),
+    ]);
+  }
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    metric: 'passed-on-retry',
+    retentionRuns: MAX_RUNS,
+    generatedAt: new Date().toISOString(),
+    runs,
+    dimensions,
+    tests,
+    series,
+  };
+}
+
+if (require.main === module) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const history = buildHistory(options);
+    const output = `${JSON.stringify(history)}\n`;
+    if (Buffer.byteLength(output) > 10 * 1024 * 1024) {
+      throw new Error(
+        'Generated flake history exceeds the 10 MiB safety limit'
+      );
+    }
+    fs.mkdirSync(path.dirname(options.output), { recursive: true });
+    fs.writeFileSync(options.output, output);
+    console.log(
+      `Wrote ${history.runs.length}-run E2E flake history to ${options.output}`
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { buildHistory, dimensionFor, normalizeFile };

--- a/.github/scripts/generate-e2e-flake-history.test.js
+++ b/.github/scripts/generate-e2e-flake-history.test.js
@@ -1,0 +1,293 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+const {
+  buildHistory,
+  dimensionFor,
+} = require('./generate-e2e-flake-history.js');
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-flake-history-'));
+}
+
+function writeReport(dir, name, assertions, flaky = []) {
+  const report = path.join(dir, name);
+  fs.writeFileSync(
+    report,
+    JSON.stringify({
+      testResults: [
+        {
+          name: '/repo/packages/core/e2e/e2e.test.ts',
+          assertionResults: assertions.map(([fullName, status]) => ({
+            title: fullName.replace(/^e2e /, ''),
+            fullName,
+            status,
+          })),
+        },
+      ],
+    })
+  );
+  fs.writeFileSync(
+    report.replace(/\.json$/, '.flaky.json'),
+    JSON.stringify(
+      flaky.map((fullName) => ({
+        file: '/repo/packages/core/e2e/e2e.test.ts',
+        fullName,
+        testName: fullName.replace(/^e2e /, ''),
+        retryCount: 1,
+      }))
+    )
+  );
+}
+
+function options(dir, runId, previous = null) {
+  return {
+    resultsDir: dir,
+    previous,
+    output: path.join(dir, 'out.json'),
+    runId: String(runId),
+    attempt: '1',
+    sha: `sha-${runId}`,
+    startedAt: `2026-09-${String(runId).padStart(2, '0')}T00:00:00Z`,
+    runUrl: `https://github.test/runs/${runId}`,
+  };
+}
+
+function observation(history, testName) {
+  const testIndex = history.tests.findIndex((entry) => entry.name === testName);
+  return history.series.find((entry) => entry[1] === testIndex);
+}
+
+test('parses lane dimensions without losing hyphenated app names', () => {
+  assert.deepStrictEqual(
+    dimensionFor('e2e-local-postgres-nextjs-turbopack-canary-quickjs.json'),
+    {
+      lane: 'local-postgres',
+      app: 'nextjs-turbopack',
+      world: 'postgres',
+      vm: 'quickjs',
+      platform: 'linux',
+      variant: 'canary',
+    }
+  );
+  assert.deepStrictEqual(
+    dimensionFor('e2e-local-dev-tanstack-start-quickjs.json'),
+    {
+      lane: 'local-dev',
+      app: 'tanstack-start',
+      world: 'local',
+      vm: 'quickjs',
+      platform: 'linux',
+    }
+  );
+  assert.deepStrictEqual(dimensionFor('e2e-community-turso-dev.json'), {
+    lane: 'community-dev',
+    app: 'turso',
+    world: 'turso',
+    vm: 'node',
+    platform: 'linux',
+  });
+  assert.deepStrictEqual(
+    dimensionFor('e2e-vercel-http-transport-tanstack-start.json'),
+    {
+      lane: 'vercel-http-transport',
+      app: 'tanstack-start',
+      world: 'vercel',
+      vm: 'node',
+      platform: 'vercel',
+      variant: 'http',
+    }
+  );
+});
+
+test('records executed denominators, excludes skips, and pairs retry data', () => {
+  const dir = tempDir();
+  writeReport(
+    dir,
+    'e2e-windows-nextjs-turbopack-node.json',
+    [
+      ['e2e passes first try', 'passed'],
+      ['e2e passes on retry', 'passed'],
+      ['e2e final failure', 'failed'],
+      ['e2e skipped', 'pending'],
+    ],
+    ['e2e passes on retry', 'e2e final failure']
+  );
+  const history = buildHistory(options(dir, 1));
+
+  assert.strictEqual(history.runs.length, 1);
+  assert.deepStrictEqual(
+    observation(history, 'e2e passes first try').slice(2),
+    [1, 0, '1', '0']
+  );
+  assert.deepStrictEqual(observation(history, 'e2e passes on retry').slice(2), [
+    1,
+    1,
+    '1',
+    '1',
+  ]);
+  assert.deepStrictEqual(observation(history, 'e2e final failure').slice(2), [
+    1,
+    0,
+    '1',
+    '0',
+  ]);
+  assert.strictEqual(observation(history, 'e2e skipped'), undefined);
+});
+
+test('rejects corrupt prior masks before decoding them', () => {
+  const dir = tempDir();
+  writeReport(dir, 'e2e-vercel-prod-vite-node.json', [['e2e test', 'passed']]);
+  const previousFile = path.join(dir, 'previous.json');
+  fs.writeFileSync(
+    previousFile,
+    JSON.stringify({
+      schemaVersion: 1,
+      runs: [
+        { id: '1.1', runId: 1, attempt: 1, startedAt: '2026-09-01T00:00:00Z' },
+      ],
+      dimensions: [{ lane: 'x', app: 'x', world: 'x', vm: 'x', platform: 'x' }],
+      tests: [{ file: 'x', name: 'x' }],
+      series: [null],
+    })
+  );
+  assert.throws(
+    () => buildHistory(options(dir, 2, previousFile)),
+    /unsupported or corrupt schema/
+  );
+});
+
+test('keeps same-app lanes and VMs as distinct series', () => {
+  const dir = tempDir();
+  writeReport(
+    dir,
+    'e2e-vercel-prod-vite-node.json',
+    [['e2e test', 'passed']],
+    ['e2e test']
+  );
+  writeReport(
+    dir,
+    'e2e-vercel-prod-vite-quickjs.json',
+    [['e2e test', 'passed']],
+    []
+  );
+  const history = buildHistory(options(dir, 1));
+  assert.strictEqual(history.dimensions.length, 2);
+  assert.strictEqual(history.series.length, 2);
+  assert.deepStrictEqual(
+    history.series.map((entry) => entry[3]).sort(),
+    [0, 1]
+  );
+});
+
+test('skips malformed and oversized pairs while retaining valid reports', () => {
+  const dir = tempDir();
+  writeReport(dir, 'e2e-vercel-prod-vite-node.json', [['e2e valid', 'passed']]);
+  fs.writeFileSync(
+    path.join(dir, 'e2e-vercel-prod-hono-node.json'),
+    JSON.stringify({ testResults: [null] })
+  );
+  fs.writeFileSync(
+    path.join(dir, 'e2e-vercel-prod-hono-node.flaky.json'),
+    '[]'
+  );
+  fs.writeFileSync(
+    path.join(dir, 'e2e-vercel-prod-express-node.json'),
+    `${' '.repeat(2 * 1024 * 1024)}\n`
+  );
+  fs.writeFileSync(
+    path.join(dir, 'e2e-vercel-prod-express-node.flaky.json'),
+    '[]'
+  );
+
+  const history = buildHistory(options(dir, 1));
+  assert.strictEqual(history.dimensions.length, 1);
+  assert.deepStrictEqual(observation(history, 'e2e valid').slice(2, 4), [1, 0]);
+});
+
+test('orders equal timestamps by numeric run and attempt', () => {
+  const dir = tempDir();
+  writeReport(dir, 'e2e-vercel-prod-vite-node.json', [['e2e test', 'passed']]);
+  const previous = {
+    schemaVersion: 1,
+    retentionRuns: 30,
+    generatedAt: '2026-09-01T00:00:00Z',
+    runs: [
+      {
+        id: '123.10',
+        runId: 123,
+        attempt: 10,
+        sha: 'a',
+        startedAt: '2026-09-01T00:00:00Z',
+        url: '',
+      },
+      {
+        id: '122.1',
+        runId: 122,
+        attempt: 1,
+        sha: 'b',
+        startedAt: '2026-09-01T00:00:00Z',
+        url: '',
+      },
+    ],
+    dimensions: [],
+    tests: [],
+    series: [],
+  };
+  const previousFile = path.join(dir, 'previous.json');
+  fs.writeFileSync(previousFile, JSON.stringify(previous));
+  const history = buildHistory({
+    ...options(dir, 123, previousFile),
+    attempt: '2',
+    startedAt: '2026-09-01T00:00:00Z',
+  });
+  assert.deepStrictEqual(
+    history.runs.map((run) => run.id),
+    ['122.1', '123.2', '123.10']
+  );
+});
+
+test('carries history forward, upserts reruns, and caps at 30 runs', () => {
+  let previous = null;
+  for (let runId = 1; runId <= 32; runId++) {
+    const dir = tempDir();
+    writeReport(
+      dir,
+      'e2e-vercel-prod-vite-node.json',
+      [['e2e recurring', 'passed']],
+      runId % 2 === 0 ? ['e2e recurring'] : []
+    );
+    const previousFile = previous ? path.join(dir, 'previous.json') : null;
+    if (previousFile) fs.writeFileSync(previousFile, JSON.stringify(previous));
+    previous = buildHistory(options(dir, runId, previousFile));
+  }
+
+  assert.strictEqual(previous.runs.length, 30);
+  assert.strictEqual(previous.runs[0].runId, 3);
+  assert.strictEqual(previous.runs.at(-1).runId, 32);
+  assert.deepStrictEqual(
+    observation(previous, 'e2e recurring').slice(2, 4),
+    [30, 15]
+  );
+
+  const dir = tempDir();
+  writeReport(
+    dir,
+    'e2e-vercel-prod-vite-node.json',
+    [['e2e recurring', 'passed']],
+    []
+  );
+  const previousFile = path.join(dir, 'previous.json');
+  fs.writeFileSync(previousFile, JSON.stringify(previous));
+  const rerun = buildHistory({
+    ...options(dir, 32, previousFile),
+    attempt: '1',
+  });
+  assert.strictEqual(rerun.runs.length, 30);
+  assert.deepStrictEqual(
+    observation(rerun, 'e2e recurring').slice(2, 4),
+    [30, 14]
+  );
+});

--- a/.github/workflows/e2e-community-world.yml
+++ b/.github/workflows/e2e-community-world.yml
@@ -242,7 +242,9 @@ jobs:
           name: e2e-results-community-${{ inputs.world-id }}
           path: |
             e2e-community-${{ inputs.world-id }}-dev.json
+            e2e-community-${{ inputs.world-id }}-dev.flaky.json
             e2e-community-${{ inputs.world-id }}.json
+            e2e-community-${{ inputs.world-id }}.flaky.json
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -558,9 +558,9 @@ jobs:
           name: e2e-results-vercel-prod-${{ matrix.app.name }}-${{ matrix.vm }}
           path: |
             e2e-vercel-prod-${{ matrix.app.name }}-${{ matrix.vm }}.json
+            e2e-vercel-prod-${{ matrix.app.name }}-${{ matrix.vm }}.flaky.json
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
-            e2e-flaky-${{ matrix.app.name }}-vercel.json
             e2e-infra-${{ matrix.app.name }}-vercel.json
             e2e-diagnostics-${{ matrix.app.name }}-vercel.json
             e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
@@ -668,9 +668,9 @@ jobs:
           name: e2e-results-vercel-multi-region-nextjs-turbopack
           path: |
             e2e-vercel-multi-region-nextjs-turbopack.json
+            e2e-vercel-multi-region-nextjs-turbopack.flaky.json
             e2e-metadata-nextjs-turbopack-vercel.json
             e2e-failures-nextjs-turbopack-vercel.json
-            e2e-flaky-nextjs-turbopack-vercel.json
             e2e-infra-nextjs-turbopack-vercel.json
             e2e-diagnostics-nextjs-turbopack-vercel.json
             e2e-runtime-logs-nextjs-turbopack-vercel.json
@@ -859,9 +859,9 @@ jobs:
           name: e2e-results-vercel-ws-transport-${{ matrix.app.name }}
           path: |
             e2e-vercel-ws-transport-${{ matrix.app.name }}.json
+            e2e-vercel-ws-transport-${{ matrix.app.name }}.flaky.json
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
-            e2e-flaky-${{ matrix.app.name }}-vercel.json
             e2e-infra-${{ matrix.app.name }}-vercel.json
             e2e-diagnostics-${{ matrix.app.name }}-vercel.json
             e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
@@ -1035,9 +1035,9 @@ jobs:
           name: e2e-results-vercel-http-transport-${{ matrix.app.name }}
           path: |
             e2e-vercel-http-transport-${{ matrix.app.name }}.json
+            e2e-vercel-http-transport-${{ matrix.app.name }}.flaky.json
             e2e-metadata-${{ matrix.app.name }}-vercel.json
             e2e-failures-${{ matrix.app.name }}-vercel.json
-            e2e-flaky-${{ matrix.app.name }}-vercel.json
             e2e-infra-${{ matrix.app.name }}-vercel.json
             e2e-diagnostics-${{ matrix.app.name }}-vercel.json
             e2e-runtime-logs-${{ matrix.app.name }}-vercel.json
@@ -1152,7 +1152,7 @@ jobs:
           name: e2e-results-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
           path: |
             e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
-            e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-local-dev-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.flaky.json
             e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
@@ -1251,7 +1251,7 @@ jobs:
           name: e2e-results-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
           path: |
             e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
-            e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-local-prod-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.flaky.json
             e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
@@ -1360,7 +1360,7 @@ jobs:
           name: e2e-results-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}
           path: |
             e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.json
-            e2e-flaky-${{ matrix.app.name }}-local.json
+            e2e-local-postgres-${{ matrix.app.name }}-${{ matrix.app.artifactSuffix }}.flaky.json
             e2e-infra-${{ matrix.app.name }}-local.json
           retention-days: 7
           if-no-files-found: ignore
@@ -1471,7 +1471,7 @@ jobs:
           name: e2e-results-conformance-python
           path: |
             e2e-conformance-python.json
-            e2e-flaky-python-local.json
+            e2e-conformance-python.flaky.json
             e2e-infra-python-local.json
             e2e-diagnostics-python-local.json
           retention-days: 7
@@ -1632,7 +1632,7 @@ jobs:
           name: e2e-results-windows-nextjs-turbopack-${{ matrix.vm }}
           path: |
             e2e-windows-nextjs-turbopack-${{ matrix.vm }}.json
-            e2e-flaky-nextjs-turbopack-local.json
+            e2e-windows-nextjs-turbopack-${{ matrix.vm }}.flaky.json
             e2e-infra-nextjs-turbopack-local.json
           retention-days: 7
           if-no-files-found: ignore
@@ -1697,7 +1697,7 @@ jobs:
   summary:
     name: E2E Summary
     runs-on: ubuntu-latest
-    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
+    needs: [ci-scope, e2e-vercel-prod, e2e-vercel-multi-region, e2e-vercel-ws-transport, e2e-vercel-http-transport, e2e-local-dev, e2e-local-prod, e2e-local-postgres, e2e-python, e2e-windows]
     if: always() && !cancelled() && needs.ci-scope.outputs.fast-path != 'true'
     timeout-minutes: 10
 
@@ -1808,12 +1808,13 @@ jobs:
   publish-results:
     name: Publish E2E Results
     runs-on: ubuntu-latest
-    needs: [summary]
+    needs: [summary, e2e-vercel-multi-region]
     # Use always() because summary uses always() - without it this job gets skipped when any E2E test fails
     if: always() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 5
 
     permissions:
+      actions: read
       contents: write
 
     steps:
@@ -1837,6 +1838,42 @@ jobs:
             --output docs-data/e2e-results.json \
             --commit "${{ github.sha }}" \
             --branch "${{ github.ref_name }}"
+
+      # Main Tests runs are serialized by the workflow concurrency group, so
+      # reading the previous file and publishing its successor cannot lose a
+      # concurrent main-branch update.
+      - name: Fetch previous E2E flake history
+        id: previous-flake-history
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api --header 'Accept: application/vnd.github.raw+json' \
+            "repos/${{ github.repository }}/contents/ci/e2e-flake-history.json?ref=gh-pages" \
+            > previous-e2e-flake-history.json 2>history-fetch-error.log; then
+            test -s previous-e2e-flake-history.json
+          elif grep -q 'HTTP 404' history-fetch-error.log; then
+            : > previous-e2e-flake-history.json
+          else
+            cat history-fetch-error.log >&2
+            exit 1
+          fi
+          RUN_STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .run_started_at)
+          echo "run-started-at=$RUN_STARTED_AT" >> "$GITHUB_OUTPUT"
+
+      - name: Generate E2E flake history
+        if: steps.previous-flake-history.outcome == 'success'
+        continue-on-error: true
+        run: |
+          node .github/scripts/generate-e2e-flake-history.js \
+            --results-dir e2e-results \
+            --previous previous-e2e-flake-history.json \
+            --output docs-data/e2e-flake-history.json \
+            --run-id "${{ github.run_id }}" \
+            --attempt "${{ github.run_attempt }}" \
+            --sha "${{ github.sha }}" \
+            --started-at "${{ steps.previous-flake-history.outputs.run-started-at }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Deploy to GitHub Pages
         uses: ./.github/actions/publish-to-gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ event-log-race-repro-server.log
 /e2e-diagnostics-*.json
 /e2e-failures-*.json
 /e2e-flaky-*.json
+/e2e-*.flaky.json
 /e2e-infra-*.json
 /e2e-metadata-*.json
 /e2e-runtime-logs-*.json

--- a/packages/core/e2e/github-reporter.ts
+++ b/packages/core/e2e/github-reporter.ts
@@ -62,9 +62,9 @@ export default class GithubAnnotationReporter implements Reporter {
       this.writeFailuresSidecar();
     }
 
-    if (this.flakyTests.length > 0) {
-      this.writeFlakySidecar();
-    }
+    // Always write the paired sidecar so history generation can distinguish a
+    // clean run from missing retry telemetry.
+    this.writeFlakySidecar();
 
     // Emit GitHub Actions annotations — this runs after vitest's own
     // output is done, so ::error commands won't be mangled by ANSI codes.
@@ -197,6 +197,22 @@ export default class GithubAnnotationReporter implements Reporter {
   }
 
   private writeFlakySidecar() {
+    // Pair retry telemetry with the exact Vitest JSON report so parallel lane,
+    // VM, and backend artifacts cannot overwrite one another when merged.
+    const outputArg = process.argv.find((arg) =>
+      arg.startsWith('--outputFile=')
+    );
+    const outputFile = outputArg?.slice('--outputFile='.length);
+    if (outputFile) {
+      const filePath = path.resolve(
+        process.cwd(),
+        outputFile.replace(/\.json$/, '.flaky.json')
+      );
+      fs.writeFileSync(filePath, JSON.stringify(this.flakyTests, null, 2));
+      return;
+    }
+
+    // Preserve the legacy name for manual invocations without a JSON output.
     const appName = process.env.APP_NAME || 'unknown';
     const isVercel = !!process.env.WORKFLOW_VERCEL_ENV;
     const backend = isVercel ? 'vercel' : 'local';
@@ -204,7 +220,6 @@ export default class GithubAnnotationReporter implements Reporter {
       process.cwd(),
       `e2e-flaky-${appName}-${backend}.json`
     );
-
     fs.writeFileSync(filePath, JSON.stringify(this.flakyTests, null, 2));
   }
 }


### PR DESCRIPTION
## Summary & Motivation

Job conclusions hide tests that pass on retry, and the evidence only lived in overwritten PR comments and 7-day artifacts, so recurring flakes couldn't be ranked against how often they ran.

- retry sidecars are now named after the Vitest report they came from, so lanes, VMs, and worlds no longer overwrite each other when artifacts merge — and the aggregate comment can attribute a flake to an exact lane
- `generate-e2e-flake-history.js` publishes a bounded 30-run history to gh-pages: one series per (lane, app, world, vm, platform) × test, carrying both an executed count and a passed-on-retry count so a rate has a denominator
- the reporter always writes the sidecar, which is what lets a clean run be distinguished from a lane that reported no retry telemetry at all

## Test Plan

Unit tests added for dimension parsing, denominators, schema validation, and the 30-run window; verified every current report filename maps to explicit dimensions, and a one-run history built from a full artifact set came out around 100 KiB.
