### PR TITLE
[world-postgres] Fix stream reader listener leaks and skipped-chunk offset cursor

### DIFF
--- a/.changeset/postgres-stream-reader-lifecycle.md
+++ b/.changeset/postgres-stream-reader-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Fix stream readers leaking EventEmitter listeners on EOF, initial query failure, and World close, and fail pending readers when the World is closed.

--- a/packages/world-postgres/src/streamer.test.ts
+++ b/packages/world-postgres/src/streamer.test.ts
@@ -1,0 +1,311 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Drizzle } from './drizzle/index.js';
+import { createStreamer } from './streamer.js';
+
+vi.mock('pg', () => ({
+  Client: vi.fn(function Client() {
+    return {
+      connect: vi.fn(async () => {}),
+      query: vi.fn(async () => {}),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      end: vi.fn(async () => {}),
+    };
+  }),
+  Pool: vi.fn(),
+}));
+
+const fakePool = {
+  options: {},
+  query: vi.fn(async () => ({ rows: [] })),
+} as any;
+
+/**
+ * Minimal fake for the drizzle query chain used by `streams.get()`:
+ * `drizzle.select(...).from(...).where(...).orderBy(...)`.
+ */
+function createFakeDrizzle(
+  rows: () => Promise<Array<{ id: string; eof: boolean; data: Buffer }>>
+): Drizzle {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => rows(),
+          limit: () => rows(),
+        }),
+      }),
+    }),
+  } as unknown as Drizzle;
+}
+
+describe('postgres streamer reader listener cleanup', () => {
+  // `createStreamer()` keeps its EventEmitter private, so capture any
+  // emitter that receives a `strm:*` listener via a prototype spy.
+  let streamEmitters: Set<EventEmitter>;
+
+  const listenerCount = (name: string) => {
+    let count = 0;
+    for (const emitter of streamEmitters) {
+      count += emitter.listenerCount(`strm:${name}`);
+    }
+    return count;
+  };
+
+  beforeEach(() => {
+    streamEmitters = new Set();
+    const originalOn = EventEmitter.prototype.on;
+    vi.spyOn(EventEmitter.prototype, 'on').mockImplementation(function (
+      this: EventEmitter,
+      eventName,
+      listener
+    ) {
+      if (typeof eventName === 'string' && eventName.startsWith('strm:')) {
+        streamEmitters.add(this);
+      }
+      return originalOn.call(this, eventName, listener);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes the listener when a persisted EOF closes the stream', async () => {
+    const drizzle = createFakeDrizzle(async () => [
+      {
+        id: 'chnk_00000000000000000000000001',
+        eof: false,
+        data: Buffer.from('hello'),
+      },
+      {
+        id: 'chnk_00000000000000000000000002',
+        eof: true,
+        data: Buffer.from([]),
+      },
+    ]);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    const warnings: Error[] = [];
+    const onWarning = (warning: Error) => warnings.push(warning);
+    process.on('warning', onWarning);
+
+    try {
+      // Repeated reads of the same completed stream must not accumulate
+      // listeners (issue reproduction uses 12 readers to trip the default
+      // max-listeners threshold of 10).
+      for (let i = 0; i < 12; i++) {
+        const stream = await streamer.streams.get('run_1', 'stream-eof');
+        const reader = stream.getReader();
+        let done = false;
+        while (!done) {
+          ({ done } = await reader.read());
+        }
+        expect(listenerCount('stream-eof')).toBe(0);
+      }
+
+      // Warnings are emitted via process.nextTick; flush before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(
+        warnings.filter((w) => w.name === 'MaxListenersExceededWarning')
+      ).toEqual([]);
+    } finally {
+      process.removeListener('warning', onWarning);
+      await streamer.close();
+    }
+  });
+
+  it('removes the listener when the initial chunk query rejects', async () => {
+    const drizzle = createFakeDrizzle(async () => {
+      throw new Error('initial query failed');
+    });
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      for (let i = 0; i < 12; i++) {
+        const stream = await streamer.streams.get('run_1', 'stream-err');
+        const reader = stream.getReader();
+        await expect(reader.read()).rejects.toThrow('initial query failed');
+      }
+      expect(listenerCount('stream-err')).toBe(0);
+    } finally {
+      await streamer.close();
+    }
+  });
+
+  it('removes the listener when a live EOF arrives via notification', async () => {
+    // No persisted EOF: the reader tails live events and is closed by an
+    // EOF chunk delivered through the LISTEN emitter.
+    const drizzle = createFakeDrizzle(async () => [
+      {
+        id: 'chnk_00000000000000000000000001',
+        eof: false,
+        data: Buffer.from('hello'),
+      },
+    ]);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      for (let i = 0; i < 12; i++) {
+        const stream = await streamer.streams.get('run_1', 'stream-live-eof');
+        const reader = stream.getReader();
+        await reader.read();
+        expect(listenerCount('stream-live-eof')).toBe(1);
+
+        for (const emitter of streamEmitters) {
+          emitter.emit('strm:stream-live-eof', {
+            id: 'chnk_00000000000000000000000002',
+            eof: true,
+            data: Buffer.from([]),
+          });
+        }
+        expect(await reader.read()).toEqual({ done: true, value: undefined });
+        expect(listenerCount('stream-live-eof')).toBe(0);
+      }
+    } finally {
+      await streamer.close();
+    }
+  });
+
+  it('detaches and fails pending readers when the streamer is closed', async () => {
+    // No EOF chunk: readers stay open, tailing live events.
+    const drizzle = createFakeDrizzle(async () => [
+      {
+        id: 'chnk_00000000000000000000000001',
+        eof: false,
+        data: Buffer.from('hello'),
+      },
+    ]);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+    for (let i = 0; i < 10; i++) {
+      const stream = await streamer.streams.get('run_1', 'stream-open');
+      readers.push(stream.getReader());
+      // Consume the persisted chunk; the reader keeps waiting for more.
+      await readers[i].read();
+    }
+    expect(listenerCount('stream-open')).toBe(10);
+
+    // An outstanding read() must settle once the streamer shuts down: the
+    // LISTEN client is gone, so nothing could ever wake it otherwise.
+    const pending = readers[0].read();
+
+    await streamer.close();
+    expect(listenerCount('stream-open')).toBe(0);
+    await expect(pending).rejects.toThrow('streamer has been closed');
+    for (const reader of readers) {
+      await expect(reader.read()).rejects.toThrow('streamer has been closed');
+    }
+  });
+
+  it('rejects streams.get() after the streamer is closed', async () => {
+    const drizzle = createFakeDrizzle(async () => []);
+    const streamer = createStreamer(fakePool, drizzle);
+    await streamer.close();
+
+    await expect(
+      streamer.streams.get('run_1', 'stream-after-close')
+    ).rejects.toThrow('streamer has been closed');
+    // A rejected get() must not leave a listener behind on the dead emitter.
+    expect(listenerCount('stream-after-close')).toBe(0);
+  });
+
+  it('cleans up when cancelled while the initial query is in flight', async () => {
+    let resolveQuery!: (
+      rows: Array<{ id: string; eof: boolean; data: Buffer }>
+    ) => void;
+    const drizzle = createFakeDrizzle(
+      () => new Promise((resolve) => (resolveQuery = resolve))
+    );
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      const stream = await streamer.streams.get('run_1', 'stream-cancel-early');
+      const reader = stream.getReader();
+      expect(listenerCount('stream-cancel-early')).toBe(1);
+      await reader.cancel();
+      expect(listenerCount('stream-cancel-early')).toBe(0);
+
+      // The query resolving into a cancelled stream is dropped; the listener
+      // count must not bounce back.
+      resolveQuery([
+        {
+          id: 'chnk_00000000000000000000000001',
+          eof: false,
+          data: Buffer.from('hello'),
+        },
+        {
+          id: 'chnk_00000000000000000000000002',
+          eof: true,
+          data: Buffer.from([]),
+        },
+      ]);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(listenerCount('stream-cancel-early')).toBe(0);
+    } finally {
+      await streamer.close();
+    }
+  });
+
+  it('does not count a redelivered skipped chunk against the start offset', async () => {
+    const drizzle = createFakeDrizzle(async () => []);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      // startIndex 2: skip 'first' and 'second', deliver from 'third'.
+      const stream = await streamer.streams.get('run_1', 'stream-offset', 2);
+      const reader = stream.getReader();
+      const first = {
+        id: 'chnk_00000000000000000000000001',
+        eof: false,
+        data: Buffer.from('first'),
+      };
+      const emit = (chunk: typeof first) => {
+        for (const emitter of streamEmitters) {
+          emitter.emit('strm:stream-offset', chunk);
+        }
+      };
+      // Let start() finish its (empty) initial query so notifications are
+      // enqueued directly rather than buffered.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      emit(first);
+      // A redelivered NOTIFY for the chunk that was just skipped must not
+      // decrement the remaining offset a second time.
+      emit(first);
+      emit({
+        id: 'chnk_00000000000000000000000002',
+        eof: false,
+        data: Buffer.from('second'),
+      });
+      emit({
+        id: 'chnk_00000000000000000000000003',
+        eof: false,
+        data: Buffer.from('third'),
+      });
+
+      const result = await reader.read();
+      expect(result.done).toBe(false);
+      expect(Buffer.from(result.value as Uint8Array).toString()).toBe('third');
+    } finally {
+      await streamer.close();
+    }
+  });
+
+  it('still cleans up on explicit consumer cancellation', async () => {
+    const drizzle = createFakeDrizzle(async () => []);
+    const streamer = createStreamer(fakePool, drizzle);
+
+    try {
+      const stream = await streamer.streams.get('run_1', 'stream-cancel');
+      const reader = stream.getReader();
+      expect(listenerCount('stream-cancel')).toBe(1);
+      await reader.cancel();
+      expect(listenerCount('stream-cancel')).toBe(0);
+    } finally {
+      await streamer.close();
+    }
+  });
+});

