### PR TITLE
[world-postgres] Deliver queue messages without implicit HTTP deadlines

### DIFF
--- a/.changeset/postgres-http-delivery-deadlines.md
+++ b/.changeset/postgres-http-delivery-deadlines.md
@@ -1,0 +1,5 @@
+---
+'@workflow/world-postgres': patch
+---
+
+Queue deliveries no longer inherit `fetch`'s 300s headers/body deadlines, which redelivered healthy long-running inline work while it was still executing. Deadlines can be set with `WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS` and `WORKFLOW_POSTGRES_BODY_TIMEOUT_MS`.

--- a/docs/content/worlds/v5/postgres.mdx
+++ b/docs/content/worlds/v5/postgres.mdx
@@ -230,6 +230,16 @@ How often a wait for a terminal run status re-reads the run, in milliseconds. De
 
 `await run.returnValue` asks the World to wait for the run to finish, and the Postgres World parks that wait on a `NOTIFY` issued by the run-terminal write. This interval is only the backstop: it bounds how long a lost notification can go unnoticed, so lowering it costs a query per waiting run per interval and buys nothing while notifications are arriving.
 
+### `WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS`
+
+Maximum time in milliseconds a queue delivery waits for the workflow handler to begin responding before the delivery is failed and Graphile Worker redelivers the message. Default: `0` (no deadline).
+
+A delivery executes the workflow body inline, so the handler responds only once that work is done. A deadline shorter than your longest inline step declares a healthy delivery crashed and redelivers it while the original is still running, executing the same steps twice. Set this only if you would rather a hung handler be redelivered than hold its worker slot until the process restarts, and set it above the longest inline work you expect.
+
+### `WORKFLOW_POSTGRES_BODY_TIMEOUT_MS`
+
+Maximum gap in milliseconds between response body chunks from the workflow handler before the delivery is failed and redelivered. Default: `0` (no deadline). The same caution as `WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS` applies.
+
 ### `WORKFLOW_POSTGRES_HOOK_RETENTION_LIMIT_DAYS`
 
 Maximum [`experimental_minRetention`](/docs/api-reference/workflow/create-hook#keep-a-token-unavailable-after-the-run-ends) accepted by the Postgres World, in days. Default: `30`. Set this to the same limit as your production World so oversized values fail during development.

--- a/packages/world-postgres/package.json
+++ b/packages/world-postgres/package.json
@@ -68,6 +68,7 @@
     "@workflow/world-testing": "workspace:*",
     "drizzle-kit": "0.31.9",
     "typescript": "catalog:",
+    "undici": "catalog:",
     "vitest": "catalog:"
   },
   "keywords": [],

--- a/packages/world-postgres/src/queue.test.ts
+++ b/packages/world-postgres/src/queue.test.ts
@@ -1,4 +1,5 @@
-import { createServer, type Server } from 'node:http';
+import { channel } from 'node:diagnostics_channel';
+import { type ClientRequest, createServer, type Server } from 'node:http';
 import { JsonTransport } from '@vercel/queue';
 import { setWorkflowBasePath } from '@workflow/utils';
 import { getWorkflowPort } from '@workflow/utils/get-port';
@@ -12,7 +13,12 @@ import {
 } from 'graphile-worker';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageData } from './message.js';
-import { createQueue } from './queue.js';
+import {
+  createQueue,
+  DEFAULT_DELIVERY_BODY_TIMEOUT_MS,
+  DEFAULT_DELIVERY_HEADERS_TIMEOUT_MS,
+  getDeliveryTimeouts,
+} from './queue.js';
 
 const transport = new JsonTransport();
 const createdQueues: Array<ReturnType<typeof createQueue>> = [];
