### PR TITLE
chore(changeset): trim the route-groups changeset to one line

### DIFF
--- a/.changeset/workflow-name-nextjs-route-segments.md
+++ b/.changeset/workflow-name-nextjs-route-segments.md
@@ -2,15 +2,4 @@
 "@workflow/core": patch
 ---
 
-Allow parentheses and square brackets in workflow names
-
-A workflow name is derived from the module path it is defined in, so Next.js App
-Router conventions end up in the name verbatim. `SAFE_WORKFLOW_NAME_PATTERN` did
-not permit `(`, `)`, `[` or `]`, so any workflow inside a route group
-(`app/(dashboard)/…`) or a dynamic segment (`app/[teamId]/…`, `app/[...slug]/…`)
-threw `Invalid workflow name` before it could be enqueued, with no way to
-override the generated name.
-
-These characters are inert in the queue name the pattern guards: `ValidQueueName`
-already accepts any suffix after its prefix, and the name is never interpolated
-into a URL or a SQL identifier.
+Allow parentheses and square brackets in workflow names, so workflows can live in Next.js route groups (`app/(dashboard)/…`) and dynamic segments (`app/[teamId]/…`).


### PR DESCRIPTION
Follow-up to #4070 (merged as d427c47) — no code change, one changeset file.

### What happened

You left [this review comment](https://github.com/vercel/workflow/pull/4070#discussion_r3995098714) on #4070's changeset: *"too verbose. let's just have the 1 line here since this will go into changelog and we don't need all the paragraphs below."*

I fixed it on **#4140**, the CI mirror of #4070 — but **#4070** is the one that merged and #4140 was closed, so the trim went with it. Nothing went wrong in the merge; the fix was just sitting on the wrong PR. (Good outcome otherwise: merging #4070 means @torsello kept authorship.)

### Why the changeset file is still the right place to fix it

The changeset has **not been consumed yet** — it's still at `.changeset/workflow-name-nextjs-route-segments.md` on `main`, and `packages/core/CHANGELOG.md` contains none of this text. The open release PR #4142 has it staged (renames to `.changeset/pre/…` and writes the long version into the changelog), and it regenerates on every push to `main`, so landing this will refresh #4142 with the one-liner. No changelog surgery needed, and nothing has been published with the verbose text.

### Before / after

```diff
-Allow parentheses and square brackets in workflow names
-
-A workflow name is derived from the module path it is defined in, so Next.js App
-Router conventions end up in the name verbatim. `SAFE_WORKFLOW_NAME_PATTERN` did
-not permit `(`, `)`, `[` or `]`, so any workflow inside a route group
-(`app/(dashboard)/…`) or a dynamic segment (`app/[teamId]/…`, `app/[...slug]/…`)
-threw `Invalid workflow name` before it could be enqueued, with no way to
-override the generated name.
-
-These characters are inert in the queue name the pattern guards: `ValidQueueName`
-already accepts any suffix after its prefix, and the name is never interpolated
-into a URL or a SQL identifier.
+Allow parentheses and square brackets in workflow names, so workflows can live in Next.js route groups (`app/(dashboard)/…`) and dynamic segments (`app/[teamId]/…`).
```

### Also lost with #4140

The `world-vercel` test from #4140 didn't land either — the one pinning that a workflow name still reaches VQS as a valid topic (`[A-Za-z0-9_-]`) after `prepareSend` folds it. That guarantee is what makes the parens/brackets fix safe on the Vercel world, and it's still untested. Deliberately **not** included here to keep this mergeable on sight; happy to send it as its own PR.

### PR Checklist - Required to merge

- [x] 📦 Changeset — this PR *is* the changeset edit; no new one needed (a `chore` on an unconsumed changeset produces no release of its own)
- [x] 🔒 DCO sign-off
- [ ] 📝 Ping `@vercel/workflow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
