### PR TITLE
perf(core): seed the published-step set as soon as handleSuspension returns

### DIFF
--- a/.changeset/dispatch-skip-republished-seed.md
+++ b/.changeset/dispatch-skip-republished-seed.md
@@ -1,0 +1,5 @@
+---
+"@workflow/core": patch
+---
+
+Record the suspension handler's step-message publishes in the invocation's published set as soon as the handler returns, so a pass that exits early on a hook conflict, attribute event, or serialization failure no longer re-publishes those steps on the next pass.

--- a/.changeset/dispatch-skip-republished-seed.md
+++ b/.changeset/dispatch-skip-republished-seed.md
@@ -2,4 +2,4 @@
 "@workflow/core": patch
 ---
 
-Record the suspension handler's step-message publishes in the invocation's published set as soon as the handler returns, so a pass that exits early on a hook conflict, attribute event, or serialization failure no longer re-publishes those steps on the next pass.
+Record the suspension handler's step-message publishes in the invocation's published set as soon as the handler returns, so a pass that exits early on a hook conflict, attribute event, or serialization failure no longer re-publishes those steps on the next pass. The set is keyed by step identity (correlation id plus step name, the dispatch idempotency key), so a step a later pass binds to a correlation id published under a different name is still dispatched.

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1471,6 +1471,23 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       return a;
     }${getWorkflowTransformCode('workflow')}`;
 
+  // Same fan-out, preceded by a fire-and-forget hook. When the World answers
+  // the hook_created write with a `hook_conflict`, the runtime's
+  // hook-conflict branch replays in-process BEFORE reaching the dispatch pass
+  // (see continueOverHookWrite), so this is the shape that exits a pass early
+  // after the suspension handler has already published step messages. The
+  // hook is never awaited, so the conflict settles nothing and the steps
+  // proceed as in stepWithSleepWorkflow.
+  const hookConflictStepWithSleepWorkflow = `const createHook = globalThis[Symbol.for("WORKFLOW_CREATE_HOOK")];
+    const add = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("add");
+    const addB = globalThis[Symbol.for("WORKFLOW_USE_STEP")]("addB");
+    const sleep = globalThis[Symbol.for("WORKFLOW_SLEEP")];
+    async function workflow() {
+      createHook({ token: 'ack-ordering-conflict-token' });
+      const [a] = await Promise.all([add(1, 2), addB(3, 4), sleep('1h')]);
+      return a;
+    }${getWorkflowTransformCode('workflow')}`;
+
   // Register the two steps so the one chosen for inline execution actually
   // runs (and completes) instead of failing as unregistered; the other is
   // queued. Both are no-ops — these tests only assert dispatch/ack ordering.
@@ -1515,6 +1532,13 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
     retryingQueuedStep?: boolean;
     /** `specVersion` to stamp on the run (gates resilient step dispatch). */
     runSpecVersion?: number;
+    /** Workflow source to drive (defaults to stepWithSleepWorkflow). */
+    workflowSource?: string;
+    /**
+     * Answer every `hook_created` write with a `hook_conflict` event (the
+     * token is held by another run), recorded in the log like a World would.
+     */
+    conflictHookCreate?: boolean;
   }) {
     const workflowRun = await makeRunningRun(opts.runId);
     if (opts.runSpecVersion !== undefined) {
@@ -1556,6 +1580,22 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
         }
         if (data.eventType === 'run_started') {
           return { run: workflowRun, events: [] as Event[] };
+        }
+        if (data.eventType === 'hook_created' && opts.conflictHookCreate) {
+          // The World found the token claimed by another run: it records a
+          // hook_conflict in this run's log in place of the hook_created and
+          // returns it, which the suspension handler reports as a conflict.
+          order.push('hook_conflict');
+          const conflict = recordEvent({
+            eventType: 'hook_conflict',
+            specVersion: SPEC_VERSION_CURRENT,
+            correlationId: data.correlationId,
+            eventData: {
+              token: data.eventData?.token,
+              conflictingRunId: 'wrun_holds_the_token',
+            },
+          });
+          return { event: conflict };
         }
         if (data.eventType === 'step_created') {
           // Eager step_created for the QUEUED step (the one not run inline).
@@ -1668,7 +1708,9 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       getEncryptionKeyForRun: vi.fn(async () => undefined),
     } as any);
 
-    const handler = workflowEntrypoint(stepWithSleepWorkflow);
+    const handler = workflowEntrypoint(
+      opts.workflowSource ?? stepWithSleepWorkflow
+    );
     // Push the ack sentinel the moment the handler resolves — i.e. right
     // before @vercel/queue would delete (ack) the orchestrator message.
     const handlerPromise = handler(new Request('https://example.test')).then(
@@ -1846,6 +1888,53 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       expect(eventsList.mock.calls.length).toBeGreaterThanOrEqual(2);
       // The one send came from the suspension handler (it carries the
       // resilient stepInput), and nothing re-published it afterwards.
+      const stepSends = queue.mock.calls.filter(
+        ([, message]: any[]) =>
+          message && typeof message === 'object' && 'stepId' in message
+      );
+      expect(stepSends).toHaveLength(1);
+      expect(stepSends[0][1]).toHaveProperty('stepInput');
+      expect(stepIdSends).toHaveLength(1);
+    } finally {
+      delete process.env.WORKFLOW_RESILIENT_STEP_DISPATCH;
+    }
+  });
+
+  it('remembers handler publishes from a pass that exited early on a hook conflict', async () => {
+    // Regression test for the seeding point of the invocation's published
+    // set. The suspension handler publishes the queued step (resilient
+    // dispatch, create + queue in parallel) and reports it in
+    // queuedStepCorrelationIds, but the same suspension's hook_created came
+    // back as a hook_conflict, so the runtime replays in-process without
+    // reaching the dispatch pass. On the next pass the step already exists
+    // and the handler no longer reports it; if the set was only seeded at the
+    // dispatch pass, that pass would publish the step a second time. The
+    // seeding must therefore happen as soon as handleSuspension returns.
+    process.env.WORKFLOW_RESILIENT_STEP_DISPATCH = '1';
+    try {
+      const { handlerPromise, order, eventsList, stepIdSends, queue } =
+        await driveHandler({
+          runId: 'wrun_no_republish_after_hook_conflict',
+          queueImpl: async () => ({ messageId: null }),
+          runSpecVersion: SPEC_VERSION_CURRENT,
+          workflowSource: hookConflictStepWithSleepWorkflow,
+          conflictHookCreate: true,
+        });
+
+      const res = (await handlerPromise) as Response;
+      expect(res.status).toBe(204);
+
+      // The first pass did hit the conflict, and its handler publish (the
+      // send carrying stepInput) happened before the conflict branch could
+      // continue the loop.
+      expect(order).toContain('hook_conflict');
+      expect(order.indexOf('queue_dispatch_start')).toBeLessThan(
+        order.indexOf('ack')
+      );
+      // The run went through more than one pass (the conflict continuation
+      // and the post-inline replay each reload the log)...
+      expect(eventsList.mock.calls.length).toBeGreaterThanOrEqual(2);
+      // ...yet the queued step's message went out exactly once.
       const stepSends = queue.mock.calls.filter(
         ([, message]: any[]) =>
           message && typeof message === 'object' && 'stepId' in message

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -20,6 +20,7 @@ import {
   DEPLOYMENT_MISMATCH_MAX_RETRIES,
   REPLAY_DIVERGENCE_MAX_RETRIES,
 } from './runtime/constants.js';
+import { stepDispatchIdempotencyKey } from './runtime/helpers.js';
 import { setWorld } from './runtime/world.js';
 import { workflowEntrypoint } from './runtime.js';
 import {
@@ -44,6 +45,31 @@ vi.mock('@vercel/functions', () => ({
     waitUntilPromises.push(p);
   }),
 }));
+
+// Pass-through wrap of the suspension handler that lets a test observe (and,
+// for the rebinding test, adjust) what the engine hands the runtime after each
+// suspension. Inert unless a test installs `onResult`.
+const suspensionResultTap = vi.hoisted(() => ({
+  onResult: undefined as
+    | ((
+        result: import('./runtime/suspension-handler.js').SuspensionHandlerResult
+      ) => void)
+    | undefined,
+}));
+vi.mock('./runtime/suspension-handler.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./runtime/suspension-handler.js')>();
+  return {
+    ...actual,
+    handleSuspension: async (
+      ...args: Parameters<typeof actual.handleSuspension>
+    ) => {
+      const result = await actual.handleSuspension(...args);
+      suspensionResultTap.onResult?.(result);
+      return result;
+    },
+  };
+});
 
 /**
  * Resolves true if any promise handed to `waitUntil` rejects. Reports whether
@@ -1870,7 +1896,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
   it("counts the suspension handler's resilient publishes as already published", async () => {
     // With resilient step dispatch the suspension handler publishes the
     // queued step itself (create + queue in parallel, message carrying
-    // stepInput) and reports it in queuedStepCorrelationIds. That publish
+    // stepInput) and reports it in queuedStepDispatchKeys. That publish
     // must seed the invocation's published set too, so the post-inline
     // replay pass does not send it again.
     process.env.WORKFLOW_RESILIENT_STEP_DISPATCH = '1';
@@ -1904,7 +1930,7 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
     // Regression test for the seeding point of the invocation's published
     // set. The suspension handler publishes the queued step (resilient
     // dispatch, create + queue in parallel) and reports it in
-    // queuedStepCorrelationIds, but the same suspension's hook_created came
+    // queuedStepDispatchKeys, but the same suspension's hook_created came
     // back as a hook_conflict, so the runtime replays in-process without
     // reaching the dispatch pass. On the next pass the step already exists
     // and the handler no longer reports it; if the set was only seeded at the
@@ -1943,6 +1969,72 @@ describe('workflowEntrypoint step-dispatch ack ordering', () => {
       expect(stepSends[0][1]).toHaveProperty('stepInput');
       expect(stepIdSends).toHaveLength(1);
     } finally {
+      delete process.env.WORKFLOW_RESILIENT_STEP_DISPATCH;
+    }
+  });
+
+  it('still dispatches a step a later pass bound to a correlation id published under another name', async () => {
+    // The invocation's published set is keyed by step identity
+    // (correlationId + stepName, the dispatch idempotency key), not by
+    // correlation id alone. Pass 1's suspension handler publishes the queued
+    // step as (id, addB); if the post-inline replay bound that id to a
+    // DIFFERENT step, a set keyed by id alone would read "already published"
+    // and skip the only dispatch that step ever gets.
+    //
+    // A workflow cannot stage the rebinding by itself within one delivery:
+    // events reach the VM one macrotask at a time, so a pass that published
+    // ordinal n never observed any state a later pass could branch on before
+    // n. The engine's output is therefore tapped: the second pass's pending
+    // item for the queued step is renamed, which is exactly what a corrected
+    // replay that derived the id for another step would hand the runtime.
+    process.env.WORKFLOW_RESILIENT_STEP_DISPATCH = '1';
+    let suspensions = 0;
+    suspensionResultTap.onResult = (result) => {
+      suspensions++;
+      if (suspensions === 1) return;
+      for (const step of result.pendingSteps) {
+        if (step.stepName === 'addB') step.stepName = 'addB_rebound';
+      }
+    };
+    try {
+      const { handlerPromise, eventsList, stepIdSends, queue } =
+        await driveHandler({
+          runId: 'wrun_rebound_correlation_id_dispatched',
+          queueImpl: async () => ({ messageId: null }),
+          runSpecVersion: SPEC_VERSION_CURRENT,
+        });
+
+      const res = (await handlerPromise) as Response;
+      expect(res.status).toBe(204);
+      expect(suspensions).toBeGreaterThanOrEqual(2);
+      expect(eventsList.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      const stepSends = queue.mock.calls.filter(
+        ([, message]: any[]) =>
+          message && typeof message === 'object' && 'stepId' in message
+      );
+      // One correlation id, two step identities, two sends: the handler's
+      // resilient publish of (id, addB) on pass 1 and the dispatch pass's
+      // (id, addB_rebound) on pass 2.
+      expect(stepIdSends).toHaveLength(2);
+      expect(new Set(stepIdSends).size).toBe(1);
+      const [id] = stepIdSends;
+      expect(stepSends.map(([, message]: any[]) => message.stepName)).toEqual([
+        'addB',
+        'addB_rebound',
+      ]);
+      expect(
+        stepSends.map(([, , opts]: any[]) => opts?.idempotencyKey)
+      ).toEqual([
+        stepDispatchIdempotencyKey(id, 'addB'),
+        stepDispatchIdempotencyKey(id, 'addB_rebound'),
+      ]);
+      // Pass 1's send came from the handler (it carries stepInput); pass 2's
+      // is the dispatch pass's bare message.
+      expect(stepSends[0][1]).toHaveProperty('stepInput');
+      expect(stepSends[1][1]).not.toHaveProperty('stepInput');
+    } finally {
+      suspensionResultTap.onResult = undefined;
       delete process.env.WORKFLOW_RESILIENT_STEP_DISPATCH;
     }
   });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3621,6 +3621,22 @@ export function workflowEntrypoint(
                           });
                           return;
                         }
+                        // Record the step messages the suspension handler
+                        // itself published this pass (resilient dispatch
+                        // publishes alongside the step_created write, the
+                        // batched fold publishes its eager creates) BEFORE any
+                        // of the early exits below can `continue` the loop.
+                        // The hook-conflict, attribute-event and
+                        // serialization-failure paths all replay in-process
+                        // without reaching the dispatch pass; on that next
+                        // pass the step already exists, so the handler no
+                        // longer reports it and only this set remembers the
+                        // send. Seeding at the dispatch pass alone let each of
+                        // those paths publish every such step twice.
+                        for (const correlationId of suspensionResult.queuedStepCorrelationIds) {
+                          publishedStepCorrelationIds.add(correlationId);
+                        }
+
                         // Open hooks/waits in the log this replay ran over,
                         // plus whatever the suspension's own writes folded back
                         // into it — so a `hook_created` this suspension
@@ -3974,11 +3990,10 @@ export function workflowEntrypoint(
                         let backstopWakesArmed = 0;
                         // Immediate re-enqueues suppressed because this
                         // invocation already published the step's message
-                        // on an earlier pass. See publishedStepCorrelationIds.
+                        // on an earlier pass. See publishedStepCorrelationIds
+                        // (seeded with this pass's handler publishes right
+                        // after handleSuspension returned, above).
                         let republishesSkipped = 0;
-                        for (const correlationId of suspensionResult.queuedStepCorrelationIds) {
-                          publishedStepCorrelationIds.add(correlationId);
-                        }
                         // TTR hand-off. The measurement may only go to an
                         // execution that will actually ATTEMPT the next
                         // durable step, and the loop below is what decides

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2868,7 +2868,7 @@ export function workflowEntrypoint(
                   // Steps THIS delivery has already published a
                   // step-execution message for, across its replay passes:
                   // the suspension handler's resilient publishes
-                  // (`queuedStepCorrelationIds`) plus the dispatch pass's
+                  // (`queuedStepDispatchKeys`) plus the dispatch pass's
                   // own immediate enqueues. A fan-out that runs some steps
                   // inline falls back into this loop once they finish,
                   // reloads the log, and finds the queued siblings still
@@ -2888,7 +2888,14 @@ export function workflowEntrypoint(
                   // concurrent wake) re-enqueues unconditionally, exactly
                   // as before, and only knowledge of this process's own
                   // sends is used to skip. Dies with this delivery.
-                  const publishedStepCorrelationIds = new Set<string>();
+                  //
+                  // Keyed by step identity (`stepDispatchIdempotencyKey`:
+                  // correlationId + stepName), the same identity the
+                  // dispatch's idempotency key uses, and for the same
+                  // reason: a corrected replay can re-derive a correlation
+                  // id for a DIFFERENT step, and the record of this step's
+                  // send must not absorb that step's dispatch.
+                  const publishedStepDispatchKeys = new Set<string>();
 
                   // Main replay loop
                   while (true) {
@@ -3495,7 +3502,7 @@ export function workflowEntrypoint(
                             // created steps publish their step-execution
                             // message (carrying `stepInput`) in parallel with
                             // the step_created write. Steps queued there are
-                            // reported back in `queuedStepCorrelationIds` and
+                            // reported back in `queuedStepDispatchKeys` and
                             // skipped by the dispatch pass below.
                             stepDispatch: {
                               queueName: getWorkflowQueueName(
@@ -3633,8 +3640,8 @@ export function workflowEntrypoint(
                         // longer reports it and only this set remembers the
                         // send. Seeding at the dispatch pass alone let each of
                         // those paths publish every such step twice.
-                        for (const correlationId of suspensionResult.queuedStepCorrelationIds) {
-                          publishedStepCorrelationIds.add(correlationId);
+                        for (const key of suspensionResult.queuedStepDispatchKeys) {
+                          publishedStepDispatchKeys.add(key);
                         }
 
                         // Open hooks/waits in the log this replay ran over,
@@ -3990,7 +3997,7 @@ export function workflowEntrypoint(
                         let backstopWakesArmed = 0;
                         // Immediate re-enqueues suppressed because this
                         // invocation already published the step's message
-                        // on an earlier pass. See publishedStepCorrelationIds
+                        // on an earlier pass. See publishedStepDispatchKeys
                         // (seeded with this pass's handler publishes right
                         // after handleSuspension returned, above).
                         let republishesSkipped = 0;
@@ -4047,10 +4054,14 @@ export function workflowEntrypoint(
                           // Ownership never applies to these: they were
                           // created this pass, so no step_started stamp can
                           // exist yet. (Earlier passes' publishes are
-                          // covered by publishedStepCorrelationIds below.)
+                          // covered by publishedStepDispatchKeys below.)
+                          const stepDispatchKey = stepDispatchIdempotencyKey(
+                            step.correlationId,
+                            step.stepName
+                          );
                           if (
-                            suspensionResult.queuedStepCorrelationIds.has(
-                              step.correlationId
+                            suspensionResult.queuedStepDispatchKeys.has(
+                              stepDispatchKey
                             )
                           ) {
                             continue;
@@ -4105,24 +4116,26 @@ export function workflowEntrypoint(
                             continue;
                           }
                           // Already published by THIS invocation on an
-                          // earlier pass (see publishedStepCorrelationIds):
+                          // earlier pass (see publishedStepDispatchKeys):
                           // the message is in the queue and the send is
                           // joined below, so a repeat buys nothing. A
                           // `step_retrying` observed since is a new
                           // schedule (the retry handoff), so it is not
                           // covered by the earlier publish and re-enqueues
-                          // as before. Checked before the TTR hand-off so a
-                          // skipped step never consumes the measurement.
+                          // as before. Keyed by step identity, so a step
+                          // that a corrected replay bound to a correlation
+                          // id an earlier pass published under a different
+                          // name is dispatched, not skipped. Checked before
+                          // the TTR hand-off so a skipped step never
+                          // consumes the measurement.
                           if (
-                            publishedStepCorrelationIds.has(
-                              step.correlationId
-                            ) &&
+                            publishedStepDispatchKeys.has(stepDispatchKey) &&
                             step.sawRetrying !== true
                           ) {
                             republishesSkipped++;
                             continue;
                           }
-                          publishedStepCorrelationIds.add(step.correlationId);
+                          publishedStepDispatchKeys.add(stepDispatchKey);
                           // This step IS being attempted, by the invocation
                           // that picks the message up. Consume the tracking
                           // here, for the first such step and no other.
@@ -4159,10 +4172,7 @@ export function workflowEntrypoint(
                                 // without absorbing a dispatch of a different
                                 // step under a reassigned correlation id.
                                 // See stepDispatchIdempotencyKey.
-                                idempotencyKey: stepDispatchIdempotencyKey(
-                                  step.correlationId,
-                                  step.stepName
-                                ),
+                                idempotencyKey: stepDispatchKey,
                               }
                             )
                           );

--- a/packages/core/src/runtime/suspension-handler.test.ts
+++ b/packages/core/src/runtime/suspension-handler.test.ts
@@ -1141,7 +1141,9 @@ describe('resilient step dispatch', () => {
       idempotencyKey: stepDispatchIdempotencyKey('s4', 's4'),
     });
     // Reported so the caller skips its own dispatch for this step.
-    expect([...result.queuedStepCorrelationIds]).toEqual(['s4']);
+    expect([...result.queuedStepDispatchKeys]).toEqual([
+      stepDispatchIdempotencyKey('s4', 's4'),
+    ]);
     expect(result.createdStepCorrelationIds).toContain('s4');
   });
 
@@ -1163,7 +1165,9 @@ describe('resilient step dispatch', () => {
 
     // The publish carried the payload, so the consumer re-ensures the event.
     expect(queue).toHaveBeenCalledTimes(1);
-    expect([...result.queuedStepCorrelationIds]).toEqual(['s4']);
+    expect([...result.queuedStepDispatchKeys]).toEqual([
+      stepDispatchIdempotencyKey('s4', 's4'),
+    ]);
     // The write did NOT land, so this handler does not claim creation.
     expect(result.createdStepCorrelationIds.has('s4')).toBe(false);
   });
@@ -1212,7 +1216,7 @@ describe('resilient step dispatch', () => {
     });
 
     expect(queue).not.toHaveBeenCalled();
-    expect(result.queuedStepCorrelationIds.size).toBe(0);
+    expect(result.queuedStepDispatchKeys.size).toBe(0);
   });
 
   it('falls back to create-only when WORKFLOW_RESILIENT_STEP_DISPATCH is unset', async () => {
@@ -1227,7 +1231,7 @@ describe('resilient step dispatch', () => {
     });
 
     expect(queue).not.toHaveBeenCalled();
-    expect(result.queuedStepCorrelationIds.size).toBe(0);
+    expect(result.queuedStepDispatchKeys.size).toBe(0);
   });
 
   it('never queues from here when no stepDispatch is provided (terminal drain)', async () => {
@@ -1240,7 +1244,7 @@ describe('resilient step dispatch', () => {
     });
 
     expect(queue).not.toHaveBeenCalled();
-    expect(result.queuedStepCorrelationIds.size).toBe(0);
+    expect(result.queuedStepDispatchKeys.size).toBe(0);
   });
 });
 
@@ -2274,7 +2278,7 @@ describe('handleSuspension batched fan-out', () => {
       expect(await probe(result.deferredBatchWork)).toBe('pending');
       // Every eager step is claimed for in-flush publishing up front, so
       // the caller's dispatch pass skips them all.
-      expect(result.queuedStepCorrelationIds.size).toBe(33);
+      expect(result.queuedStepDispatchKeys.size).toBe(33);
       // The pair chunk carries no eager step, so nothing has published yet:
       // each plain chunk's messages wait for THAT chunk's commit.
       await tick();
@@ -2357,7 +2361,10 @@ describe('handleSuspension batched fan-out', () => {
           opts: { idempotencyKey: stepDispatchIdempotencyKey(stepId, stepId) },
         }))
       );
-      expect([...result.queuedStepCorrelationIds]).toEqual(['s2', 's3']);
+      expect([...result.queuedStepDispatchKeys]).toEqual([
+        stepDispatchIdempotencyKey('s2', 's2'),
+        stepDispatchIdempotencyKey('s3', 's3'),
+      ]);
       for (const { event } of createBatch.mock.calls[0][1]) {
         expect(event.eventData).not.toHaveProperty('runContext');
       }
@@ -2426,7 +2433,9 @@ describe('handleSuspension batched fan-out', () => {
       const result = await pending;
       expect(result.inlineClaims.get('s1')?.owned).toBe(true);
       expect(result.inlineClaims.get('s2')?.owned).toBe(true);
-      expect([...result.queuedStepCorrelationIds]).toEqual(['s3']);
+      expect([...result.queuedStepDispatchKeys]).toEqual([
+        stepDispatchIdempotencyKey('s3', 's3'),
+      ]);
       expect(result.createdStepCorrelationIds.size).toBe(0);
       expect(await probe(result.deferredBatchWork)).toBe('pending');
       await tick();

--- a/packages/core/src/runtime/suspension-handler.ts
+++ b/packages/core/src/runtime/suspension-handler.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import type { Span } from '@opentelemetry/api';
 import {
   EntityConflictError,
@@ -110,7 +111,7 @@ export interface SuspensionHandlerParams {
    * publish, and the queue message carries the serialized step input
    * (`stepInput`) so the consumer can idempotently re-ensure the event if the
    * direct write failed transiently. Steps queued this way are reported in
-   * {@link SuspensionHandlerResult.queuedStepCorrelationIds} so the caller
+   * {@link SuspensionHandlerResult.queuedStepDispatchKeys} so the caller
    * skips them in its own dispatch pass. Omitted by callers that must not
    * queue (terminal drain, tests); creates then behave exactly as before.
    */
@@ -179,15 +180,21 @@ export interface SuspensionHandlerResult {
    */
   failedStepCorrelationIds: Set<string>;
   /**
-   * Correlation IDs of steps this suspension call already published
+   * Dispatch keys ({@link stepDispatchIdempotencyKey}, i.e. `(correlationId,
+   * stepName)` identity) of the steps this suspension call already published
    * step-execution queue messages for, via resilient step dispatch (the
    * `step_created` write parallelized with a `stepInput`-carrying queue
-   * publish). The caller MUST NOT dispatch these again: the message is
-   * already out (a duplicate would be deduped by its idempotency key, but
-   * costs a wasted round-trip). Empty when {@link SuspensionHandlerParams.stepDispatch}
-   * was not provided or no step was eligible.
+   * publish) or the batched fold's eager creates. The caller MUST NOT
+   * dispatch these again: the message is already out (a duplicate would be
+   * deduped by its idempotency key, but costs a wasted round-trip). Keyed by
+   * step identity rather than correlation id alone for the same reason the
+   * idempotency key is: a corrected replay can rebind a correlation id to a
+   * different step, and that step's dispatch must not be absorbed by the
+   * record of this one's. Empty when
+   * {@link SuspensionHandlerParams.stepDispatch} was not provided or no step
+   * was eligible.
    */
-  queuedStepCorrelationIds: Set<string>;
+  queuedStepDispatchKeys: Set<string>;
   /**
    * How many events this phase's writes reported back as occupying slots they
    * skipped over, already merged into the caller's `eventLog.events`. Nonzero
@@ -242,7 +249,7 @@ export interface SuspensionHandlerResult {
    * MUST await it before acking: a rejection here is a failed suspension
    * write and fails the delivery exactly as it would have at the handler's
    * return. Steps whose messages this work publishes are already in
-   * {@link queuedStepCorrelationIds} at return time.
+   * {@link queuedStepDispatchKeys} at return time.
    */
   deferredBatchWork?: Promise<void>;
   /**
@@ -1026,10 +1033,12 @@ export async function handleSuspension({
 
   const ops: Promise<void>[] = [];
 
-  // Correlation IDs of steps whose step-execution queue message was already
-  // published by the resilient-dispatch ops below (alongside the step_created
-  // write). Reported to the caller so its dispatch pass skips them.
-  const queuedStepCorrelationIds = new Set<string>();
+  // Dispatch keys (step identity: correlationId + stepName, see
+  // stepDispatchIdempotencyKey) of the steps whose step-execution queue
+  // message was already published by the resilient-dispatch ops below
+  // (alongside the step_created write) or by the batched fold's flush.
+  // Reported to the caller so its dispatch pass skips them.
+  const queuedStepDispatchKeys = new Set<string>();
 
   // Resilient step dispatch eligibility, shared by every step op below (the
   // per-step input-size check is applied inside the op). All must hold:
@@ -1127,7 +1136,7 @@ export async function handleSuspension({
   // Steps: create step_created events (no queuing, V2 returns pending steps
   // to caller, EXCEPT on the resilient dispatch path, which parallelizes the
   // create with the step's queue publish and reports it in
-  // `queuedStepCorrelationIds`).
+  // `queuedStepDispatchKeys`).
   let batchOrderCounter = 0;
   for (const queueItem of stepItems) {
     if (stepsNeedingCreation.has(queueItem.correlationId)) {
@@ -1291,7 +1300,12 @@ export async function handleSuspension({
           if (queueResult.status === 'rejected') {
             throw queueResult.reason;
           }
-          queuedStepCorrelationIds.add(queueItem.correlationId);
+          queuedStepDispatchKeys.add(
+            stepDispatchIdempotencyKey(
+              queueItem.correlationId,
+              queueItem.stepName
+            )
+          );
           if (createResult.status === 'rejected') {
             const err = createResult.reason;
             if (EntityConflictError.is(err)) {
@@ -1579,7 +1593,12 @@ export async function handleSuspension({
         if (publishEagerSteps) {
           for (const entry of entries) {
             if (entry.kind === 'step') {
-              queuedStepCorrelationIds.add(entry.correlationId);
+              // Step entries always carry their name (set where they are
+              // enqueued above); the in-flush publish keys on it too.
+              assert(entry.stepName !== undefined);
+              queuedStepDispatchKeys.add(
+                stepDispatchIdempotencyKey(entry.correlationId, entry.stepName)
+              );
             }
           }
         }
@@ -1986,7 +2005,7 @@ export async function handleSuspension({
     pendingSteps: stepItems,
     createdStepCorrelationIds,
     failedStepCorrelationIds,
-    queuedStepCorrelationIds,
+    queuedStepDispatchKeys,
     lazyInlineSteps,
     inlineClaims,
     deferredBatchWork,


### PR DESCRIPTION
Follow-up to #4099, addressing the Copilot review comment https://github.com/vercel/workflow/pull/4099#discussion_r3987298134.

## Problem

#4099 added an invocation-scoped set of step correlation ids this delivery already published, so the post-inline replay pass stops re-publishing them. That set was seeded from the suspension handler's `queuedStepCorrelationIds` only at the dispatch pass. But three branches `continue` the replay loop in-process **before** the dispatch pass runs: the hook-conflict continuation, the attribute-event detour, and the serialization-failure replay. `handleSuspension` can publish resilient step messages (and the batched fold's eager publishes) on exactly such a pass. On the next pass the step already exists, so the handler no longer reports it, and the dispatch pass re-publishes it. The scenario Copilot described is real: the new test reproduces 2 sends for one step on `main`.

## Change

- `packages/core/src/runtime.ts`: seed `publishedStepCorrelationIds` from `suspensionResult.queuedStepCorrelationIds` immediately after the `handleSuspension` try/catch, before any early exit; remove the dispatch-pass-only seeding. The skip logic itself is unchanged, and a fresh delivery still re-enqueues unconditionally.
- `packages/core/src/runtime.test.ts`: the ack-ordering harness gains `workflowSource` and `conflictHookCreate` options (the mock World answers `hook_created` with a recorded `hook_conflict`). New test drives a fire-and-forget hook plus the two-step fan-out with resilient dispatch on, asserts the first pass hit the conflict, went through more than one log load, and the queued step's message was sent exactly once (carrying `stepInput`). Fails with 2 sends without the runtime change.

## Tests

| Suite | Result |
|---|---|
| `src/runtime.test.ts` | 50 passed |
| full `@workflow/core` (`FORCE_COLOR=0 pnpm test`) | 114 files passed, 1 skipped; 2446 tests passed, 3 expected fail, 1 skipped |
| `tsc --noEmit` | clean |

## Review follow-up

The published set is keyed by step identity (`stepDispatchIdempotencyKey(correlationId, stepName)`), not by correlation id alone, so it agrees with the dispatch idempotency key: a step that a corrected replay binds to a correlation id an earlier pass published under a different name is still dispatched. The suspension handler reports its publishes as `queuedStepDispatchKeys` accordingly. Covered by the new rebinding test (which taps the engine's output to stage the rebinding, since a workflow cannot observe log state between two synchronous calls within one delivery). See https://github.com/vercel/workflow/pull/4128#discussion_r3993283137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
