### PR TITLE
fix(core): keep the error message and stack in the run-failure log

### DIFF
--- a/.changeset/run-failure-log-error-stack.md
+++ b/.changeset/run-failure-log-error-stack.md
@@ -1,0 +1,5 @@
+---
+'@workflow/core': patch
+---
+
+Render the `errorStack` field as the log body when the message carries no stack of its own, so the run-failure log shows the stack instead of discarding it.

--- a/packages/core/src/log-format.test.ts
+++ b/packages/core/src/log-format.test.ts
@@ -113,6 +113,75 @@ describe('composeLogLine', () => {
     `);
   });
 
+  test('renders the errorStack field as the body when the message has none', () => {
+    // The run-failure log in runtime.ts logs a bare framing line and passes
+    // the source-map-remapped stack as metadata. Dropping `errorStack`
+    // unconditionally left that call site with no stack at all.
+    const out = composeLogLine(PREFIX, 'Error while running workflow', {
+      workflowRunId: 'wrun_01ABC',
+      errorCode: 'USER_ERROR',
+      errorName: 'Error',
+      errorMessage: 'thing went wrong',
+      errorStack: [
+        'Error: thing went wrong',
+        '    at workflow (./workflows/x.ts:3:15)',
+        '    at <unknown> (.../node_modules/.pnpm/next@16.2.1/dist/server/base-server.js:1454:9)',
+      ].join('\n'),
+    });
+    // The promoted stack header carries both the class and the message, so
+    // neither is restated as a row above it.
+    expect(out).not.toMatch(/^\s+error\s+/m);
+    expect(out).not.toMatch(/^\s+Error\s*$/m);
+    expect(out).toMatchInlineSnapshot(`
+      "[workflow-sdk] Error while running workflow
+        run    wrun_01ABC
+        code   USER_ERROR
+      Error: thing went wrong
+          at workflow (./workflows/x.ts:3:15)
+              … 1 more frame in framework internals"
+    `);
+  });
+
+  test('does not duplicate a stack the message already embeds', () => {
+    const stack = [
+      'Error: boom',
+      '    at userStep (./workflows/x.ts:15:11)',
+    ].join('\n');
+    const out = composeLogLine(PREFIX, `Step blew up\n${stack}`, {
+      errorStack: stack,
+    });
+    expect(out).toBe(`[workflow-sdk] Step blew up\n${stack}`);
+  });
+
+  test('keeps the class on the header row when it carries an attribution badge', () => {
+    // The badge is something the stack cannot express, so the row still
+    // earns its line even though the stack header repeats the class.
+    const out = composeLogLine(PREFIX, 'Error while running workflow', {
+      errorAttribution: 'sdk',
+      errorName: 'CorruptedEventLogError',
+      errorStack: 'CorruptedEventLogError: corrupted event log',
+    });
+    expect(out).toMatchInlineSnapshot(`
+      "[workflow-sdk] Error while running workflow
+        sdk error · CorruptedEventLogError
+      CorruptedEventLogError: corrupted event log"
+    `);
+  });
+
+  test('keeps the class row when the stack belongs to a different class', () => {
+    // A wrapped/replaced stack can name something other than `errorName`.
+    // Dropping the row there would lose the real class.
+    const out = composeLogLine(PREFIX, 'Error while running workflow', {
+      errorName: 'FatalError',
+      errorStack: 'TypeError: undefined is not a function',
+    });
+    expect(out).toMatchInlineSnapshot(`
+      "[workflow-sdk] Error while running workflow
+        FatalError
+      TypeError: undefined is not a function"
+    `);
+  });
+
   test('falls back gracefully on machine names it cannot parse', () => {
     const out = composeLogLine(PREFIX, 'msg', {
       workflowRunId: 'wrun_X',

--- a/packages/core/src/log-format.ts
+++ b/packages/core/src/log-format.ts
@@ -19,6 +19,9 @@ import {
  *     FatalError: …
  *         at … (trimmed stack, internals collapsed)
  *
+ * The stack body comes from the message when the caller embedded it there,
+ * and from the `errorStack` metadata field otherwise.
+ *
  * Without this composition, callers passing `${framing}\n${stack}` as the
  * message and structured fields as the metadata object got `util.inspect`'s
  * default object dump appended *after* the stack, which buries the run ID
@@ -35,7 +38,15 @@ export function composeLogLine(
   metadata: Record<string, unknown> | undefined
 ): string {
   const [framing, ...rest] = message.split('\n');
-  const body = rest.join('\n');
+  const embeddedBody = rest.join('\n');
+  // Callers supply the stack one of two ways: embedded in the message (step
+  // executor / combined runtime render `${framing}\n${stack}`) or as an
+  // `errorStack` field next to a single-line framing (the run-failure log in
+  // runtime.ts). Promote the field when the message has no body of its own so
+  // the stack survives either way, and gets the same trimming either way.
+  const body = embeddedBody.trim()
+    ? embeddedBody
+    : (pickString(metadata ?? {}, 'errorStack') ?? '');
   const fields = renderStructuredFields(framing ?? '', body, metadata);
   const trimmedBody = trimStackBody(body);
 
@@ -52,12 +63,13 @@ function renderStructuredFields(
 ): string | null {
   if (!metadata || Object.keys(metadata).length === 0) return null;
 
-  // Drop fields that the message already encodes. We render framings and
-  // stacks into the message string itself in step executor / combined runtime, so
-  // repeating them here would be pure noise. A message with neither (a WARN
-  // whose framing is a fixed sentence and whose `errorMessage` is the only
-  // place the underlying error's text appears) keeps `errorMessage` and
-  // renders it as its own row below.
+  // Drop fields the composed line already shows elsewhere. `errorStack` is
+  // always rendered as the body — embedded in the message by the step
+  // executor / combined runtime, or promoted out of the field by
+  // composeLogLine — so repeating it here would be pure noise. A message
+  // with neither (a WARN whose framing is a fixed sentence and whose
+  // `errorMessage` is the only place the underlying error's text appears)
+  // keeps `errorMessage` and renders it as its own row below.
   const redundant = new Set<string>();
   redundant.add('errorStack');
   const errorMessage = pickString(metadata, 'errorMessage');
@@ -86,9 +98,17 @@ function renderStructuredFields(
   const lines: string[] = [];
 
   // Header: error class + attribution badge.
+  //
+  // Without a badge the row is just the class name, which the stack header
+  // below (`Name: message`) already states — so it only earns its line when
+  // the stack doesn't open with that same name. A badge always earns its
+  // line: attribution is the one thing the stack cannot express, and the
+  // class stays attached to it as the thing being attributed.
   const errorName = pickString(metadata, 'errorName');
   const attribution = pickString(metadata, 'errorAttribution');
-  if (errorName || attribution) {
+  const nameEchoedByStack =
+    errorName !== null && stackHeaderNames(body, errorName);
+  if (attribution || (errorName && !nameEchoedByStack)) {
     const badge = attribution
       ? attribution === 'sdk'
         ? Ansi.magenta('sdk error')
@@ -253,6 +273,16 @@ function isFrameworkFrame(line: string): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * True when the stack body opens with `<errorName>:` (or the bare name), the
+ * shape V8 gives `Error#stack`. Used to avoid restating the class in a
+ * header row directly above it.
+ */
+function stackHeaderNames(body: string, errorName: string): boolean {
+  const header = body.split('\n', 1)[0]?.trim() ?? '';
+  return header === errorName || header.startsWith(`${errorName}:`);
 }
 
 function pickString(

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -3690,3 +3690,73 @@ describe('workflowEntrypoint latency telemetry (ttfs / stso)', () => {
     expect(optimizations).toEqual(['lazyStepStart']);
   });
 });
+
+describe('workflowEntrypoint run-failure logging', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    setWorld(undefined);
+    vi.clearAllMocks();
+  });
+
+  const failingRun = async (): Promise<WorkflowRun> => ({
+    runId: 'wrun_run_failure_logging',
+    workflowName: 'workflow',
+    status: 'running',
+    input: await dehydrateWorkflowArguments(
+      [],
+      'wrun_run_failure_logging',
+      undefined,
+      []
+    ),
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    startedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deploymentId: 'test-deployment',
+    specVersion: SPEC_VERSION_CURRENT,
+  });
+
+  /**
+   * The run-failure log is the only place a user sees *why* their workflow
+   * died when they are tailing logs rather than opening the dashboard. Its
+   * framing line ("Error while running workflow") carries no error text of
+   * its own, so the (source-map-remapped) stack has to survive the trip
+   * through the formatter rather than being dropped as redundant.
+   */
+  it('emits the error message and stack in the run-failure log', async () => {
+    const workflowRun = await failingRun();
+    const createdEvents: any[] = [];
+
+    await runWorkflowHandlerWithEvents(
+      `async function workflow() {
+        throw new Error('user workflow blew up');
+      };globalThis.__private_workflows = new Map();
+      globalThis.__private_workflows.set("workflow", workflow);`,
+      workflowRun,
+      [],
+      { createdEvents }
+    );
+
+    expect(createdEvents).toContainEqual(
+      expect.objectContaining({ eventType: 'run_failed' })
+    );
+
+    const runFailureLog = errorSpy.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.includes('Error while running workflow'));
+    expect(runFailureLog).toBeDefined();
+
+    // The run id and error code already render today.
+    expect(runFailureLog).toContain('wrun_run_failure_logging');
+    expect(runFailureLog).toContain(RUN_ERROR_CODES.USER_ERROR);
+    // …and so must the two details that actually explain the failure: the
+    // thrown message and at least one stack frame.
+    expect(runFailureLog).toContain('user workflow blew up');
+    expect(runFailureLog).toMatch(/^\s+at /m);
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -5104,10 +5104,10 @@ export function workflowEntrypoint(
                           workflowRunId: runId,
                           errorCode,
                           errorName,
-                          // The console renderer drops `errorStack` on the
-                          // assumption that the message body carries it, and
-                          // this message has no body, so without this row the
-                          // terminal error's text never reaches the console.
+                          // This message has no body, so the console
+                          // renderer promotes `errorStack` into one and
+                          // shows `errorMessage` on its own row when the
+                          // throw produced no stack to carry it.
                           errorMessage,
                           errorStack,
                         });