--- a/packages/world-postgres/src/streamer.ts
+++ b/packages/world-postgres/src/streamer.ts
@@ -95,6 +95,15 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
   const { streams } = Schema;
   const genChunkId = () => `chnk_${ulid()}` as const;
   const mutexes = new Map<string, Rc<{ drop(): void; mutex: Mutex }>>();
+  // One abort function per reader that has not yet reached a terminal state
+  // (EOF, cancel, or initial-query failure). `close()` drains this set so a
+  // streamer shutdown detaches every listener still registered on `events`
+  // and settles readers that would otherwise wait forever: the LISTEN client
+  // is gone, so no notification can ever wake them.
+  const activeReaders = new Set<() => void>();
+  let closed = false;
+  const streamerClosedError = () =>
+    new Error('Cannot read stream: the Postgres streamer has been closed');
   const getMutex = (key: string) => {
     let mutex = mutexes.get(key);
     if (!mutex) {
@@ -138,6 +147,17 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
   const notifyStream = async (payload: string) => {
     await pool.query('SELECT pg_notify($1, $2)', [STREAM_TOPIC, payload]);
   };
+
+  const loadPersistedChunks = (name: string): Promise<StreamChunkEvent[]> =>
+    drizzle
+      .select({
+        id: streams.chunkId,
+        eof: streams.eof,
+        data: streams.chunkData,
+      })
+      .from(streams)
+      .where(and(eq(streams.streamId, name)))
+      .orderBy(streams.chunkId);
 
   // Helper to convert chunk to Buffer
   const toBuffer = (chunk: string | Uint8Array): Buffer =>
@@ -354,10 +374,34 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
         name: string,
         startIndex?: number
       ): Promise<ReadableStream<Uint8Array>> {
+        if (closed) {
+          throw streamerClosedError();
+        }
+
         const cleanups: (() => void)[] = [];
+        let cleanedUp = false;
+        // Idempotent: reachable from EOF, cancel(), initial-query failure,
+        // and streamer close(), and more than one of those can fire for the
+        // same reader (e.g. cancel() while the initial query is in flight).
+        const cleanup = () => {
+          if (cleanedUp) return;
+          cleanedUp = true;
+          activeReaders.delete(abort);
+          cleanups.forEach((fn) => void fn());
+        };
+        // `start()` runs synchronously inside the ReadableStream constructor
+        // up to its first `await`, so `controller` is assigned before `get()`
+        // returns and before `abort` can be invoked from `close()`.
+        let controller!: ReadableStreamDefaultController<Uint8Array>;
+        const abort = () => {
+          cleanup();
+          controller.error(streamerClosedError());
+        };
+        activeReaders.add(abort);
 
         return new ReadableStream<Uint8Array>({
-          async start(controller) {
+          async start(ctrl) {
+            controller = ctrl;
             // an empty string is always < than any string,
             // so `'' < ulid()` and `ulid() < ulid()` (maintaining order)
             let lastChunkId = '';
@@ -369,11 +413,17 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
               data: Uint8Array;
               eof: boolean;
             }) {
+              if (cleanedUp) {
+                // The reader was cancelled or the streamer closed while the
+                // initial query was in flight; the controller is no longer
+                // writable.
+                return;
+              }
+
               if (lastChunkId >= msg.id) {
                 // already sent or out of order
                 return;
               }
-
               lastChunkId = msg.id;
               if (offset > 0) {
                 offset--;
@@ -384,6 +434,7 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
                 controller.enqueue(new Uint8Array(msg.data));
               }
               if (msg.eof) {
+                cleanup();
                 controller.close();
               }
             }
@@ -400,15 +451,12 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
               events.off(`strm:${name}`, onData);
             });
 
-            const chunks = await drizzle
-              .select({
-                id: streams.chunkId,
-                eof: streams.eof,
-                data: streams.chunkData,
-              })
-              .from(streams)
-              .where(and(eq(streams.streamId, name)))
-              .orderBy(streams.chunkId);
+            // A rejection here fails the stream; detach the listener that was
+            // registered above so a failing stream does not leak on each read.
+            const chunks = await loadPersistedChunks(name).catch((err) => {
+              cleanup();
+              throw err;
+            });
 
             // Resolve negative offset relative to the data chunk count
             // (excluding the trailing EOF marker, if present)
@@ -426,7 +474,7 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
             buffer = null;
           },
           cancel() {
-            cleanups.forEach((fn) => void fn());
+            cleanup();
           },
         });
       },
