### PR TITLE
fix(core): allow Next.js route groups and dynamic segments in workflow names (CI mirror of #4070)

### DIFF
--- a/.changeset/workflow-name-nextjs-route-segments.md
+++ b/.changeset/workflow-name-nextjs-route-segments.md
@@ -1,0 +1,16 @@
+---
+"@workflow/core": patch
+---
+
+Allow parentheses and square brackets in workflow names
+
+A workflow name is derived from the module path it is defined in, so Next.js App
+Router conventions end up in the name verbatim. `SAFE_WORKFLOW_NAME_PATTERN` did
+not permit `(`, `)`, `[` or `]`, so any workflow inside a route group
+(`app/(dashboard)/…`) or a dynamic segment (`app/[teamId]/…`, `app/[...slug]/…`)
+threw `Invalid workflow name` before it could be enqueued, with no way to
+override the generated name.
+
+These characters are inert in the queue name the pattern guards: `ValidQueueName`
+already accepts any suffix after its prefix, and the name is never interpolated
+into a URL or a SQL identifier.

--- a/.changeset/workflow-name-nextjs-route-segments.md
+++ b/.changeset/workflow-name-nextjs-route-segments.md
@@ -2,15 +2,4 @@
 "@workflow/core": patch
 ---
 
-Allow parentheses and square brackets in workflow names
-
-A workflow name is derived from the module path it is defined in, so Next.js App
-Router conventions end up in the name verbatim. `SAFE_WORKFLOW_NAME_PATTERN` did
-not permit `(`, `)`, `[` or `]`, so any workflow inside a route group
-(`app/(dashboard)/…`) or a dynamic segment (`app/[teamId]/…`, `app/[...slug]/…`)
-threw `Invalid workflow name` before it could be enqueued, with no way to
-override the generated name.
-
-These characters are inert in the queue name the pattern guards: `ValidQueueName`
-already accepts any suffix after its prefix, and the name is never interpolated
-into a URL or a SQL identifier.
+Allow parentheses and square brackets in workflow names, so workflows can live in Next.js route groups (`app/(dashboard)/…`) and dynamic segments (`app/[teamId]/…`).

--- a/packages/core/src/runtime/helpers.test.ts
+++ b/packages/core/src/runtime/helpers.test.ts
@@ -151,6 +151,32 @@ describe('getWorkflowQueueName', () => {
     );
   });
 