### PR DESCRIPTION
## The bug

When a workflow run fails, `packages/core/src/runtime.ts` computes a source-map-remapped `errorStack` and logs it alongside a framing line that has no body of its own:

```ts
runtimeLogger.error('Error while running workflow', { …, errorName, errorMessage, errorStack });
```

`composeLogLine` in `packages/core/src/log-format.ts` does `redundant.add('errorStack')` unconditionally. That's correct for the step executor and the combined runtime, which render `${framing}\n${stack}` into the message string — but this call site logs a bare, single-line framing, so the stack is dropped with nothing to replace it.

#4021 hit the same wall from the `errorMessage` side and worked around it, leaving a comment at the call site that names the problem exactly:

```ts
// The console renderer drops `errorStack` on the
// assumption that the message body carries it, and
// this message has no body, so without this row the
// terminal error's text never reaches the console.
errorMessage,
```

So today the message survives but the stack still doesn't — a user tailing logs sees *that* their run failed and *what* the error said, but never *where* it was thrown.

## Reproduction

`packages/core/src/runtime.test.ts` gains a test that drives a throwing workflow through the real `workflowEntrypoint` and asserts the emitted `console.error` line. Against `main` it fails on the stack assertion:

```
AssertionError: expected '[workflow-sdk] Error while running wo…' to match /^\s+at /m
```