@@ -443,6 +491,10 @@ export function createStreamer(pool: Pool, drizzle: Drizzle): PostgresStreamer {
     },
 
     async close() {
+      closed = true;
+      for (const abort of [...activeReaders]) {
+        abort();
+      }
       const sub = await listenSubscription.catch(() => undefined);
       if (sub) await sub.close();
     },


### PR DESCRIPTION
Fixes #3120, closes #3158.

Carries #3158 (@Mohith26) into a signed PR and addresses the review feedback on it. The original author is credited via `Co-authored-by` on the commit. #4113 (@komly, the start-offset cursor fix) was folded in originally and has since merged to `main` on its own; this PR is rebased on top of it and only keeps an extra mock-based test for that path.

## What

`world-postgres` stream readers registered an `events.on('strm:<name>', onData)` listener whose removal only ran on explicit `ReadableStream.cancel()`. EOF, initial-query rejection, and `createStreamer().close()` left it attached, so repeated reads of a completed or failing stream accumulated listeners until `MaxListenersExceededWarning`. Each reader now owns one idempotent `cleanup()` invoked from every terminal path.

**Review feedback on #3158, addressed here:**
- `close()` now also settles outstanding readers by erroring their controllers. Previously it detached the listener but left a pending `read()` hanging forever (the LISTEN client is gone, so nothing could wake it). Erroring rather than closing is deliberate: a clean close would tell an HTTP consumer tailing the stream that it completed when it did not.
- `streams.get()` after `close()` rejects instead of registering a listener on the dead emitter that nothing would ever remove.
- Live-EOF (EOF arriving via notification rather than from the initial query) is now covered.
- Changeset added.

Also: `enqueue` ignores chunks arriving for a reader that was cancelled or aborted while the initial query was in flight, and the initial query moved into a helper so the new try/catch does not push `start()` over Biome's complexity threshold (same two pre-existing warnings as `main`, none new).

## Tests

`src/streamer.test.ts` (mock pg client, no live Postgres): listener count returns to zero on persisted EOF, live EOF, initial-query rejection, `close()`, cancel, and cancel-during-query; `close()` rejects pending and subsequent reads; `get()` after `close()` rejects; a redelivered skipped chunk does not consume the offset twice. Against `main`'s `streamer.ts` before #4113, 6 of 8 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