+  it('should allow parentheses for Next.js route groups', () => {
+    expect(
+      getWorkflowQueueName(
+        'workflow//./app/(marketing)/workflows/checkout.ts//processOrder'
+      )
+    ).toBe(
+      '__wkf_workflow_workflow//./app/(marketing)/workflows/checkout.ts//processOrder'
+    );
+  });
+
+  it('should allow square brackets for Next.js dynamic segments', () => {
+    expect(
+      getWorkflowQueueName(
+        'workflow//./app/[teamId]/workflows/sync.ts//syncTeam'
+      )
+    ).toBe(
+      '__wkf_workflow_workflow//./app/[teamId]/workflows/sync.ts//syncTeam'
+    );
+    expect(
+      getWorkflowQueueName('workflow//./app/[...slug]/workflows/x.ts//run')
+    ).toBe('__wkf_workflow_workflow//./app/[...slug]/workflows/x.ts//run');
+    expect(
+      getWorkflowQueueName('workflow//./app/[[...slug]]/workflows/x.ts//run')
+    ).toBe('__wkf_workflow_workflow//./app/[[...slug]]/workflows/x.ts//run');
+  });
+
   it('should throw for names containing spaces', () => {
     expect(() => getWorkflowQueueName('my workflow')).toThrow(
       'Invalid workflow name'

--- a/packages/core/src/runtime/helpers.ts
+++ b/packages/core/src/runtime/helpers.ts
@@ -43,9 +43,11 @@ const DEFAULT_HEALTH_CHECK_TIMEOUT = 30_000;
 /**
  * Pattern for safe workflow names. Only allows alphanumeric characters,
  * underscores, hyphens, dots, forward slashes (for namespaced workflows),
- * and at signs (for scoped packages).
+ * at signs (for scoped packages), and parentheses and square brackets (for
+ * Next.js route groups and dynamic segments, which appear verbatim in the
+ * module path a workflow name is derived from).
  */
-const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@]+$/;
+const SAFE_WORKFLOW_NAME_PATTERN = /^[a-zA-Z0-9_\-./@()[\]]+$/;
 
 /**
  * Validates a workflow name and returns the corresponding queue name.
@@ -58,7 +60,7 @@ export function getWorkflowQueueName(
 ): ValidQueueName {
   if (!SAFE_WORKFLOW_NAME_PATTERN.test(workflowName)) {
     throw new Error(
-      `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, or at signs`
+      `Invalid workflow name "${workflowName}": must only contain alphanumeric characters, underscores, hyphens, dots, forward slashes, at signs, parentheses, or square brackets`
     );
   }
   const prefix = getQueueTopicPrefix(

--- a/packages/world-vercel/src/queue.test.ts
+++ b/packages/world-vercel/src/queue.test.ts
@@ -444,6 +444,67 @@ describe('createQueue', () => {
     });
   });
 
+  describe('VQS topic sanitization', () => {
+    /**
+     * VQS rejects a topic that is not `[A-Za-z0-9_-]{1,256}`
+     * (`V3QueueNameSchema` on the send path), so `queue()` folds every other
+     * character to `-` before it calls `send`. A workflow name is derived from
+     * its module path and always carries `/` and `.`, so this has to hold for
+     * every workflow — these cases pin the Next.js App Router conventions
+     * (issue #3991), whose parentheses and brackets reach the topic the same
+     * way the slashes already do.
+     */
+    const VQS_TOPIC_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
+
+    let originalDeploymentId: string | undefined;
+
+    beforeEach(() => {
+      originalDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+      process.env.VERCEL_DEPLOYMENT_ID = 'dpl_test';
+      mockSend.mockResolvedValue({ messageId: 'msg-123' });
+    });
+
+    afterEach(() => {
+      if (originalDeploymentId !== undefined) {
+        process.env.VERCEL_DEPLOYMENT_ID = originalDeploymentId;
+      } else {
+        delete process.env.VERCEL_DEPLOYMENT_ID;
+      }
+    });
+
+    it.each([
+      ['plain module path', 'workflow//./workflows/1_simple//simple'],
+      ['route group', 'workflow//./app/(group)/workflows/hello//routeGroup'],
+      ['dynamic segment', 'workflow//./app/[teamId]/workflows/sync//syncTeam'],
+      ['catch-all', 'workflow//./app/[...slug]/workflows/x//run'],
+      ['optional catch-all', 'workflow//./app/[[...slug]]/workflows/x//run'],
+      ['intercepting route', 'workflow//./app/(.)photo/workflows/x//run'],
+      ['scoped package', 'workflow//@acme/jobs@1.2.3//processOrder'],
+    ])('sends a VQS-valid topic for a %s name', async (_label, name) => {
+      const queue = createQueue();
+      await queue.queue(`__wkf_workflow_${name}`, { runId: 'wrun_abc' });
+
+      expect(mockSend.mock.calls[0][0]).toMatch(VQS_TOPIC_PATTERN);
+      // The logical queue name survives untouched inside the wrapper: handler
+      // dispatch and the re-enqueue path both key off it, not off the topic.
+      expect(mockSend.mock.calls[0][1].queueName).toBe(
+        `__wkf_workflow_${name}`
+      );
+    });
+
+    it('keeps the sanitized topic under the flow-topic wildcard the trigger subscribes with', async () => {
+      const queue = createQueue();
+      await queue.queue(
+        '__wkf_workflow_workflow//./app/(group)/workflows/hello//routeGroup',
+        { runId: 'wrun_abc' }
+      );
+
+      expect(mockSend.mock.calls[0][0]).toBe(
+        '__wkf_workflow_workflow----app--group--workflows-hello--routeGroup'
+      );
+    });
+  });
+
   describe('strict concurrency (WORKFLOW_SEQUENTIAL_REPLAYS)', () => {
     let originalDeploymentId: string | undefined;
     let originalStrict: string | undefined;


### PR DESCRIPTION
> **Draft — CI mirror of #4070.** The fix commit is @torsello's, cherry-picked with an unchanged diff so CI actually runs; community PRs don't trigger it. Credit and review belong on **#4070**. Close whichever of the two we don't land.
>
> Heads-up on the author line: this was pushed from a Vercel devbox, whose push path rewrites every commit to `author: vercel[bot]` and re-signs it with GitHub's key. I could not preserve @torsello's git author field through that. Their `Signed-off-by:` and an explicit `Co-authored-by:` trailer are on the commit instead, and the diff is byte-for-byte theirs — verify with `git range-diff` against `pull/4070/head` if you want to confirm.

Fixes #3991.

### What's here

| Commit | |
| --- | --- |
| `fix(core): allow Next.js route groups and dynamic segments in workflow names` | @torsello's commit from #4070; diff unchanged, co-author trailer added |
| `test(world-vercel): pin that workflow names reach VQS as valid topics` | new — see below |
| `chore(changeset): trim to the one-line summary` | addresses @pranaygp's review comment on #4070 (changeset was too verbose for the changelog) |

### The question the fix raises

A workflow name is derived from its module path, so route groups and dynamic segments land in the name verbatim, and the name is interpolated into the queue name we hand to Vercel Queues as a topic. `@vercel/queue` documents the topic pattern as `[A-Za-z0-9_-]+` — which does not include `(`, `)`, `[`, `]`. So: does widening `SAFE_WORKFLOW_NAME_PATTERN` just move the failure downstream?

**No.** `prepareSend` in `packages/world-vercel/src/queue.ts` already folds everything outside that set to `-` before `client.send`:

```ts
const topic = getPhysicalQueueName(queueName, payload).replace(/[^A-Za-z0-9-_]/g, '-');
```

That is why the `/` and `.` that *every* workflow name carries have always been fine. The four new characters take exactly the same path:

```
__wkf_workflow_workflow//./app/(group)/workflows/hello//routeGroup
  -> __wkf_workflow_workflow----app--group--workflows-hello--routeGroup
```

still matched by the `__wkf_workflow_*` wildcard the flow trigger subscribes with, and still inside the topic length limit. The unsanitized logical queue name keeps travelling in the message wrapper, so handler dispatch and the re-enqueue path are untouched.

None of that was covered by a test, so the second commit pins it: for each App Router convention (plus a scoped-package name as a control), the topic passed to `send` matches the VQS pattern and `wrapper.queueName` is still the raw name.

Two pre-existing properties this makes visible, neither changed by the fix: the fold is lossy, so distinct workflow names can collapse onto one physical topic (only a routing/concurrency bucket — dispatch keys off the logical name); and the topic has a length cap a deeply nested path could exceed.

### Verification

Reproduced on `main` first, in `workbench/nextjs-turbopack`:

- `app/(group)/workflows/hello.ts` + a route calling `start()` → **HTTP 500**, `Invalid workflow name "workflow//./app/(group)/workflows/hello//routeGroupWorkflow"`. Worth knowing: discovery, compilation and the manifest all succeed — the workflow *is* registered — and the run row is written as `pending` before the throw, so the run is created and then orphaned.
- With the fix: route group **HTTP 200** `{"result":2}`, dynamic segment **HTTP 200** `{"result":42}`.
- `@workflow/core` full suite with the fix: 2380 passed — identical to the unpatched baseline.
- New `world-vercel` cases: 8 passed.

Those local numbers were produced against the tree as of `4547e1a7a`; this branch is on current `main`, whose lockfile pulls a package my sandbox can't authenticate to, so I could not re-run them locally after rebasing. That's what this PR is for — and CI is green on it.

### Not addressed here

The reporter also asked for a way to *supply* a workflow name rather than inherit it from the path. There's no such API today; that belongs with the `workflow.config.ts` RFC (#2446), and this fix unblocks them without it.

### PR Checklist

- [x] `pnpm changeset` — `patch` on `@workflow/core`, carried in the cherry-picked commit
- [x] DCO sign-off on both commits
- [x] Review feedback from #4070 addressed (changeset trimmed)
- [ ] **Needs an approval on this PR.** Auto-merge (squash) is enabled and CI is green; the approval on #4070 does not carry over, and I cannot approve a PR opened under my own account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)