## The fix

- **`composeLogLine` promotes the `errorStack` field into the stack body** when the message carries no body of its own. It then goes through the same `trimStackBody` frame collapsing as an embedded stack, and is still never duplicated when the caller did embed one. This also lets #4021's existing `body.includes(errorMessage)` check suppress the now-redundant `error` row here, since the promoted stack header already carries the message.
- **The header row is skipped when it would be a lone class name** that the promoted stack header already states. A badge still always renders — attribution is the one thing the stack cannot express, and the class stays attached to it as the thing being attributed. So the step-executor and combined-runtime sites are untouched, as is a stack whose class differs from `errorName`.
- The stale workaround comment in `runtime.ts` is updated; `errorMessage` stays passed, since it's still the row shown when a throw produced no stack at all.

Before / after at this call site:

```diff
  [workflow-sdk] Error while running workflow
-   Error
    run    wrun_01ABC
    code   USER_ERROR
-   error  user workflow blew up
+ Error: user workflow blew up
+     at workflow (./workflows/x.ts:3:15)
+         … 1 more frame in framework internals
```

## Tests

- New runtime-level regression test in `runtime.test.ts` (the reproduction above).
- New `log-format.test.ts` cases: stack promoted when the message has none; no duplication when the message already embeds it; class row kept when a badge is present; class row kept when the stack names a different class.
- **No existing snapshot changes** — the composition is byte-identical everywhere except the run-failure log.

`pnpm vitest run src` in `packages/core`: 2443 passed, 3 expected fail, 1 skipped. `tsc --noEmit` clean; `biome check` warning count unchanged from `main` (301).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