@@ -82,7 +88,48 @@ describe('postgres queue http execution', () => {
     vi.useRealTimers();
     delete process.env.WORKFLOW_LOCAL_BASE_URL;
     delete process.env.PORT;
+    delete process.env.WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS;
+    delete process.env.WORKFLOW_POSTGRES_BODY_TIMEOUT_MS;
     setWorkflowBasePath(undefined);
+  });
+
+  it('places no deadline on a delivery unless the operator sets one', () => {
+    expect(getDeliveryTimeouts()).toEqual({
+      headersTimeoutMs: DEFAULT_DELIVERY_HEADERS_TIMEOUT_MS,
+      bodyTimeoutMs: DEFAULT_DELIVERY_BODY_TIMEOUT_MS,
+    });
+    expect(DEFAULT_DELIVERY_HEADERS_TIMEOUT_MS).toBe(0);
+    expect(DEFAULT_DELIVERY_BODY_TIMEOUT_MS).toBe(0);
+
+    process.env.WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS = '1500';
+    process.env.WORKFLOW_POSTGRES_BODY_TIMEOUT_MS = 'not-a-number';
+    expect(getDeliveryTimeouts()).toEqual({
+      headersTimeoutMs: 1500,
+      bodyTimeoutMs: DEFAULT_DELIVERY_BODY_TIMEOUT_MS,
+    });
+  });
+
+  it('fails a delivery whose handler exceeds an operator-set headers deadline', async () => {
+    const server = await startHangingWorkflowHttpServer('headers');
+    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
+    process.env.WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS = '50';
+
+    const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
+    await queue.start();
+
+    const execution = getTaskHandler('workflow_flows')(
+      buildMessageData('__wkf_workflow_test-step', {
+        runId: 'run_01ABC',
+        stepId: 'step_01ABC',
+        stepName: 'test-step',
+      }),
+      { abortSignal: new AbortController().signal, job: { attempts: 1 } }
+    );
+
+    // Rejecting hands the job back to Graphile for redelivery; the queue
+    // must not schedule a replacement of its own.
+    await expect(execution).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+    expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
   });
 
   it('uses a late-detected local port when the queue starts before PORT is available', async () => {
@@ -211,19 +258,22 @@ describe('postgres queue http execution', () => {
   it('aborts while reading an HTTP response body without scheduling a replacement', async () => {
     const server = await startHangingWorkflowHttpServer('body');
     process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
-    const nativeFetch = globalThis.fetch;
+    const target = new URL(server.baseUrl);
     let resolveResponseReceived!: () => void;
     const responseReceived = new Promise<void>((resolve) => {
       resolveResponseReceived = resolve;
     });
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (...args: Parameters<typeof fetch>) => {
-        const response = await nativeFetch(...args);
+    const responseChannel = channel('http.client.response.finish');
+    const onResponse = (message: unknown) => {
+      const { request } = message as { request: ClientRequest };
+      if (
+        request.getHeader('host') === target.host &&
+        request.path === '/.well-known/workflow/v1/flow'
+      ) {
         resolveResponseReceived();
-        return response;
-      })
-    );
+      }
+    };
+    responseChannel.subscribe(onResponse);
 
     try {
       const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
@@ -247,7 +297,8 @@ describe('postgres queue http execution', () => {
       );
 
       await responseReceived;
-      // Let executeMessageOverHttp enter response.text() before aborting.
+      // The diagnostic fires before the response event; let its promise
+      // continuation enter response.text() before aborting the body read.
       await Promise.resolve();
       controller.abort();
 
@@ -257,7 +308,7 @@ describe('postgres queue http execution', () => {
       });
       expect(workerUtilsMock.addJob).not.toHaveBeenCalled();
     } finally {
-      vi.unstubAllGlobals();
+      responseChannel.unsubscribe(onResponse);
     }
   });
 
@@ -273,7 +324,7 @@ describe('postgres queue http execution', () => {
     let requestCount = 0;
     let activeRequests = 0;
     let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
+    const server = await startWorkflowHttpServer([], 0, undefined, async () => {
       requestCount += 1;
       activeRequests += 1;
       maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
@@ -284,10 +335,8 @@ describe('postgres queue http execution', () => {
       }
 
       activeRequests -= 1;
-      return Response.json({ ok: true });
     });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
+    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
 
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     try {
@@ -311,7 +360,7 @@ describe('postgres queue http execution', () => {
       );
 
       await firstRequestStarted;
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(requestCount).toBe(1);
       expect(maxActiveRequests).toBe(1);
 
@@ -320,9 +369,8 @@ describe('postgres queue http execution', () => {
 
       expect(requestCount).toBe(2);
       expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
-      vi.unstubAllGlobals();
+      resolveReleaseFirstRequest();
     }
   });
 
@@ -338,7 +386,7 @@ describe('postgres queue http execution', () => {
     let requestCount = 0;
     let activeRequests = 0;
     let maxActiveRequests = 0;
-    const fetchMock = vi.fn(async () => {
+    const server = await startWorkflowHttpServer([], 0, undefined, async () => {
       requestCount += 1;
       activeRequests += 1;
       maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
@@ -349,10 +397,8 @@ describe('postgres queue http execution', () => {
       }
 
       activeRequests -= 1;
-      return Response.json({ ok: true });
     });
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
+    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
 
     const queue = buildQueue(
       { connectionString: 'postgres://test', namespace: 'custom' },
@@ -379,7 +425,7 @@ describe('postgres queue http execution', () => {
       );
 
       await firstRequestStarted;
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(requestCount).toBe(1);
       expect(maxActiveRequests).toBe(1);
 
@@ -388,16 +434,15 @@ describe('postgres queue http execution', () => {
 
       expect(requestCount).toBe(2);
       expect(maxActiveRequests).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
-      vi.unstubAllGlobals();
+      resolveReleaseFirstRequest();
     }
   });
 
   it('does not require a runId for workflow health-check payloads', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
-    process.env.WORKFLOW_LOCAL_BASE_URL = 'https://workflow.example.test';
+    const requests: Parameters<typeof startWorkflowHttpServer>[0] = [];
+    const server = await startWorkflowHttpServer(requests);
+    process.env.WORKFLOW_LOCAL_BASE_URL = server.baseUrl;
 
     const queue = buildQueue({ connectionString: 'postgres://test' }, pool);
     try {
@@ -411,25 +456,28 @@ describe('postgres queue http execution', () => {
 
       await expect(task(payload, {} as any)).resolves.toBeUndefined();
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://workflow.example.test/.well-known/workflow/v1/flow',
+      expect(requests).toEqual([
         expect.objectContaining({
+          url: '/.well-known/workflow/v1/flow',
           method: 'POST',
           headers: expect.objectContaining({
             'x-vqs-queue-name': '__wkf_workflow_health_check',
           }),
-        })
-      );
+        }),
+      ]);
     } finally {
       vi.unstubAllGlobals();
     }
   });
 
   it('uses basePath for local postgres queue HTTP delivery', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
+    const requests: Parameters<typeof startWorkflowHttpServer>[0] = [];
     const port = await getUnusedLoopbackPort();
-    await startWorkflowHttpServer([], port);
+    await startWorkflowHttpServer(
+      requests,
+      port,
+      '/v2/.well-known/workflow/v1/flow'
+    );
     process.env.PORT = String(port);
     setWorkflowBasePath('/v2');
 
@@ -446,10 +494,12 @@ describe('postgres queue http execution', () => {
 
       await expect(task(payload, {} as any)).resolves.toBeUndefined();
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        `http://localhost:${port}/v2/.well-known/workflow/v1/flow`,
-        expect.objectContaining({ method: 'POST' })
-      );
+      expect(requests).toEqual([
+        expect.objectContaining({
+          url: '/v2/.well-known/workflow/v1/flow',
+          method: 'POST',
+        }),
+      ]);
       expect(getWorkflowPort).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
@@ -576,7 +626,9 @@ async function startWorkflowHttpServer(
     headers: Record<string, string | string[] | undefined>;
     body: string;
   }>,
-  port = 0
+  port = 0,
+  path = '/.well-known/workflow/v1/flow',
+  beforeResponse?: () => Promise<void>
 ) {
   const server = createServer(async (req, res) => {
     const body = await new Promise<string>((resolve, reject) => {
@@ -597,7 +649,8 @@ async function startWorkflowHttpServer(
     };
     requests.push(request);
 
-    if (req.method === 'POST' && req.url === '/.well-known/workflow/v1/flow') {
+    if (req.method === 'POST' && req.url === path) {
+      if (beforeResponse) await beforeResponse();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
       return;

--- a/packages/world-postgres/src/queue.ts
+++ b/packages/world-postgres/src/queue.ts
@@ -19,6 +19,11 @@ import {
   type ValidQueueName,
   WorkflowInvokePayloadSchema,
 } from '@workflow/world';
+import {
+  createNodeHttpAgents,
+  destroyNodeHttpAgents,
+  nodeHttpFetch,
+} from '@workflow/world/node-http.js';
 import { createWorld } from '@workflow/world-local';
 import {
   Logger,
@@ -52,6 +57,43 @@ function createGraphileLogger() {
 }
 
 const graphileLogger = createGraphileLogger();
+
+/**
+ * Default deadlines for a queue delivery's response: none. A delivery executes
+ * the workflow body inline, so response headers arrive only once that work is
+ * done, and a bound here declares a slow-but-healthy delivery crashed and
+ * redelivers it while the original is still running (two executions of the
+ * same steps). Crash recovery is covered by Graphile releasing the job when
+ * the worker dies, plus `reenqueueActiveRuns` on start.
+ */
+export const DEFAULT_DELIVERY_HEADERS_TIMEOUT_MS = 0;
+export const DEFAULT_DELIVERY_BODY_TIMEOUT_MS = 0;
+
+function envTimeoutMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Per-request deadlines for the loopback delivery request. `0` disables the
+ * deadline. An operator who prefers a hung handler to be redelivered rather
+ * than hold its worker slot until restart sets these to a value above the
+ * longest inline step they expect.
+ */
+export function getDeliveryTimeouts() {
+  return {
+    headersTimeoutMs: envTimeoutMs(
+      'WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS',
+      DEFAULT_DELIVERY_HEADERS_TIMEOUT_MS
+    ),
+    bodyTimeoutMs: envTimeoutMs(
+      'WORKFLOW_POSTGRES_BODY_TIMEOUT_MS',
+      DEFAULT_DELIVERY_BODY_TIMEOUT_MS
+    ),
+  };
+}
 const COMPLETED_IDEMPOTENCY_CACHE_LIMIT = 10_000;
 // Core records MAX_DELIVERIES_EXCEEDED on delivery 49.
 const MAX_GRAPHILE_JOB_ATTEMPTS = 49;
@@ -91,6 +133,16 @@ export function createQueue(
 ): PostgresQueue {
   const port = process.env.PORT ? Number(process.env.PORT) : undefined;
   const localWorld = createWorld({ dataDir: undefined, port });
+  // Deliveries go over Node's core HTTP client rather than the global `fetch`:
+  // undici's default 300s headers/body deadlines cannot be lifted without a
+  // custom dispatcher, and a queue-owned pool keeps these sockets out of the
+  // process-global agent. Concurrency is bounded by the Graphile runner, so
+  // the pool itself does not need a socket cap.
+  const httpAgents = createNodeHttpAgents({
+    maxSockets: Infinity,
+    keepAliveMs: 30_000,
+  });
+  const deliveryTimeouts = getDeliveryTimeouts();
 
   // JSON transport that preserves Uint8Array values via a tagged
   // envelope ({ __type: 'Uint8Array', data: '<base64>' }).  Required
@@ -354,13 +406,19 @@ export function createQueue(
     if (!baseUrl) {
       throw new Error('Unable to resolve base URL for workflow queue.');
     }
-    const response = await fetch(createWorkflowUrl(baseUrl, { type: 'flow' }), {
-      method: 'POST',
-      duplex: 'half',
-      headers,
-      body,
-      signal: abortSignal,
-    } as any);
+    // Queue shutdown aborts the delivery through Graphile's signal; the
+    // deadlines are the operator's (see `getDeliveryTimeouts`).
+    const response = await nodeHttpFetch(
+      createWorkflowUrl(baseUrl, { type: 'flow' }),
+      {
+        method: 'POST',
+        headers: new Headers(headers),
+        body,
+        signal: abortSignal,
+        agents: httpAgents,
+        ...deliveryTimeouts,
+      }
+    );
     const text = await response.text();
 
     if (!response.ok) {
@@ -685,6 +743,7 @@ export function createQueue(
         workerUtils = null;
       }
       startPromise = null;
+      destroyNodeHttpAgents(httpAgents);
       await localWorld.close?.();
     },
   };

--- a/packages/world-postgres/test/queue-http.test.ts
+++ b/packages/world-postgres/test/queue-http.test.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { getQueueTopicPrefix } from '@workflow/world';
+import { Pool } from 'pg';
+import { Agent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { createQueue } from '../src/queue.js';
+
+/**
+ * Queue deliveries execute the workflow body inline, so response headers
+ * arrive only once that work is done. These tests run a real Graphile Worker
+ * against a loopback handler that answers slowly, with the process-global
+ * `fetch` dispatcher pinned to a 10ms deadline: a delivery that still went
+ * through `fetch` would be declared failed and redelivered (attempt 2), which
+ * is the production failure mode at undici's default 300s.
+ */
+describe('Postgres queue HTTP deadlines (integration)', () => {
+  if (process.platform === 'win32') {
+    test.skip('skipped on Windows since it relies on a docker container', () => {});
+    return;
+  }
+
+  const originalBaseUrl = process.env.WORKFLOW_LOCAL_BASE_URL;
+  const originalDispatcher = getGlobalDispatcher();
+  const shortDeadline = new Agent({ headersTimeout: 10, bodyTimeout: 10 });
+  let container: Awaited<ReturnType<PostgreSqlContainer['start']>>;
+  let pool: Pool;
+  let connectionString: string;
+  let server: Server;
+  let phase: 'headers' | 'body' | 'abort';
+  let accepted = Promise.withResolvers<void>();
+  let disconnected = Promise.withResolvers<void>();
+  let attempts: string[] = [];
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:15-alpine').start();
+    connectionString = container.getConnectionUri();
+    pool = new Pool({ connectionString, max: 4 });
+    server = createServer(async (request, response) => {
+      await request.toArray();
+      attempts.push(String(request.headers['x-vqs-message-attempt']));
+      response.on('close', () => disconnected.resolve());
+      accepted.resolve();
+      if (phase === 'abort') return;
+      if (phase === 'body') {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.flushHeaders();
+      }
+      await sleep(1_500);
+      response.end('{}');
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('Expected a TCP server');
+    process.env.WORKFLOW_LOCAL_BASE_URL = `http://127.0.0.1:${address.port}`;
+    setGlobalDispatcher(shortDeadline);
+  }, 120_000);
+
+  afterAll(async () => {
+    setGlobalDispatcher(originalDispatcher);
+    await shortDeadline.close();
+    if (originalBaseUrl === undefined) {
+      delete process.env.WORKFLOW_LOCAL_BASE_URL;
+    } else {
+      process.env.WORKFLOW_LOCAL_BASE_URL = originalBaseUrl;
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+      server.closeAllConnections();
+    });
+    await pool.end();
+    await container.stop();
+  });
+
+  test.each([
+    'headers',
+    'body',
+  ] as const)('a healthy delivery outlives the global fetch %s deadline', async (delayedPhase) => {
+    phase = delayedPhase;
+    attempts = [];
+    accepted = Promise.withResolvers<void>();
+    disconnected = Promise.withResolvers<void>();
+    const queue = createQueue(
+      {
+        connectionString,
+        queueConcurrency: 1,
+        applicationManagedShutdown: true,
+      },
+      pool
+    );
+    try {
+      const { messageId } = await queue.queue(
+        `${getQueueTopicPrefix('workflow')}test`,
+        { runId: `run_${randomUUID()}` }
+      );
+      await accepted.promise;
+      await expect
+        .poll(
+          async () => {
+            const jobs = await pool.query(
+              'SELECT count(*)::int AS count FROM graphile_worker._private_jobs WHERE key = $1',
+              [messageId]
+            );
+            return jobs.rows[0].count;
+          },
+          { timeout: 2_500 }
+        )
+        .toBe(0);
+      expect(attempts).toEqual(['1']);
+    } finally {
+      await queue.close();
+      await pool.query('TRUNCATE graphile_worker._private_jobs');
+    }
+  });
+
+  test('shutdown still aborts a pending delivery and releases its job', async () => {
+    phase = 'abort';
+    accepted = Promise.withResolvers<void>();
+    disconnected = Promise.withResolvers<void>();
+    const queue = createQueue(
+      {
+        connectionString,
+        queueConcurrency: 1,
+        applicationManagedShutdown: true,
+      },
+      pool
+    );
+    await queue.queue(`${getQueueTopicPrefix('workflow')}test`, {
+      runId: `run_${randomUUID()}`,
+    });
+    await accepted.promise;
+    await queue.close();
+    await disconnected.promise;
+    const jobs = await pool.query(
+      'SELECT attempts, locked_at FROM graphile_worker._private_jobs'
+    );
+    expect(jobs.rows).toEqual([{ attempts: 1, locked_at: null }]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1525,6 +1525,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      undici:
+        specifier: 'catalog:'
+        version: 7.29.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@8.1.3(@types/node@22.19.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))


### PR DESCRIPTION
Fixes #3811, closes #4114.

Carries #4114 (@komly) into a signed PR with review findings addressed. The original author is credited via `Co-authored-by`.

## What

`executeMessageOverHttp` used the global `fetch`, so every queue delivery inherited undici's default 300s `headersTimeout` / `bodyTimeout`. A delivery executes the workflow body inline and the handler responds only once that work is done, so any inline step slower than about five minutes was declared crashed (`TypeError: fetch failed`), the Graphile task failed, and the message was redelivered while the original delivery was still running: two concurrent executions of the same steps, as reported in #3811.

Deliveries now go over `@workflow/world/node-http.js` (the `node:http` client `world-local` and `world-vercel` already use behind `WORKFLOW_NODE_HTTP`), with no deadline by default. Graphile's abort signal still cancels the in-flight request on `close()`.

**Changes relative to #4114:**
- The deadlines are operator-configurable via `WORKFLOW_POSTGRES_HEADERS_TIMEOUT_MS` / `WORKFLOW_POSTGRES_BODY_TIMEOUT_MS` (default `0`, unbounded), mirroring `world-local`'s `WORKFLOW_LOCAL_*_TIMEOUT_MS`. #4114 hard-coded `0`, which leaves an operator no way to have a hung handler redelivered rather than hold its worker slot until restart. Documented in `docs/content/worlds/v5/postgres.mdx`.
- Requests dispatch on a keep-alive pool the queue creates and destroys in `close()`, rather than Node's process-global `http.globalAgent`. (I verified the global agent's 5s socket `timeout` does not tear down a slow request, so this is hygiene, not a correctness fix.)
- The Testcontainers integration test always uses a container, like the package's other integration tests; the `WORKFLOW_POSTGRES_URL` branch that threw on a non-loopback URL and the README additions are dropped.
- `undici` is added as a devDependency only, so the integration test can pin the global dispatcher to a 10ms deadline and prove the delivery no longer goes through `fetch` without a five-minute wait.

## Tests

- `test/queue-http.test.ts` (Testcontainers, real Graphile Worker + loopback HTTP): a delivery whose headers or body arrive after the global `fetch` deadline completes on attempt 1 with no redelivery; shutdown still aborts a pending delivery and releases its job. The two healthy-delivery cases fail against `main`'s `queue.ts`.
- `src/queue.test.ts`: existing `fetch`-stub tests rewritten against loopback servers (from #4114), plus: defaults are unbounded and env parsing rejects garbage; an operator-set 50ms headers deadline fails a stalled delivery with `ETIMEDOUT` and schedules no replacement job.

## Related observation (not changed here)

`world-local` bounds the same loopback delivery at 30s by default (`WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS`, #3255) and redelivers on expiry. If its handler also executes inline steps before responding, an inline step over 30s would hit the same double-execution there. I have not verified that empirically; flagging it for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
